### PR TITLE
Use yaml.UnmarshalStrict

### DIFF
--- a/generate/config.go
+++ b/generate/config.go
@@ -120,7 +120,7 @@ func ReadAndValidateConfig(filename string) (*Config, error) {
 			return nil, errorf(nil, "unreadable config file %v: %v", filename, err)
 		}
 
-		err = yaml.Unmarshal(text, &config)
+		err = yaml.UnmarshalStrict(text, &config)
 		if err != nil {
 			return nil, errorf(nil, "invalid config file %v: %v", filename, err)
 		}


### PR DESCRIPTION
## Summary:
As Mark pointed out in a review where I realized that the *example* had
a bogus config key (which I hadn't noticed earlier because it was just
using the default value), we should probably do a strict-unmarshal;
there's no reason you should have random extra keys in your config and
if you do it's probably a mistake.  (Or maybe you're running a too-old
version of genqlient for your codebase, which you probably also want to
know.)  Now we do.

## Test plan:
- `make check`
- in webapp, `go mod edit -replace github.com/Khan/genqlient=../genqlient`
  then `make genqlient` produces no diffs (except go.mod/go.sum).
