### PR TITLE
Fix type-naming in the presence of interfaces, and refactor it a lot

### DIFF
--- a/generate/convert.go
+++ b/generate/convert.go
@@ -345,6 +345,8 @@ func (g *generator) convertSelectionSet(
 		case *ast.FragmentSpread:
 			return nil, errorf(selection.Position, "not implemented: %T", selection)
 		case *ast.InlineFragment:
+			// (Note this will return nil, nil if the fragment doesn't apply to
+			// this type.)
 			fragmentFields, err := g.convertInlineFragment(
 				namePrefix, selection, containingTypedef, queryOptions)
 			if err != nil {
@@ -433,7 +435,8 @@ func fragmentMatches(containingTypedef, fragmentTypedef *ast.Definition) bool {
 // containingTypedef is the type-def corresponding to the type into which we
 // are spreading; it may be either an interface type (when spreading into one)
 // or an object type (when writing the implementations of such an interface, or
-// when using an inline fragment in an object type which is rare).
+// when using an inline fragment in an object type which is rare).  If the
+// given fragment does not apply to that type, this function returns nil, nil.
 //
 // In general, we treat such fragments' fields as if they were fields of the
 // parent selection-set (except of course they are only included in types the


### PR DESCRIPTION
## Summary:
When adding support for interfaces, I did not do the type-names as I
intended: they came out to be `MyFieldMyType`, not
`MyInterfaceMyFieldMyType`, which is inconsistent, but not strictly
wrong.  But once supporting fragments, this is also now incorrect.
(Exactly why is described in the comments inline.)  In this commit, in
any case, I fix it.

To do that, I finally did the last of the refactors I've been hoping to
do but unable to successfully implement, which is to make the type-name
and type-name-prefix management clearer.  In the past it was kind of
spread out, and each caller would have to pass the right name into
`convertDefinition`, which go quite unwieldy.  Now, the case that really
wanted that -- the operation toplevel -- just does it own thing; and the
main name-generation code  is factored out into a separate file with
tests, and with a long comment that goes into all the details of the
algorithm that the design-doc didn't cover.  (I even had some fun using
a linked list to implement the prefix-stack!)

This allowed me to fix the above bug fairly easily -- actually the fix
was pretty much automatic once I understood how to organize things.
There is one change which is that if your query name is unexported, we
no longer do the same with the input-type names; it's unclear to me if
anyone will actually care about this behavior (Khan always makes the
queries exported) but if they did it was very inconsistent (only at the
query toplevel, and only for input-objects, not enums), so we can
reimplement it properly if that comes up.  As a bonus fix, we now better
handle the case where your type-names are lowercase, which is legal if
nonstandard GraphQL.

Issue: https://github.com/Khan/genqlient/issues/8

## Test plan:
make tesc
