### PR TITLE
Add tests for behavior on error

### DIFF
--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -266,6 +266,17 @@ func (v *UserFields) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// failingQueryMeUser includes the requested fields of the GraphQL type User.
+type failingQueryMeUser struct {
+	Id string `json:"id"`
+}
+
+// failingQueryResponse is returned by failingQuery on success.
+type failingQueryResponse struct {
+	Fail bool               `json:"fail"`
+	Me   failingQueryMeUser `json:"me"`
+}
+
 // queryWithFragmentsBeingsAnimal includes the requested fields of the GraphQL type Animal.
 type queryWithFragmentsBeingsAnimal struct {
 	Typename string                                       `json:"__typename"`
@@ -1065,6 +1076,30 @@ query simpleQuery {
 		id
 		name
 		luckyNumber
+	}
+}
+`,
+		&retval,
+		nil,
+	)
+	return &retval, err
+}
+
+func failingQuery(
+	ctx context.Context,
+	client graphql.Client,
+) (*failingQueryResponse, error) {
+	var err error
+
+	var retval failingQueryResponse
+	err = client.MakeRequest(
+		ctx,
+		"failingQuery",
+		`
+query failingQuery {
+	fail
+	me {
+		id
 	}
 }
 `,

--- a/internal/integration/schema.graphql
+++ b/internal/integration/schema.graphql
@@ -4,6 +4,7 @@ type Query {
   being(id: ID!): Being
   beings(ids: [ID!]!): [Being]!
   lotteryWinner(number: Int!): Lucky
+  fail: Boolean
 }
 
 type User implements Being & Lucky {

--- a/internal/integration/server/server.go
+++ b/internal/integration/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 
 	"github.com/99designs/gqlgen/graphql/handler"
@@ -80,6 +81,11 @@ func (r *queryResolver) LotteryWinner(ctx context.Context, number int) (Lucky, e
 		}
 	}
 	return nil, nil
+}
+
+func (r *queryResolver) Fail(ctx context.Context) (*bool, error) {
+	f := true
+	return &f, fmt.Errorf("oh no")
 }
 
 func RunServer() *httptest.Server {


### PR DESCRIPTION
## Summary:
We guarantee that we never return a nil response, so you can safely do
```
resp, err := myQuery(...)
return resp.Field.SubField, err
```
And furthermore, if the error was a GraphQL error, `resp` may even be
nonzero; other, non-failing fields may be set.  (This depends on the
server, of course.) But we weren't testing either of those.  Now we do.

## Test plan:
make check
