### PR TITLE
Let the Doer Do it

### DIFF
--- a/graphql/client.go
+++ b/graphql/client.go
@@ -62,12 +62,15 @@ type client struct {
 // The typical method of adding authentication headers is to wrap the client's
 // Transport to add those headers.  See example/caller.go for an example.
 func NewClient(endpoint string, httpClient Doer) Client {
-	if httpClient == nil {
+	if httpClient == nil || httpClient == (*http.Client)(nil) {
 		httpClient = http.DefaultClient
 	}
 	return &client{httpClient, endpoint, http.MethodPost}
 }
 
+// Doer encapsulates the methods from *http.Client needed by Client.
+// The methods should have behavior to match that of *http.Client
+// (or mocks for the same).
 type Doer interface {
 	Do(*http.Request) (*http.Response, error)
 }

--- a/graphql/client.go
+++ b/graphql/client.go
@@ -47,7 +47,7 @@ type Client interface {
 }
 
 type client struct {
-	httpClient *http.Client
+	httpClient Doer
 	endpoint   string
 	method     string
 }
@@ -61,11 +61,15 @@ type client struct {
 //
 // The typical method of adding authentication headers is to wrap the client's
 // Transport to add those headers.  See example/caller.go for an example.
-func NewClient(endpoint string, httpClient *http.Client) Client {
+func NewClient(endpoint string, httpClient Doer) Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 	return &client{httpClient, endpoint, http.MethodPost}
+}
+
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
 }
 
 type payload struct {


### PR DESCRIPTION
This PR introduces switches to using the common interface `Doer` instead of the concrete `*http.Client` to be more flexible for consumers test construction.

Prior to this PR, `genqlient` has not supported one of the three common testing techniques by consumers. See [Let the Doer Do it](https://www.0value.com/let-the-doer-do-it) for more details.

---
Generally, there are three common ways to test HTTP client requests:
1. By Replacing `http.Transport`
Transport specifies the mechanism by which individual HTTP requests are made. Instead of using the default http.Transport, we’ll replace it with our own implementation. To implement a transport, we’ll have to implement http.RoundTripper interface. 
2.  Using `httptest.Server`:
`httptest.Server` allows us to create a local HTTP server and listen for any requests. When starting, the server chooses any available open port and uses that. So we need to get the URL of the test server and use it instead of the actual service URL.
3. [Accept a Doer as a parameter](https://www.0value.com/let-the-doer-do-it) instead of `*http.Client`
The `Doer` is a single-method interface, as is often the case in Go:
```
type Doer interface {
    Do(*http.Request) (*http.Response, error)
}
```
Note: It does not really exist - it is not defined anywhere in the stdlib - but it is trivial to summon it from thin air in a package. Many people do as I did above, and because Go implicitly satisfies interfaces, any type that implements this method will be a valid Doer.
