### PR TITLE
Autofix lint when we can

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ example:
 
 lint:
 	( cd internal/lint && go build -o golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint )
-	internal/lint/golangci-lint run ./...
+	internal/lint/golangci-lint run ./... --fix
 
 check: lint
 	go test -cover ./...


### PR DESCRIPTION
## Summary:
This is mostly useful for gofumpt, although a few other linters may
support it.  Anyway, we may as well.

## Test plan:
make lint
