### PR TITLE
Clean up godoc

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -329,11 +329,12 @@ func (g *generator) addOperation(op *ast.OperationDefinition) error {
 	return nil
 }
 
-// Generate returns a map from absolute-path filename to generated content.
+// Generate is the main programmatic entrypoint to genqlient, and generates and
+// returns Go source code based on the given configuration.
 //
-// This is the main entrypoint to the code-generation process for callers who
-// wish to manage the config-reading (ReadAndValidateConfig) and file-writing
-// on their own.  (Those are wired in by Main.)
+// See Config for more on creating a configuration.  The return value is a map
+// from filename to the generated file-content (e.g. Go source).  Callers who
+// don't want to manage reading and writing the files should call Main.
 func Generate(config *Config) (map[string][]byte, error) {
 	// Step 1: Read in the schema and operations from the files defined by the
 	// config (and validate the operations against the schema).  This is all
@@ -343,7 +344,7 @@ func Generate(config *Config) (map[string][]byte, error) {
 		return nil, err
 	}
 
-	document, err := getAndValidateQueries(config.baseDir(), config.Operations, schema)
+	document, err := getAndValidateQueries(config.baseDir, config.Operations, schema)
 	if err != nil {
 		return nil, err
 	}

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -145,43 +145,43 @@ func defaultConfig(t *testing.T) *Config {
 // configurations.  It uses snapshots, just like TestGenerate.
 func TestGenerateWithConfig(t *testing.T) {
 	tests := []struct {
-		name   string
-		config *Config // omits Schema and Operations, set below.
+		name    string
+		baseDir string  // relative to dataDir
+		config  *Config // omits Schema and Operations, set below.
 	}{
-		{"DefaultConfig", defaultConfig(t)},
-		{"Subpackage", &Config{
+		{"DefaultConfig", "", defaultConfig(t)},
+		{"Subpackage", "", &Config{
 			Generated: "mypkg/myfile.go",
 		}},
-		{"SubpackageConfig", &Config{
-			baseDir:   "mypkg",     // (relative to dataDir, see below)
+		{"SubpackageConfig", "mypkg", &Config{
 			Generated: "myfile.go", // (relative to genqlient.yaml)
 		}},
-		{"PackageName", &Config{
+		{"PackageName", "", &Config{
 			Generated: "myfile.go",
 			Package:   "mypkg",
 		}},
-		{"ExportOperations", &Config{
+		{"ExportOperations", "", &Config{
 			Generated:        "generated.go",
 			ExportOperations: "operations.json",
 		}},
-		{"CustomContext", &Config{
+		{"CustomContext", "", &Config{
 			Generated:   "generated.go",
 			ContextType: "github.com/Khan/genqlient/internal/testutil.MyContext",
 		}},
-		{"NoContext", &Config{
+		{"NoContext", "", &Config{
 			Generated:   "generated.go",
 			ContextType: "-",
 		}},
-		{"ClientGetter", &Config{
+		{"ClientGetter", "", &Config{
 			Generated:    "generated.go",
 			ClientGetter: "github.com/Khan/genqlient/internal/testutil.GetClientFromContext",
 		}},
-		{"ClientGetterCustomContext", &Config{
+		{"ClientGetterCustomContext", "", &Config{
 			Generated:    "generated.go",
 			ClientGetter: "github.com/Khan/genqlient/internal/testutil.GetClientFromMyContext",
 			ContextType:  "github.com/Khan/genqlient/internal/testutil.MyContext",
 		}},
-		{"ClientGetterNoContext", &Config{
+		{"ClientGetterNoContext", "", &Config{
 			Generated:    "generated.go",
 			ClientGetter: "github.com/Khan/genqlient/internal/testutil.GetClientFromNowhere",
 			ContextType:  "-",
@@ -192,9 +192,9 @@ func TestGenerateWithConfig(t *testing.T) {
 
 	for _, test := range tests {
 		config := test.config
+		baseDir := filepath.Join(dataDir, test.baseDir)
 		t.Run(test.name, func(t *testing.T) {
-			err := config.ValidateAndFillDefaults(
-				filepath.Join(dataDir, config.baseDir))
+			err := config.ValidateAndFillDefaults(baseDir)
 			config.Schema = filepath.Join(dataDir, "schema.graphql")
 			config.Operations = []string{filepath.Join(dataDir, sourceFilename)}
 			if err != nil {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -145,43 +145,43 @@ func defaultConfig(t *testing.T) *Config {
 // configurations.  It uses snapshots, just like TestGenerate.
 func TestGenerateWithConfig(t *testing.T) {
 	tests := []struct {
-		name               string
-		fakeConfigFilename string
-		config             *Config // omits Schema and Operations, set below.
+		name   string
+		config *Config // omits Schema and Operations, set below.
 	}{
-		{"DefaultConfig", "genqlient.yaml", defaultConfig(t)},
-		{"Subpackage", "genqlient.yaml", &Config{
+		{"DefaultConfig", defaultConfig(t)},
+		{"Subpackage", &Config{
 			Generated: "mypkg/myfile.go",
 		}},
-		{"SubpackageConfig", "mypkg/genqlient.yaml", &Config{
+		{"SubpackageConfig", &Config{
+			baseDir:   "mypkg",     // (relative to dataDir, see below)
 			Generated: "myfile.go", // (relative to genqlient.yaml)
 		}},
-		{"PackageName", "genqlient.yaml", &Config{
+		{"PackageName", &Config{
 			Generated: "myfile.go",
 			Package:   "mypkg",
 		}},
-		{"ExportOperations", "genqlient.yaml", &Config{
+		{"ExportOperations", &Config{
 			Generated:        "generated.go",
 			ExportOperations: "operations.json",
 		}},
-		{"CustomContext", "genqlient.yaml", &Config{
+		{"CustomContext", &Config{
 			Generated:   "generated.go",
 			ContextType: "github.com/Khan/genqlient/internal/testutil.MyContext",
 		}},
-		{"NoContext", "genqlient.yaml", &Config{
+		{"NoContext", &Config{
 			Generated:   "generated.go",
 			ContextType: "-",
 		}},
-		{"ClientGetter", "genqlient.yaml", &Config{
+		{"ClientGetter", &Config{
 			Generated:    "generated.go",
 			ClientGetter: "github.com/Khan/genqlient/internal/testutil.GetClientFromContext",
 		}},
-		{"ClientGetterCustomContext", "genqlient.yaml", &Config{
+		{"ClientGetterCustomContext", &Config{
 			Generated:    "generated.go",
 			ClientGetter: "github.com/Khan/genqlient/internal/testutil.GetClientFromMyContext",
 			ContextType:  "github.com/Khan/genqlient/internal/testutil.MyContext",
 		}},
-		{"ClientGetterNoContext", "genqlient.yaml", &Config{
+		{"ClientGetterNoContext", &Config{
 			Generated:    "generated.go",
 			ClientGetter: "github.com/Khan/genqlient/internal/testutil.GetClientFromNowhere",
 			ContextType:  "-",
@@ -194,7 +194,7 @@ func TestGenerateWithConfig(t *testing.T) {
 		config := test.config
 		t.Run(test.name, func(t *testing.T) {
 			err := config.ValidateAndFillDefaults(
-				filepath.Join(dataDir, test.fakeConfigFilename))
+				filepath.Join(dataDir, config.baseDir))
 			config.Schema = filepath.Join(dataDir, "schema.graphql")
 			config.Operations = []string{filepath.Join(dataDir, sourceFilename)}
 			if err != nil {

--- a/generate/main.go
+++ b/generate/main.go
@@ -1,3 +1,6 @@
+// Package generate provides programmatic access to genqlient's functionality,
+// and documentation of its configuration options.  For general usage
+// documentation, see github.com/Khan/genqlient.
 package generate
 
 import (
@@ -50,6 +53,9 @@ See https://github.com/Khan/genqlient for full documentation.
 `)
 }
 
+// Main is the command-line entrypoint to genqlient; it's equivalent to calling
+// `go run github.com/Khan/genqlient`.  For lower-level control over
+// genqlient's operation, see Generate.
 func Main() {
 	exitIfError := func(err error) {
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,4 +1,9 @@
-// package main is at the root to allow "go run github.com/Khan/genqlient"
+// genqlient is a GraphQL client generator for Go.
+//
+// To run genqlient:
+//	go run github.com/Khan/genqlient
+// For programmatic access, see the "generate" package, below.  For
+// user documentation, see github.com/Khan/genqlient.
 package main
 
 import (


### PR DESCRIPTION
## Summary:
Before open-sourcing, we want to make sure that (a) GoDoc looks
reasonable, and (b) everything in the API is something we want to commit
to.  In this commit, I do some miscellaneous cleanup on both fronts;
this does involve a few breaking changes to the programmatic API (better
now than once it has users).  In future commits, I'll likely move the
documentation for `genqlient.yaml` and `@genqlient` to clearer places,
and make `GenqlientDirective` private, such that GoDoc is really only
for programmatic users.

Fixes #25.

Issue: https://github.com/Khan/genqlient/issues/25

## Test plan:
make check
