### PR TITLE
Allow genqlient types to be marshaled safely

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,8 @@ When releasing a new version:
 
 ### New features:
 
+- genqlient's types are now safe to JSON-marshal, which can be useful for putting them in a cache, for example.  See the [docs](FAQ.md#-let-me-json-marshal-my-response-objects) for details.
+
 ### Bug fixes:
 
 ## v0.2.0

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,6 +96,19 @@ bindings:
 
 Or, you can bind it to any other type, perhaps one with size-checked constructors; see the [`genqlient.yaml` documentation](`genqlient.yaml`) for more details.
 
+### … let me json-marshal my response objects
+
+This is supported by default!  All genqlient-generated types support both JSON-marshaling and unmarshaling, which can be useful for putting them in a cache, inspecting them by hand, using them in mocks (although this is [not recommended](#-test-my-graphql-apis)), or anything else you can do with JSON.  It's not guaranteed that marshaling a genqlient type will produce the exact GraphQL input -- we try to get as close as we can but there are some limitations around Go zero values -- but unmarshaling again should produce the value genqlient returned.  That is:
+
+```go
+resp, err := MyQuery(...)
+// not guaranteed to match what the server sent (but close):
+b, err := json.Marshal(resp)
+// guaranteed to match resp:
+var respAgain MyQueryResponse
+err := json.Unmarshal(b, &resp)
+```
+
 ## How do I make a query with …
 
 ### … a specific name for a field?

--- a/generate/marshal.go.tmpl
+++ b/generate/marshal.go.tmpl
@@ -1,28 +1,60 @@
-{{/* See unmarshal.go.tmpl for more on how this works; this is mostly just
-     parallel (and simplified -- we don't need to handle embedding). */}}
+{{/* We generate MarshalJSON for much the same reasons as UnmarshalJSON -- see
+     unmarshal.go.tmpl for details.  (Note we generate both even if genqlient
+     itself needs only UnmarshalJSON, for the benefit of callers who want to,
+     for example, put genqlient responses in a cache.)  But our implementation
+     for marshaling is quite different.
+
+     Specifically, the treatment of field-visibility with embedded fields must
+     differ from both ordinary encoding/json and unmarshaling: we need to
+     choose exactly one conflicting field in all cases (whereas Go chooses at
+     most one and when unmarshaling we choose them all).  See
+     goStructType.FlattenedFields in types.go for more discussion of embedding
+     and visibility.
+
+     To accomplish that, we essentially flatten out all the embedded fields
+     when marshaling, following those precedence rules.  Then we basically
+     follow what we do in unmarshaling, but in reverse order: first we marshal
+     the special fields, then we glue everything together with the ordinary
+     fields.
+
+     We do one other thing differently, for the benefit of the marshal-helper
+     in marshal_helper.go.tmpl.  While when unmarshaling it's easy to unmarshal
+     out the __typename field, then unmarshal out everything else, with
+     marshaling we can't do the same (at least not without some careful
+     JSON-stitching; the considerations are basically the same as those
+     discussed in FlattenedFields).  So we write out a helper method
+     __premarshalJSON() which basically does all but the final JSON-marshal.
+     (Then the real MarshalJSON() just calls that, and then marshals.)
+     Thus a marshal-helper for this type, if any, can call __premarshalJSON()
+     directly, and embed its result. */}}
+
+type __premarshal{{.GoName}} struct{
+    {{range .FlattenedFields -}}
+    {{if .NeedsMarshaling -}}
+    {{.GoName}} {{repeat .GoType.SliceDepth "[]"}}{{ref "encoding/json.RawMessage"}} `json:"{{.JSONName}}"`
+    {{else}}
+    {{.GoName}} {{.GoType.Reference}} `json:"{{.JSONName}}"`
+    {{end}}
+    {{end}}
+}
 
 func (v *{{.GoName}}) MarshalJSON() ([]byte, error) {
-    {{/* We do the two passes in the opposite order of unmarshal: first, we
-         marshal the special fields, then we assign those to the wrapper struct
-         and finish marshaling the whole object.  But first we set up the
-         object for the second part, so we can assign to it as we go. */}}
-    var fullObject struct{
-        *{{.GoName}}
-        {{range .Fields -}}
-        {{if .NeedsMarshaler -}}
-        {{.GoName}} {{repeat .GoType.SliceDepth "[]"}}{{ref "encoding/json.RawMessage"}} `json:"{{.JSONName}}"`
-        {{end -}}
-        {{end -}}
-        {{ref "github.com/Khan/genqlient/graphql.NoMarshalJSON"}}
+    premarshaled, err := v.__premarshalJSON()
+    if err != nil {
+        return nil, err
     }
-    fullObject.{{.GoName}} = v
+    return json.Marshal(premarshaled)
+}
 
-    {{range $field := .Fields -}}
-    {{if $field.NeedsMarshaler -}}
+func (v *{{.GoName}}) __premarshalJSON() (*__premarshal{{.GoName}}, error) {
+    var retval __premarshal{{.GoName}}
+
+    {{range $field := .FlattenedFields -}}
+    {{if $field.NeedsMarshaling -}}
     {
-        {{/* Here dst is the json.RawMessage, and src is the Go type */}}
-        dst := &fullObject.{{$field.GoName}}
-        src := v.{{$field.GoName}}
+        {{/* Here dst is the json.RawMessage, and src is the Go type. */}}
+        dst := &retval.{{$field.GoName}}
+        src := v.{{$field.Selector}}
         {{range $i := intRange $field.GoType.SliceDepth -}}
         *dst = make(
             {{repeat (sub $field.GoType.SliceDepth $i) "[]"}}{{ref "encoding/json.RawMessage"}},
@@ -45,7 +77,7 @@ func (v *{{.GoName}}) MarshalJSON() ([]byte, error) {
             {{if not $field.GoType.IsPointer}}&{{end}}src)
         if err != nil {
             return nil, fmt.Errorf(
-                "Unable to marshal {{$.GoName}}.{{$field.GoName}}: %w", err)
+                "Unable to marshal {{$.GoName}}.{{$field.Selector}}: %w", err)
         }
         {{if $field.GoType.IsPointer -}}
         }{{/* end if src != nil */}}
@@ -54,8 +86,10 @@ func (v *{{.GoName}}) MarshalJSON() ([]byte, error) {
         }
         {{end -}}
     }
+    {{else -}}
+    retval.{{$field.GoName}} = v.{{$field.Selector}}
     {{end -}}
-    {{end}}
+    {{end -}}
 
-    return {{ref "encoding/json.Marshal"}}(&fullObject)
+    return &retval, nil
 }

--- a/generate/marshal_helper.go.tmpl
+++ b/generate/marshal_helper.go.tmpl
@@ -1,0 +1,44 @@
+{{/* This is somewhat parallel to unmarshal_helper.go.tmpl, but, as usual, in
+     reverse.  Note the helper accepts a pointer-to-interface, for
+     consistency with unmarshaling and with the API we expect of custom
+     marshalers. */}}
+
+func __marshal{{.GoName}}(v *{{.GoName}}) ([]byte, error) {
+    {{/* Determine the GraphQL typename, which the unmarshaler will need should
+         it be called on our output. */}}
+    var typename string
+    switch v := (*v).(type) {
+    {{range .Implementations -}}
+    case *{{.GoName}}:
+        typename = "{{.GraphQLName}}"
+
+        {{/* Now actually do the marshal, with the concrete type. (Go only
+             marshals embeds the way we want if they're structs.)  Except that
+             won't work right if the implementation-type has its own
+             MarshalJSON method (maybe it in turn has an interface-typed
+             field), so we call the helper __premarshalJSON directly (see
+             marshal.go.tmpl). */}}
+        {{if .NeedsMarshaling -}}
+        premarshaled, err := v.__premarshalJSON()
+        if err != nil {
+            return nil, err
+        }
+        result := struct {
+            TypeName string `json:"__typename"`
+            *__premarshal{{.GoName}}
+        }{typename, premarshaled}
+        {{else -}}
+        result := struct {
+            TypeName string `json:"__typename"`
+            *{{.GoName}}
+        }{typename, v}
+        {{end -}}
+        return json.Marshal(result)
+    {{end -}}
+    case nil:
+        return []byte("null"), nil
+    default:
+        return nil, {{ref "fmt.Errorf"}}(
+            `Unexpected concrete type for {{.GoName}}: "%T"`, v)
+    }
+}

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -87,6 +87,42 @@ func __unmarshalComplexInlineFragmentsConflictingStuffContent(b []byte, v *Compl
 	}
 }
 
+func __marshalComplexInlineFragmentsConflictingStuffContent(v *ComplexInlineFragmentsConflictingStuffContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ComplexInlineFragmentsConflictingStuffArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsConflictingStuffArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsConflictingStuffVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsConflictingStuffVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsConflictingStuffTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsConflictingStuffTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for ComplexInlineFragmentsConflictingStuffContent: "%T"`, v)
+	}
+}
+
 // ComplexInlineFragmentsConflictingStuffTopic includes the requested fields of the GraphQL type Topic.
 type ComplexInlineFragmentsConflictingStuffTopic struct {
 	Typename string `json:"__typename"`
@@ -174,6 +210,46 @@ func __unmarshalComplexInlineFragmentsNestedStuffContent(b []byte, v *ComplexInl
 	}
 }
 
+func __marshalComplexInlineFragmentsNestedStuffContent(v *ComplexInlineFragmentsNestedStuffContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ComplexInlineFragmentsNestedStuffArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffTopic:
+		typename = "Topic"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalComplexInlineFragmentsNestedStuffTopic
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffContent: "%T"`, v)
+	}
+}
+
 // ComplexInlineFragmentsNestedStuffTopic includes the requested fields of the GraphQL type Topic.
 type ComplexInlineFragmentsNestedStuffTopic struct {
 	Typename string                                                  `json:"__typename"`
@@ -217,6 +293,46 @@ func (v *ComplexInlineFragmentsNestedStuffTopic) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalComplexInlineFragmentsNestedStuffTopic struct {
+	Typename string `json:"__typename"`
+
+	Children []json.RawMessage `json:"children"`
+}
+
+func (v *ComplexInlineFragmentsNestedStuffTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ComplexInlineFragmentsNestedStuffTopic) __premarshalJSON() (*__premarshalComplexInlineFragmentsNestedStuffTopic, error) {
+
+	var retval __premarshalComplexInlineFragmentsNestedStuffTopic
+
+	retval.Typename = v.Typename
+	{
+
+		dst := &retval.Children
+		src := v.Children
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalComplexInlineFragmentsNestedStuffTopicChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal ComplexInlineFragmentsNestedStuffTopic.Children: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticle includes the requested fields of the GraphQL type Article.
@@ -270,6 +386,43 @@ func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParen
 		}
 	}
 	return nil
+}
+
+type __premarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic struct {
+	Children []json.RawMessage `json:"children"`
+}
+
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) __premarshalJSON() (*__premarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic, error) {
+
+	var retval __premarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic
+
+	{
+
+		dst := &retval.Children
+		src := v.Children
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic.Children: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle includes the requested fields of the GraphQL type Article.
@@ -388,6 +541,42 @@ func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentConte
 	}
 }
 
+func __marshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent(v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent: "%T"`, v)
+	}
+}
+
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic includes the requested fields of the GraphQL type Topic.
 type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic struct {
 	Typename string `json:"__typename"`
@@ -488,6 +677,42 @@ func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenContent(b []byte, 
 	default:
 		return fmt.Errorf(
 			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenContent: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalComplexInlineFragmentsNestedStuffTopicChildrenContent(v *ComplexInlineFragmentsNestedStuffTopicChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenContent: "%T"`, v)
 	}
 }
 
@@ -606,6 +831,42 @@ func __unmarshalComplexInlineFragmentsRandomItemContent(b []byte, v *ComplexInli
 	default:
 		return fmt.Errorf(
 			`Unexpected concrete type for ComplexInlineFragmentsRandomItemContent: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalComplexInlineFragmentsRandomItemContent(v *ComplexInlineFragmentsRandomItemContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ComplexInlineFragmentsRandomItemArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRandomItemArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsRandomItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRandomItemVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsRandomItemTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for ComplexInlineFragmentsRandomItemContent: "%T"`, v)
 	}
 }
 
@@ -765,6 +1026,42 @@ func __unmarshalComplexInlineFragmentsRepeatedStuffContent(b []byte, v *ComplexI
 	}
 }
 
+func __marshalComplexInlineFragmentsRepeatedStuffContent(v *ComplexInlineFragmentsRepeatedStuffContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ComplexInlineFragmentsRepeatedStuffArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRepeatedStuffArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsRepeatedStuffVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRepeatedStuffVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsRepeatedStuffTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRepeatedStuffTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for ComplexInlineFragmentsRepeatedStuffContent: "%T"`, v)
+	}
+}
+
 // ComplexInlineFragmentsRepeatedStuffTopic includes the requested fields of the GraphQL type Topic.
 type ComplexInlineFragmentsRepeatedStuffTopic struct {
 	Typename string `json:"__typename"`
@@ -872,6 +1169,82 @@ func (v *ComplexInlineFragmentsResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalComplexInlineFragmentsResponse struct {
+	Root ComplexInlineFragmentsRootTopic `json:"root"`
+
+	RandomItem json.RawMessage `json:"randomItem"`
+
+	RepeatedStuff json.RawMessage `json:"repeatedStuff"`
+
+	ConflictingStuff json.RawMessage `json:"conflictingStuff"`
+
+	NestedStuff json.RawMessage `json:"nestedStuff"`
+}
+
+func (v *ComplexInlineFragmentsResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ComplexInlineFragmentsResponse) __premarshalJSON() (*__premarshalComplexInlineFragmentsResponse, error) {
+
+	var retval __premarshalComplexInlineFragmentsResponse
+
+	retval.Root = v.Root
+	{
+
+		dst := &retval.RandomItem
+		src := v.RandomItem
+		var err error
+		*dst, err = __marshalComplexInlineFragmentsRandomItemContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal ComplexInlineFragmentsResponse.RandomItem: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.RepeatedStuff
+		src := v.RepeatedStuff
+		var err error
+		*dst, err = __marshalComplexInlineFragmentsRepeatedStuffContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal ComplexInlineFragmentsResponse.RepeatedStuff: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.ConflictingStuff
+		src := v.ConflictingStuff
+		var err error
+		*dst, err = __marshalComplexInlineFragmentsConflictingStuffContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal ComplexInlineFragmentsResponse.ConflictingStuff: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.NestedStuff
+		src := v.NestedStuff
+		var err error
+		*dst, err = __marshalComplexInlineFragmentsNestedStuffContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal ComplexInlineFragmentsResponse.NestedStuff: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 // ComplexInlineFragmentsRootTopic includes the requested fields of the GraphQL type Topic.

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -310,7 +310,6 @@ func (v *ComplexInlineFragmentsNestedStuffTopic) MarshalJSON() ([]byte, error) {
 }
 
 func (v *ComplexInlineFragmentsNestedStuffTopic) __premarshalJSON() (*__premarshalComplexInlineFragmentsNestedStuffTopic, error) {
-
 	var retval __premarshalComplexInlineFragmentsNestedStuffTopic
 
 	retval.Typename = v.Typename
@@ -401,7 +400,6 @@ func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParen
 }
 
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) __premarshalJSON() (*__premarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic, error) {
-
 	var retval __premarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic
 
 	{
@@ -1192,7 +1190,6 @@ func (v *ComplexInlineFragmentsResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *ComplexInlineFragmentsResponse) __premarshalJSON() (*__premarshalComplexInlineFragmentsResponse, error) {
-
 	var retval __premarshalComplexInlineFragmentsResponse
 
 	retval.Root = v.Root

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -40,6 +40,65 @@ func (v *ComplexNamedFragmentsResponse) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalComplexNamedFragmentsResponse struct {
+	RandomItem json.RawMessage `json:"randomItem"`
+
+	RandomLeaf json.RawMessage `json:"randomLeaf"`
+
+	OtherLeaf json.RawMessage `json:"otherLeaf"`
+}
+
+func (v *ComplexNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ComplexNamedFragmentsResponse) __premarshalJSON() (*__premarshalComplexNamedFragmentsResponse, error) {
+
+	var retval __premarshalComplexNamedFragmentsResponse
+
+	{
+
+		dst := &retval.RandomItem
+		src := v.QueryFragment.InnerQueryFragment.RandomItem
+		var err error
+		*dst, err = __marshalInnerQueryFragmentRandomItemContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal ComplexNamedFragmentsResponse.QueryFragment.InnerQueryFragment.RandomItem: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.RandomLeaf
+		src := v.QueryFragment.InnerQueryFragment.RandomLeaf
+		var err error
+		*dst, err = __marshalInnerQueryFragmentRandomLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal ComplexNamedFragmentsResponse.QueryFragment.InnerQueryFragment.RandomLeaf: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.OtherLeaf
+		src := v.QueryFragment.InnerQueryFragment.OtherLeaf
+		var err error
+		*dst, err = __marshalInnerQueryFragmentOtherLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal ComplexNamedFragmentsResponse.QueryFragment.InnerQueryFragment.OtherLeaf: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
 // ContentFields includes the GraphQL fields of Content requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
 //
@@ -110,6 +169,42 @@ func __unmarshalContentFields(b []byte, v *ContentFields) error {
 	default:
 		return fmt.Errorf(
 			`Unexpected concrete type for ContentFields: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalContentFields(v *ContentFields) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ContentFieldsArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ContentFieldsArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ContentFieldsVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ContentFieldsVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ContentFieldsTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ContentFieldsTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for ContentFields: "%T"`, v)
 	}
 }
 
@@ -211,6 +306,65 @@ func (v *InnerQueryFragment) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalInnerQueryFragment struct {
+	RandomItem json.RawMessage `json:"randomItem"`
+
+	RandomLeaf json.RawMessage `json:"randomLeaf"`
+
+	OtherLeaf json.RawMessage `json:"otherLeaf"`
+}
+
+func (v *InnerQueryFragment) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragment) __premarshalJSON() (*__premarshalInnerQueryFragment, error) {
+
+	var retval __premarshalInnerQueryFragment
+
+	{
+
+		dst := &retval.RandomItem
+		src := v.RandomItem
+		var err error
+		*dst, err = __marshalInnerQueryFragmentRandomItemContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal InnerQueryFragment.RandomItem: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.RandomLeaf
+		src := v.RandomLeaf
+		var err error
+		*dst, err = __marshalInnerQueryFragmentRandomLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal InnerQueryFragment.RandomLeaf: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.OtherLeaf
+		src := v.OtherLeaf
+		var err error
+		*dst, err = __marshalInnerQueryFragmentOtherLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal InnerQueryFragment.OtherLeaf: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
 // InnerQueryFragmentOtherLeafArticle includes the requested fields of the GraphQL type Article.
 type InnerQueryFragmentOtherLeafArticle struct {
 	Typename             string `json:"__typename"`
@@ -240,6 +394,32 @@ func (v *InnerQueryFragmentOtherLeafArticle) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalInnerQueryFragmentOtherLeafArticle struct {
+	Typename string `json:"__typename"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+}
+
+func (v *InnerQueryFragmentOtherLeafArticle) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragmentOtherLeafArticle) __premarshalJSON() (*__premarshalInnerQueryFragmentOtherLeafArticle, error) {
+
+	var retval __premarshalInnerQueryFragmentOtherLeafArticle
+
+	retval.Typename = v.Typename
+	retval.Name = v.ContentFieldsArticle.Name
+	retval.Url = v.ContentFieldsArticle.Url
+	return &retval, nil
 }
 
 // InnerQueryFragmentOtherLeafLeafContent includes the requested fields of the GraphQL interface LeafContent.
@@ -297,6 +477,42 @@ func __unmarshalInnerQueryFragmentOtherLeafLeafContent(b []byte, v *InnerQueryFr
 	}
 }
 
+func __marshalInnerQueryFragmentOtherLeafLeafContent(v *InnerQueryFragmentOtherLeafLeafContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InnerQueryFragmentOtherLeafArticle:
+		typename = "Article"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentOtherLeafArticle
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *InnerQueryFragmentOtherLeafVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentOtherLeafVideo
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InnerQueryFragmentOtherLeafLeafContent: "%T"`, v)
+	}
+}
+
 // InnerQueryFragmentOtherLeafVideo includes the requested fields of the GraphQL type Video.
 type InnerQueryFragmentOtherLeafVideo struct {
 	Typename           string `json:"__typename"`
@@ -334,6 +550,38 @@ func (v *InnerQueryFragmentOtherLeafVideo) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalInnerQueryFragmentOtherLeafVideo struct {
+	Typename string `json:"__typename"`
+
+	Id *testutil.ID `json:"id"`
+
+	Parent *MoreVideoFieldsParentTopic `json:"parent"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+}
+
+func (v *InnerQueryFragmentOtherLeafVideo) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragmentOtherLeafVideo) __premarshalJSON() (*__premarshalInnerQueryFragmentOtherLeafVideo, error) {
+
+	var retval __premarshalInnerQueryFragmentOtherLeafVideo
+
+	retval.Typename = v.Typename
+	retval.Id = v.MoreVideoFields.Id
+	retval.Parent = v.MoreVideoFields.Parent
+	retval.Name = v.ContentFieldsVideo.Name
+	retval.Url = v.ContentFieldsVideo.Url
+	return &retval, nil
+}
+
 // InnerQueryFragmentRandomItemArticle includes the requested fields of the GraphQL type Article.
 type InnerQueryFragmentRandomItemArticle struct {
 	Typename string `json:"__typename"`
@@ -366,6 +614,35 @@ func (v *InnerQueryFragmentRandomItemArticle) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalInnerQueryFragmentRandomItemArticle struct {
+	Typename string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+}
+
+func (v *InnerQueryFragmentRandomItemArticle) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragmentRandomItemArticle) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomItemArticle, error) {
+
+	var retval __premarshalInnerQueryFragmentRandomItemArticle
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Name = v.Name
+	retval.Url = v.ContentFieldsArticle.Url
+	return &retval, nil
 }
 
 // InnerQueryFragmentRandomItemContent includes the requested fields of the GraphQL interface Content.
@@ -459,6 +736,54 @@ func __unmarshalInnerQueryFragmentRandomItemContent(b []byte, v *InnerQueryFragm
 	}
 }
 
+func __marshalInnerQueryFragmentRandomItemContent(v *InnerQueryFragmentRandomItemContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InnerQueryFragmentRandomItemArticle:
+		typename = "Article"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentRandomItemArticle
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *InnerQueryFragmentRandomItemVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentRandomItemVideo
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *InnerQueryFragmentRandomItemTopic:
+		typename = "Topic"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentRandomItemTopic
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InnerQueryFragmentRandomItemContent: "%T"`, v)
+	}
+}
+
 // InnerQueryFragmentRandomItemTopic includes the requested fields of the GraphQL type Topic.
 type InnerQueryFragmentRandomItemTopic struct {
 	Typename string `json:"__typename"`
@@ -491,6 +816,35 @@ func (v *InnerQueryFragmentRandomItemTopic) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalInnerQueryFragmentRandomItemTopic struct {
+	Typename string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+}
+
+func (v *InnerQueryFragmentRandomItemTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragmentRandomItemTopic) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomItemTopic, error) {
+
+	var retval __premarshalInnerQueryFragmentRandomItemTopic
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Name = v.Name
+	retval.Url = v.ContentFieldsTopic.Url
+	return &retval, nil
 }
 
 // InnerQueryFragmentRandomItemVideo includes the requested fields of the GraphQL type Video.
@@ -533,6 +887,41 @@ func (v *InnerQueryFragmentRandomItemVideo) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalInnerQueryFragmentRandomItemVideo struct {
+	Typename string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+
+	Duration int `json:"duration"`
+
+	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
+}
+
+func (v *InnerQueryFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragmentRandomItemVideo) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomItemVideo, error) {
+
+	var retval __premarshalInnerQueryFragmentRandomItemVideo
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Name = v.Name
+	retval.Url = v.VideoFields.Url
+	retval.Duration = v.VideoFields.Duration
+	retval.Thumbnail = v.VideoFields.Thumbnail
+	return &retval, nil
+}
+
 // InnerQueryFragmentRandomLeafArticle includes the requested fields of the GraphQL type Article.
 type InnerQueryFragmentRandomLeafArticle struct {
 	Typename             string `json:"__typename"`
@@ -562,6 +951,32 @@ func (v *InnerQueryFragmentRandomLeafArticle) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalInnerQueryFragmentRandomLeafArticle struct {
+	Typename string `json:"__typename"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+}
+
+func (v *InnerQueryFragmentRandomLeafArticle) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragmentRandomLeafArticle) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomLeafArticle, error) {
+
+	var retval __premarshalInnerQueryFragmentRandomLeafArticle
+
+	retval.Typename = v.Typename
+	retval.Name = v.ContentFieldsArticle.Name
+	retval.Url = v.ContentFieldsArticle.Url
+	return &retval, nil
 }
 
 // InnerQueryFragmentRandomLeafLeafContent includes the requested fields of the GraphQL interface LeafContent.
@@ -619,6 +1034,42 @@ func __unmarshalInnerQueryFragmentRandomLeafLeafContent(b []byte, v *InnerQueryF
 	}
 }
 
+func __marshalInnerQueryFragmentRandomLeafLeafContent(v *InnerQueryFragmentRandomLeafLeafContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InnerQueryFragmentRandomLeafArticle:
+		typename = "Article"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentRandomLeafArticle
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *InnerQueryFragmentRandomLeafVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentRandomLeafVideo
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InnerQueryFragmentRandomLeafLeafContent: "%T"`, v)
+	}
+}
+
 // InnerQueryFragmentRandomLeafVideo includes the requested fields of the GraphQL type Video.
 type InnerQueryFragmentRandomLeafVideo struct {
 	Typename           string `json:"__typename"`
@@ -660,6 +1111,44 @@ func (v *InnerQueryFragmentRandomLeafVideo) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalInnerQueryFragmentRandomLeafVideo struct {
+	Typename string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+
+	Duration int `json:"duration"`
+
+	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
+
+	Parent *MoreVideoFieldsParentTopic `json:"parent"`
+}
+
+func (v *InnerQueryFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InnerQueryFragmentRandomLeafVideo) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomLeafVideo, error) {
+
+	var retval __premarshalInnerQueryFragmentRandomLeafVideo
+
+	retval.Typename = v.Typename
+	retval.Id = v.VideoFields.Id
+	retval.Name = v.VideoFields.Name
+	retval.Url = v.VideoFields.Url
+	retval.Duration = v.VideoFields.Duration
+	retval.Thumbnail = v.VideoFields.Thumbnail
+	retval.Parent = v.MoreVideoFields.Parent
+	return &retval, nil
 }
 
 // MoreVideoFields includes the GraphQL fields of Video requested by the fragment MoreVideoFields.
@@ -720,6 +1209,49 @@ func (v *MoreVideoFieldsParentTopic) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalMoreVideoFieldsParentTopic struct {
+	Name *string `json:"name"`
+
+	Url *string `json:"url"`
+
+	Children []json.RawMessage `json:"children"`
+}
+
+func (v *MoreVideoFieldsParentTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MoreVideoFieldsParentTopic) __premarshalJSON() (*__premarshalMoreVideoFieldsParentTopic, error) {
+
+	var retval __premarshalMoreVideoFieldsParentTopic
+
+	retval.Name = v.Name
+	retval.Url = v.Url
+	{
+
+		dst := &retval.Children
+		src := v.Children
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalMoreVideoFieldsParentTopicChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal MoreVideoFieldsParentTopic.Children: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // MoreVideoFieldsParentTopicChildrenArticle includes the requested fields of the GraphQL type Article.
@@ -792,6 +1324,46 @@ func __unmarshalMoreVideoFieldsParentTopicChildrenContent(b []byte, v *MoreVideo
 	}
 }
 
+func __marshalMoreVideoFieldsParentTopicChildrenContent(v *MoreVideoFieldsParentTopicChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *MoreVideoFieldsParentTopicChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*MoreVideoFieldsParentTopicChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *MoreVideoFieldsParentTopicChildrenVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalMoreVideoFieldsParentTopicChildrenVideo
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *MoreVideoFieldsParentTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*MoreVideoFieldsParentTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for MoreVideoFieldsParentTopicChildrenContent: "%T"`, v)
+	}
+}
+
 // MoreVideoFieldsParentTopicChildrenTopic includes the requested fields of the GraphQL type Topic.
 type MoreVideoFieldsParentTopicChildrenTopic struct {
 	Typename *string `json:"__typename"`
@@ -828,6 +1400,41 @@ func (v *MoreVideoFieldsParentTopicChildrenVideo) UnmarshalJSON(b []byte) error 
 	return nil
 }
 
+type __premarshalMoreVideoFieldsParentTopicChildrenVideo struct {
+	Typename *string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+
+	Duration int `json:"duration"`
+
+	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
+}
+
+func (v *MoreVideoFieldsParentTopicChildrenVideo) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MoreVideoFieldsParentTopicChildrenVideo) __premarshalJSON() (*__premarshalMoreVideoFieldsParentTopicChildrenVideo, error) {
+
+	var retval __premarshalMoreVideoFieldsParentTopicChildrenVideo
+
+	retval.Typename = v.Typename
+	retval.Id = v.VideoFields.Id
+	retval.Name = v.VideoFields.Name
+	retval.Url = v.VideoFields.Url
+	retval.Duration = v.VideoFields.Duration
+	retval.Thumbnail = v.VideoFields.Thumbnail
+	return &retval, nil
+}
+
 // QueryFragment includes the GraphQL fields of Query requested by the fragment QueryFragment.
 // The GraphQL type's documentation follows.
 //
@@ -859,6 +1466,65 @@ func (v *QueryFragment) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalQueryFragment struct {
+	RandomItem json.RawMessage `json:"randomItem"`
+
+	RandomLeaf json.RawMessage `json:"randomLeaf"`
+
+	OtherLeaf json.RawMessage `json:"otherLeaf"`
+}
+
+func (v *QueryFragment) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *QueryFragment) __premarshalJSON() (*__premarshalQueryFragment, error) {
+
+	var retval __premarshalQueryFragment
+
+	{
+
+		dst := &retval.RandomItem
+		src := v.InnerQueryFragment.RandomItem
+		var err error
+		*dst, err = __marshalInnerQueryFragmentRandomItemContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal QueryFragment.InnerQueryFragment.RandomItem: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.RandomLeaf
+		src := v.InnerQueryFragment.RandomLeaf
+		var err error
+		*dst, err = __marshalInnerQueryFragmentRandomLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal QueryFragment.InnerQueryFragment.RandomLeaf: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.OtherLeaf
+		src := v.InnerQueryFragment.OtherLeaf
+		var err error
+		*dst, err = __marshalInnerQueryFragmentOtherLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal QueryFragment.InnerQueryFragment.OtherLeaf: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 // VideoFields includes the GraphQL fields of Video requested by the fragment VideoFields.
@@ -895,6 +1561,38 @@ func (v *VideoFields) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalVideoFields struct {
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+
+	Duration int `json:"duration"`
+
+	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
+}
+
+func (v *VideoFields) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *VideoFields) __premarshalJSON() (*__premarshalVideoFields, error) {
+
+	var retval __premarshalVideoFields
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	retval.Url = v.Url
+	retval.Duration = v.Duration
+	retval.Thumbnail = v.Thumbnail
+	return &retval, nil
 }
 
 // VideoFieldsThumbnail includes the requested fields of the GraphQL type Thumbnail.

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -57,7 +57,6 @@ func (v *ComplexNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *ComplexNamedFragmentsResponse) __premarshalJSON() (*__premarshalComplexNamedFragmentsResponse, error) {
-
 	var retval __premarshalComplexNamedFragmentsResponse
 
 	{
@@ -323,7 +322,6 @@ func (v *InnerQueryFragment) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragment) __premarshalJSON() (*__premarshalInnerQueryFragment, error) {
-
 	var retval __premarshalInnerQueryFragment
 
 	{
@@ -413,7 +411,6 @@ func (v *InnerQueryFragmentOtherLeafArticle) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragmentOtherLeafArticle) __premarshalJSON() (*__premarshalInnerQueryFragmentOtherLeafArticle, error) {
-
 	var retval __premarshalInnerQueryFragmentOtherLeafArticle
 
 	retval.Typename = v.Typename
@@ -571,7 +568,6 @@ func (v *InnerQueryFragmentOtherLeafVideo) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragmentOtherLeafVideo) __premarshalJSON() (*__premarshalInnerQueryFragmentOtherLeafVideo, error) {
-
 	var retval __premarshalInnerQueryFragmentOtherLeafVideo
 
 	retval.Typename = v.Typename
@@ -635,7 +631,6 @@ func (v *InnerQueryFragmentRandomItemArticle) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragmentRandomItemArticle) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomItemArticle, error) {
-
 	var retval __premarshalInnerQueryFragmentRandomItemArticle
 
 	retval.Typename = v.Typename
@@ -837,7 +832,6 @@ func (v *InnerQueryFragmentRandomItemTopic) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragmentRandomItemTopic) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomItemTopic, error) {
-
 	var retval __premarshalInnerQueryFragmentRandomItemTopic
 
 	retval.Typename = v.Typename
@@ -910,7 +904,6 @@ func (v *InnerQueryFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragmentRandomItemVideo) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomItemVideo, error) {
-
 	var retval __premarshalInnerQueryFragmentRandomItemVideo
 
 	retval.Typename = v.Typename
@@ -970,7 +963,6 @@ func (v *InnerQueryFragmentRandomLeafArticle) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragmentRandomLeafArticle) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomLeafArticle, error) {
-
 	var retval __premarshalInnerQueryFragmentRandomLeafArticle
 
 	retval.Typename = v.Typename
@@ -1138,7 +1130,6 @@ func (v *InnerQueryFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InnerQueryFragmentRandomLeafVideo) __premarshalJSON() (*__premarshalInnerQueryFragmentRandomLeafVideo, error) {
-
 	var retval __premarshalInnerQueryFragmentRandomLeafVideo
 
 	retval.Typename = v.Typename
@@ -1228,7 +1219,6 @@ func (v *MoreVideoFieldsParentTopic) MarshalJSON() ([]byte, error) {
 }
 
 func (v *MoreVideoFieldsParentTopic) __premarshalJSON() (*__premarshalMoreVideoFieldsParentTopic, error) {
-
 	var retval __premarshalMoreVideoFieldsParentTopic
 
 	retval.Name = v.Name
@@ -1423,7 +1413,6 @@ func (v *MoreVideoFieldsParentTopicChildrenVideo) MarshalJSON() ([]byte, error) 
 }
 
 func (v *MoreVideoFieldsParentTopicChildrenVideo) __premarshalJSON() (*__premarshalMoreVideoFieldsParentTopicChildrenVideo, error) {
-
 	var retval __premarshalMoreVideoFieldsParentTopicChildrenVideo
 
 	retval.Typename = v.Typename
@@ -1485,7 +1474,6 @@ func (v *QueryFragment) MarshalJSON() ([]byte, error) {
 }
 
 func (v *QueryFragment) __premarshalJSON() (*__premarshalQueryFragment, error) {
-
 	var retval __premarshalQueryFragment
 
 	{
@@ -1584,7 +1572,6 @@ func (v *VideoFields) MarshalJSON() ([]byte, error) {
 }
 
 func (v *VideoFields) __premarshalJSON() (*__premarshalVideoFields, error) {
-
 	var retval __premarshalVideoFields
 
 	retval.Id = v.Id

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -76,7 +76,6 @@ func (v *CustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
 }
 
 func (v *CustomMarshalUsersBornOnUser) __premarshalJSON() (*__premarshalCustomMarshalUsersBornOnUser, error) {
-
 	var retval __premarshalCustomMarshalUsersBornOnUser
 
 	retval.Id = v.Id
@@ -146,7 +145,6 @@ func (v *__CustomMarshalInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *__CustomMarshalInput) __premarshalJSON() (*__premarshal__CustomMarshalInput, error) {
-
 	var retval __premarshal__CustomMarshalInput
 
 	{

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -61,23 +61,97 @@ func (v *CustomMarshalUsersBornOnUser) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalCustomMarshalUsersBornOnUser struct {
+	Id testutil.ID `json:"id"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *CustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *CustomMarshalUsersBornOnUser) __premarshalJSON() (*__premarshalCustomMarshalUsersBornOnUser, error) {
+
+	var retval __premarshalCustomMarshalUsersBornOnUser
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Birthdate
+		src := v.Birthdate
+		var err error
+		*dst, err = testutil.MarshalDate(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal CustomMarshalUsersBornOnUser.Birthdate: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
 // __CustomMarshalInput is used internally by genqlient
 type __CustomMarshalInput struct {
 	Date time.Time `json:"-"`
 }
 
-func (v *__CustomMarshalInput) MarshalJSON() ([]byte, error) {
+func (v *__CustomMarshalInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*__CustomMarshalInput
 		Date json.RawMessage `json:"date"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.__CustomMarshalInput = v
+	firstPass.__CustomMarshalInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Date
+		src := firstPass.Date
+		if len(src) != 0 && string(src) != "null" {
+			err = testutil.UnmarshalDate(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal __CustomMarshalInput.Date: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshal__CustomMarshalInput struct {
+	Date json.RawMessage `json:"date"`
+}
+
+func (v *__CustomMarshalInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *__CustomMarshalInput) __premarshalJSON() (*__premarshal__CustomMarshalInput, error) {
+
+	var retval __premarshal__CustomMarshalInput
 
 	{
 
-		dst := &fullObject.Date
+		dst := &retval.Date
 		src := v.Date
 		var err error
 		*dst, err = testutil.MarshalDate(
@@ -87,8 +161,7 @@ func (v *__CustomMarshalInput) MarshalJSON() ([]byte, error) {
 				"Unable to marshal __CustomMarshalInput.Date: %w", err)
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 func CustomMarshal(

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -122,7 +122,6 @@ func (v *__CustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *__CustomMarshalSliceInput) __premarshalJSON() (*__premarshal__CustomMarshalSliceInput, error) {
-
 	var retval __premarshal__CustomMarshalSliceInput
 
 	{

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -23,19 +23,111 @@ type __CustomMarshalSliceInput struct {
 	Datesssp [][][]*time.Time `json:"-"`
 }
 
-func (v *__CustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
+func (v *__CustomMarshalSliceInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*__CustomMarshalSliceInput
 		Datesss  [][][]json.RawMessage `json:"datesss"`
 		Datesssp [][][]json.RawMessage `json:"datesssp"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.__CustomMarshalSliceInput = v
+	firstPass.__CustomMarshalSliceInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Datesss
+		src := firstPass.Datesss
+		*dst = make(
+			[][][]time.Time,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			*dst = make(
+				[][]time.Time,
+				len(src))
+			for i, src := range src {
+				dst := &(*dst)[i]
+				*dst = make(
+					[]time.Time,
+					len(src))
+				for i, src := range src {
+					dst := &(*dst)[i]
+					if len(src) != 0 && string(src) != "null" {
+						err = testutil.UnmarshalDate(
+							src, dst)
+						if err != nil {
+							return fmt.Errorf(
+								"Unable to unmarshal __CustomMarshalSliceInput.Datesss: %w", err)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	{
+		dst := &v.Datesssp
+		src := firstPass.Datesssp
+		*dst = make(
+			[][][]*time.Time,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			*dst = make(
+				[][]*time.Time,
+				len(src))
+			for i, src := range src {
+				dst := &(*dst)[i]
+				*dst = make(
+					[]*time.Time,
+					len(src))
+				for i, src := range src {
+					dst := &(*dst)[i]
+					if len(src) != 0 && string(src) != "null" {
+						*dst = new(time.Time)
+						err = testutil.UnmarshalDate(
+							src, *dst)
+						if err != nil {
+							return fmt.Errorf(
+								"Unable to unmarshal __CustomMarshalSliceInput.Datesssp: %w", err)
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshal__CustomMarshalSliceInput struct {
+	Datesss [][][]json.RawMessage `json:"datesss"`
+
+	Datesssp [][][]json.RawMessage `json:"datesssp"`
+}
+
+func (v *__CustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *__CustomMarshalSliceInput) __premarshalJSON() (*__premarshal__CustomMarshalSliceInput, error) {
+
+	var retval __premarshal__CustomMarshalSliceInput
 
 	{
 
-		dst := &fullObject.Datesss
+		dst := &retval.Datesss
 		src := v.Datesss
 		*dst = make(
 			[][][]json.RawMessage,
@@ -65,7 +157,7 @@ func (v *__CustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
 	}
 	{
 
-		dst := &fullObject.Datesssp
+		dst := &retval.Datesssp
 		src := v.Datesssp
 		*dst = make(
 			[][][]json.RawMessage,
@@ -95,8 +187,7 @@ func (v *__CustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
 			}
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 func CustomMarshalSlice(

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -61,18 +61,76 @@ type UserQueryInput struct {
 	Birthdate  time.Time        `json:"-"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*UserQueryInput
 		Birthdate json.RawMessage `json:"birthdate"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.UserQueryInput = v
+	firstPass.UserQueryInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
 
 	{
+		dst := &v.Birthdate
+		src := firstPass.Birthdate
+		if len(src) != 0 && string(src) != "null" {
+			err = testutil.UnmarshalDate(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal UserQueryInput.Birthdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
 
-		dst := &fullObject.Birthdate
+type __premarshalUserQueryInput struct {
+	Email string `json:"email"`
+
+	Name string `json:"name"`
+
+	Id testutil.ID `json:"id"`
+
+	Role Role `json:"role"`
+
+	Names []string `json:"names"`
+
+	HasPokemon testutil.Pokemon `json:"hasPokemon"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
+
+	var retval __premarshalUserQueryInput
+
+	retval.Email = v.Email
+	retval.Name = v.Name
+	retval.Id = v.Id
+	retval.Role = v.Role
+	retval.Names = v.Names
+	retval.HasPokemon = v.HasPokemon
+	{
+
+		dst := &retval.Birthdate
 		src := v.Birthdate
 		var err error
 		*dst, err = testutil.MarshalDate(
@@ -82,8 +140,7 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 				"Unable to marshal UserQueryInput.Birthdate: %w", err)
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __InputObjectQueryInput is used internally by genqlient

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -119,7 +119,6 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
-
 	var retval __premarshalUserQueryInput
 
 	retval.Email = v.Email

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -63,6 +63,49 @@ func (v *InterfaceListFieldRootTopic) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalInterfaceListFieldRootTopic struct {
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Children []json.RawMessage `json:"children"`
+}
+
+func (v *InterfaceListFieldRootTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InterfaceListFieldRootTopic) __premarshalJSON() (*__premarshalInterfaceListFieldRootTopic, error) {
+
+	var retval __premarshalInterfaceListFieldRootTopic
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Children
+		src := v.Children
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalInterfaceListFieldRootTopicChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal InterfaceListFieldRootTopic.Children: %w", err)
+			}
+		}
+	}
+	return &retval, nil
+}
+
 // InterfaceListFieldRootTopicChildrenArticle includes the requested fields of the GraphQL type Article.
 type InterfaceListFieldRootTopicChildrenArticle struct {
 	Typename string `json:"__typename"`
@@ -161,6 +204,42 @@ func __unmarshalInterfaceListFieldRootTopicChildrenContent(b []byte, v *Interfac
 	}
 }
 
+func __marshalInterfaceListFieldRootTopicChildrenContent(v *InterfaceListFieldRootTopicChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceListFieldRootTopicChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldRootTopicChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListFieldRootTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldRootTopicChildrenVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListFieldRootTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldRootTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceListFieldRootTopicChildrenContent: "%T"`, v)
+	}
+}
+
 // InterfaceListFieldRootTopicChildrenTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceListFieldRootTopicChildrenTopic struct {
 	Typename string `json:"__typename"`
@@ -222,6 +301,49 @@ func (v *InterfaceListFieldWithPointerTopic) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalInterfaceListFieldWithPointerTopic struct {
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Children []json.RawMessage `json:"children"`
+}
+
+func (v *InterfaceListFieldWithPointerTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InterfaceListFieldWithPointerTopic) __premarshalJSON() (*__premarshalInterfaceListFieldWithPointerTopic, error) {
+
+	var retval __premarshalInterfaceListFieldWithPointerTopic
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Children
+		src := v.Children
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalInterfaceListFieldWithPointerTopicChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal InterfaceListFieldWithPointerTopic.Children: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // InterfaceListFieldWithPointerTopicChildrenArticle includes the requested fields of the GraphQL type Article.
@@ -319,6 +441,42 @@ func __unmarshalInterfaceListFieldWithPointerTopicChildrenContent(b []byte, v *I
 	default:
 		return fmt.Errorf(
 			`Unexpected concrete type for InterfaceListFieldWithPointerTopicChildrenContent: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalInterfaceListFieldWithPointerTopicChildrenContent(v *InterfaceListFieldWithPointerTopicChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceListFieldWithPointerTopicChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldWithPointerTopicChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListFieldWithPointerTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldWithPointerTopicChildrenVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListFieldWithPointerTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldWithPointerTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceListFieldWithPointerTopicChildrenContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -80,7 +80,6 @@ func (v *InterfaceListFieldRootTopic) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InterfaceListFieldRootTopic) __premarshalJSON() (*__premarshalInterfaceListFieldRootTopic, error) {
-
 	var retval __premarshalInterfaceListFieldRootTopic
 
 	retval.Id = v.Id
@@ -320,7 +319,6 @@ func (v *InterfaceListFieldWithPointerTopic) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InterfaceListFieldWithPointerTopic) __premarshalJSON() (*__premarshalInterfaceListFieldWithPointerTopic, error) {
-
 	var retval __premarshalInterfaceListFieldWithPointerTopic
 
 	retval.Id = v.Id

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -283,7 +283,6 @@ func (v *InterfaceListOfListOfListsFieldResponse) MarshalJSON() ([]byte, error) 
 }
 
 func (v *InterfaceListOfListOfListsFieldResponse) __premarshalJSON() (*__premarshalInterfaceListOfListOfListsFieldResponse, error) {
-
 	var retval __premarshalInterfaceListOfListOfListsFieldResponse
 
 	{

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -118,6 +118,42 @@ func __unmarshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(b []b
 	}
 }
 
+func __marshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceListOfListOfListsFieldListOfListsOfListsOfContent: "%T"`, v)
+	}
+}
+
 // InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle includes the requested fields of the GraphQL type Article.
 type InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle struct {
 	Typename string `json:"__typename"`
@@ -232,6 +268,89 @@ func (v *InterfaceListOfListOfListsFieldResponse) UnmarshalJSON(b []byte) error 
 	return nil
 }
 
+type __premarshalInterfaceListOfListOfListsFieldResponse struct {
+	ListOfListsOfListsOfContent [][][]json.RawMessage `json:"listOfListsOfListsOfContent"`
+
+	WithPointer [][][]json.RawMessage `json:"withPointer"`
+}
+
+func (v *InterfaceListOfListOfListsFieldResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InterfaceListOfListOfListsFieldResponse) __premarshalJSON() (*__premarshalInterfaceListOfListOfListsFieldResponse, error) {
+
+	var retval __premarshalInterfaceListOfListOfListsFieldResponse
+
+	{
+
+		dst := &retval.ListOfListsOfListsOfContent
+		src := v.ListOfListsOfListsOfContent
+		*dst = make(
+			[][][]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			*dst = make(
+				[][]json.RawMessage,
+				len(src))
+			for i, src := range src {
+				dst := &(*dst)[i]
+				*dst = make(
+					[]json.RawMessage,
+					len(src))
+				for i, src := range src {
+					dst := &(*dst)[i]
+					var err error
+					*dst, err = __marshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(
+						&src)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"Unable to marshal InterfaceListOfListOfListsFieldResponse.ListOfListsOfListsOfContent: %w", err)
+					}
+				}
+			}
+		}
+	}
+	{
+
+		dst := &retval.WithPointer
+		src := v.WithPointer
+		*dst = make(
+			[][][]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			*dst = make(
+				[][]json.RawMessage,
+				len(src))
+			for i, src := range src {
+				dst := &(*dst)[i]
+				*dst = make(
+					[]json.RawMessage,
+					len(src))
+				for i, src := range src {
+					dst := &(*dst)[i]
+					if src != nil {
+						var err error
+						*dst, err = __marshalInterfaceListOfListOfListsFieldWithPointerContent(
+							src)
+						if err != nil {
+							return nil, fmt.Errorf(
+								"Unable to marshal InterfaceListOfListOfListsFieldResponse.WithPointer: %w", err)
+						}
+					}
+				}
+			}
+		}
+	}
+	return &retval, nil
+}
+
 // InterfaceListOfListOfListsFieldWithPointerArticle includes the requested fields of the GraphQL type Article.
 type InterfaceListOfListOfListsFieldWithPointerArticle struct {
 	Typename string `json:"__typename"`
@@ -327,6 +446,42 @@ func __unmarshalInterfaceListOfListOfListsFieldWithPointerContent(b []byte, v *I
 	default:
 		return fmt.Errorf(
 			`Unexpected concrete type for InterfaceListOfListOfListsFieldWithPointerContent: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalInterfaceListOfListOfListsFieldWithPointerContent(v *InterfaceListOfListOfListsFieldWithPointerContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceListOfListOfListsFieldWithPointerArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldWithPointerArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListOfListOfListsFieldWithPointerVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldWithPointerVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListOfListOfListsFieldWithPointerTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldWithPointerTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceListOfListOfListsFieldWithPointerContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -76,7 +76,6 @@ func (v *InterfaceNestingRootTopic) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InterfaceNestingRootTopic) __premarshalJSON() (*__premarshalInterfaceNestingRootTopic, error) {
-
 	var retval __premarshalInterfaceNestingRootTopic
 
 	retval.Id = v.Id
@@ -302,7 +301,6 @@ func (v *InterfaceNestingRootTopicChildrenContentParentTopic) MarshalJSON() ([]b
 }
 
 func (v *InterfaceNestingRootTopicChildrenContentParentTopic) __premarshalJSON() (*__premarshalInterfaceNestingRootTopicChildrenContentParentTopic, error) {
-
 	var retval __premarshalInterfaceNestingRootTopicChildrenContentParentTopic
 
 	retval.Id = v.Id

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -61,6 +61,46 @@ func (v *InterfaceNestingRootTopic) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalInterfaceNestingRootTopic struct {
+	Id testutil.ID `json:"id"`
+
+	Children []json.RawMessage `json:"children"`
+}
+
+func (v *InterfaceNestingRootTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InterfaceNestingRootTopic) __premarshalJSON() (*__premarshalInterfaceNestingRootTopic, error) {
+
+	var retval __premarshalInterfaceNestingRootTopic
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Children
+		src := v.Children
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalInterfaceNestingRootTopicChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal InterfaceNestingRootTopic.Children: %w", err)
+			}
+		}
+	}
+	return &retval, nil
+}
+
 // InterfaceNestingRootTopicChildrenArticle includes the requested fields of the GraphQL type Article.
 type InterfaceNestingRootTopicChildrenArticle struct {
 	Typename string `json:"__typename"`
@@ -165,6 +205,42 @@ func __unmarshalInterfaceNestingRootTopicChildrenContent(b []byte, v *InterfaceN
 	}
 }
 
+func __marshalInterfaceNestingRootTopicChildrenContent(v *InterfaceNestingRootTopicChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceNestingRootTopicChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNestingRootTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNestingRootTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceNestingRootTopicChildrenContent: "%T"`, v)
+	}
+}
+
 // InterfaceNestingRootTopicChildrenContentParentTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceNestingRootTopicChildrenContentParentTopic struct {
 	// ID is documented in the Content interface.
@@ -209,6 +285,46 @@ func (v *InterfaceNestingRootTopicChildrenContentParentTopic) UnmarshalJSON(b []
 		}
 	}
 	return nil
+}
+
+type __premarshalInterfaceNestingRootTopicChildrenContentParentTopic struct {
+	Id testutil.ID `json:"id"`
+
+	Children []json.RawMessage `json:"children"`
+}
+
+func (v *InterfaceNestingRootTopicChildrenContentParentTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InterfaceNestingRootTopicChildrenContentParentTopic) __premarshalJSON() (*__premarshalInterfaceNestingRootTopicChildrenContentParentTopic, error) {
+
+	var retval __premarshalInterfaceNestingRootTopicChildrenContentParentTopic
+
+	retval.Id = v.Id
+	{
+
+		dst := &retval.Children
+		src := v.Children
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal InterfaceNestingRootTopicChildrenContentParentTopic.Children: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle includes the requested fields of the GraphQL type Article.
@@ -306,6 +422,42 @@ func __unmarshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenConte
 	default:
 		return fmt.Errorf(
 			`Unexpected concrete type for InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent(v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -108,6 +108,42 @@ func __unmarshalInterfaceNoFragmentsQueryRandomItemContent(b []byte, v *Interfac
 	}
 }
 
+func __marshalInterfaceNoFragmentsQueryRandomItemContent(v *InterfaceNoFragmentsQueryRandomItemContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceNoFragmentsQueryRandomItemArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryRandomItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryRandomItemTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceNoFragmentsQueryRandomItemContent: "%T"`, v)
+	}
+}
+
 // InterfaceNoFragmentsQueryRandomItemTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceNoFragmentsQueryRandomItemTopic struct {
 	Typename string `json:"__typename"`
@@ -228,6 +264,42 @@ func __unmarshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(b []byte,
 	}
 }
 
+func __marshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(v *InterfaceNoFragmentsQueryRandomItemWithTypeNameContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceNoFragmentsQueryRandomItemWithTypeNameContent: "%T"`, v)
+	}
+}
+
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic struct {
 	Typename string `json:"__typename"`
@@ -312,6 +384,70 @@ func (v *InterfaceNoFragmentsQueryResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalInterfaceNoFragmentsQueryResponse struct {
+	Root InterfaceNoFragmentsQueryRootTopic `json:"root"`
+
+	RandomItem json.RawMessage `json:"randomItem"`
+
+	RandomItemWithTypeName json.RawMessage `json:"randomItemWithTypeName"`
+
+	WithPointer json.RawMessage `json:"withPointer"`
+}
+
+func (v *InterfaceNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *InterfaceNoFragmentsQueryResponse) __premarshalJSON() (*__premarshalInterfaceNoFragmentsQueryResponse, error) {
+
+	var retval __premarshalInterfaceNoFragmentsQueryResponse
+
+	retval.Root = v.Root
+	{
+
+		dst := &retval.RandomItem
+		src := v.RandomItem
+		var err error
+		*dst, err = __marshalInterfaceNoFragmentsQueryRandomItemContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal InterfaceNoFragmentsQueryResponse.RandomItem: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.RandomItemWithTypeName
+		src := v.RandomItemWithTypeName
+		var err error
+		*dst, err = __marshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal InterfaceNoFragmentsQueryResponse.RandomItemWithTypeName: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.WithPointer
+		src := v.WithPointer
+		if src != nil {
+			var err error
+			*dst, err = __marshalInterfaceNoFragmentsQueryWithPointerContent(
+				src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal InterfaceNoFragmentsQueryResponse.WithPointer: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // InterfaceNoFragmentsQueryRootTopic includes the requested fields of the GraphQL type Topic.
@@ -416,6 +552,42 @@ func __unmarshalInterfaceNoFragmentsQueryWithPointerContent(b []byte, v *Interfa
 	default:
 		return fmt.Errorf(
 			`Unexpected concrete type for InterfaceNoFragmentsQueryWithPointerContent: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalInterfaceNoFragmentsQueryWithPointerContent(v *InterfaceNoFragmentsQueryWithPointerContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *InterfaceNoFragmentsQueryWithPointerArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryWithPointerArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryWithPointerVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryWithPointerVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryWithPointerTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryWithPointerTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for InterfaceNoFragmentsQueryWithPointerContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -405,7 +405,6 @@ func (v *InterfaceNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *InterfaceNoFragmentsQueryResponse) __premarshalJSON() (*__premarshalInterfaceNoFragmentsQueryResponse, error) {
-
 	var retval __premarshalInterfaceNoFragmentsQueryResponse
 
 	retval.Root = v.Root

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -86,7 +86,6 @@ func (v *MyInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *MyInput) __premarshalJSON() (*__premarshalMyInput, error) {
-
 	var retval __premarshalMyInput
 
 	retval.Email = v.Email
@@ -233,7 +232,6 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
-
 	var retval __premarshalUserQueryInput
 
 	retval.Email = v.Email

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -27,18 +27,77 @@ type MyInput struct {
 	Birthdate  *time.Time        `json:"-"`
 }
 
-func (v *MyInput) MarshalJSON() ([]byte, error) {
+func (v *MyInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*MyInput
 		Birthdate json.RawMessage `json:"birthdate"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.MyInput = v
+	firstPass.MyInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
 
 	{
+		dst := &v.Birthdate
+		src := firstPass.Birthdate
+		if len(src) != 0 && string(src) != "null" {
+			*dst = new(time.Time)
+			err = testutil.UnmarshalDate(
+				src, *dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal MyInput.Birthdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
 
-		dst := &fullObject.Birthdate
+type __premarshalMyInput struct {
+	Email *string `json:"email"`
+
+	Name *string `json:"name"`
+
+	Id *testutil.ID `json:"id"`
+
+	Role *Role `json:"role"`
+
+	Names []*string `json:"names"`
+
+	HasPokemon *testutil.Pokemon `json:"hasPokemon"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *MyInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *MyInput) __premarshalJSON() (*__premarshalMyInput, error) {
+
+	var retval __premarshalMyInput
+
+	retval.Email = v.Email
+	retval.Name = v.Name
+	retval.Id = v.Id
+	retval.Role = v.Role
+	retval.Names = v.Names
+	retval.HasPokemon = v.HasPokemon
+	{
+
+		dst := &retval.Birthdate
 		src := v.Birthdate
 		if src != nil {
 			var err error
@@ -50,8 +109,7 @@ func (v *MyInput) MarshalJSON() ([]byte, error) {
 			}
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // MyMultipleDirectivesResponse is returned by MultipleDirectives on success.
@@ -116,18 +174,77 @@ type UserQueryInput struct {
 	Birthdate  *time.Time        `json:"-"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*UserQueryInput
 		Birthdate json.RawMessage `json:"birthdate"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.UserQueryInput = v
+	firstPass.UserQueryInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
 
 	{
+		dst := &v.Birthdate
+		src := firstPass.Birthdate
+		if len(src) != 0 && string(src) != "null" {
+			*dst = new(time.Time)
+			err = testutil.UnmarshalDate(
+				src, *dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal UserQueryInput.Birthdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
 
-		dst := &fullObject.Birthdate
+type __premarshalUserQueryInput struct {
+	Email *string `json:"email"`
+
+	Name *string `json:"name"`
+
+	Id *testutil.ID `json:"id"`
+
+	Role *Role `json:"role"`
+
+	Names []*string `json:"names"`
+
+	HasPokemon *testutil.Pokemon `json:"hasPokemon"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
+
+	var retval __premarshalUserQueryInput
+
+	retval.Email = v.Email
+	retval.Name = v.Name
+	retval.Id = v.Id
+	retval.Role = v.Role
+	retval.Names = v.Names
+	retval.HasPokemon = v.HasPokemon
+	{
+
+		dst := &retval.Birthdate
 		src := v.Birthdate
 		if src != nil {
 			var err error
@@ -139,8 +256,7 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 			}
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __MultipleDirectivesInput is used internally by genqlient

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -75,18 +75,76 @@ type UserQueryInput struct {
 	Birthdate  time.Time        `json:"-"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*UserQueryInput
 		Birthdate json.RawMessage `json:"birthdate"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.UserQueryInput = v
+	firstPass.UserQueryInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
 
 	{
+		dst := &v.Birthdate
+		src := firstPass.Birthdate
+		if len(src) != 0 && string(src) != "null" {
+			err = testutil.UnmarshalDate(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal UserQueryInput.Birthdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
 
-		dst := &fullObject.Birthdate
+type __premarshalUserQueryInput struct {
+	Email string `json:"email"`
+
+	Name string `json:"name"`
+
+	Id testutil.ID `json:"id"`
+
+	Role Role `json:"role"`
+
+	Names []string `json:"names"`
+
+	HasPokemon testutil.Pokemon `json:"hasPokemon"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
+
+	var retval __premarshalUserQueryInput
+
+	retval.Email = v.Email
+	retval.Name = v.Name
+	retval.Id = v.Id
+	retval.Role = v.Role
+	retval.Names = v.Names
+	retval.HasPokemon = v.HasPokemon
+	{
+
+		dst := &retval.Birthdate
 		src := v.Birthdate
 		var err error
 		*dst, err = testutil.MarshalDate(
@@ -96,8 +154,7 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 				"Unable to marshal UserQueryInput.Birthdate: %w", err)
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __OmitEmptyQueryInput is used internally by genqlient

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -133,7 +133,6 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
-
 	var retval __premarshalUserQueryInput
 
 	retval.Email = v.Email

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -82,18 +82,77 @@ type UserQueryInput struct {
 	Birthdate  *time.Time        `json:"-"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*UserQueryInput
 		Birthdate json.RawMessage `json:"birthdate"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.UserQueryInput = v
+	firstPass.UserQueryInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
 
 	{
+		dst := &v.Birthdate
+		src := firstPass.Birthdate
+		if len(src) != 0 && string(src) != "null" {
+			*dst = new(time.Time)
+			err = testutil.UnmarshalDate(
+				src, *dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal UserQueryInput.Birthdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
 
-		dst := &fullObject.Birthdate
+type __premarshalUserQueryInput struct {
+	Email *string `json:"email"`
+
+	Name *string `json:"name"`
+
+	Id *testutil.ID `json:"id"`
+
+	Role *Role `json:"role"`
+
+	Names []*string `json:"names"`
+
+	HasPokemon *testutil.Pokemon `json:"hasPokemon"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
+
+	var retval __premarshalUserQueryInput
+
+	retval.Email = v.Email
+	retval.Name = v.Name
+	retval.Id = v.Id
+	retval.Role = v.Role
+	retval.Names = v.Names
+	retval.HasPokemon = v.HasPokemon
+	{
+
+		dst := &retval.Birthdate
 		src := v.Birthdate
 		if src != nil {
 			var err error
@@ -105,8 +164,7 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 			}
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __PointersQueryInput is used internally by genqlient

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -141,7 +141,6 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
-
 	var retval __premarshalUserQueryInput
 
 	retval.Email = v.Email

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -140,7 +140,6 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
-
 	var retval __premarshalUserQueryInput
 
 	retval.Email = v.Email

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -82,18 +82,76 @@ type UserQueryInput struct {
 	Birthdate  time.Time        `json:"-"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*UserQueryInput
 		Birthdate json.RawMessage `json:"birthdate"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.UserQueryInput = v
+	firstPass.UserQueryInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
 
 	{
+		dst := &v.Birthdate
+		src := firstPass.Birthdate
+		if len(src) != 0 && string(src) != "null" {
+			err = testutil.UnmarshalDate(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal UserQueryInput.Birthdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
 
-		dst := &fullObject.Birthdate
+type __premarshalUserQueryInput struct {
+	Email string `json:"email"`
+
+	Name string `json:"name"`
+
+	Id testutil.ID `json:"id"`
+
+	Role Role `json:"role"`
+
+	Names []string `json:"names"`
+
+	HasPokemon testutil.Pokemon `json:"hasPokemon"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
+
+	var retval __premarshalUserQueryInput
+
+	retval.Email = v.Email
+	retval.Name = v.Name
+	retval.Id = v.Id
+	retval.Role = v.Role
+	retval.Names = v.Names
+	retval.HasPokemon = v.HasPokemon
+	{
+
+		dst := &retval.Birthdate
 		src := v.Birthdate
 		var err error
 		*dst, err = testutil.MarshalDate(
@@ -103,8 +161,7 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 				"Unable to marshal UserQueryInput.Birthdate: %w", err)
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __PointersQueryInput is used internally by genqlient

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -109,6 +109,42 @@ func __unmarshalSimpleInlineFragmentRandomItemContent(b []byte, v *SimpleInlineF
 	}
 }
 
+func __marshalSimpleInlineFragmentRandomItemContent(v *SimpleInlineFragmentRandomItemContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *SimpleInlineFragmentRandomItemArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleInlineFragmentRandomItemArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *SimpleInlineFragmentRandomItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleInlineFragmentRandomItemVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *SimpleInlineFragmentRandomItemTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleInlineFragmentRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for SimpleInlineFragmentRandomItemContent: "%T"`, v)
+	}
+}
+
 // SimpleInlineFragmentRandomItemTopic includes the requested fields of the GraphQL type Topic.
 type SimpleInlineFragmentRandomItemTopic struct {
 	Typename string `json:"__typename"`
@@ -162,6 +198,37 @@ func (v *SimpleInlineFragmentResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalSimpleInlineFragmentResponse struct {
+	RandomItem json.RawMessage `json:"randomItem"`
+}
+
+func (v *SimpleInlineFragmentResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SimpleInlineFragmentResponse) __premarshalJSON() (*__premarshalSimpleInlineFragmentResponse, error) {
+
+	var retval __premarshalSimpleInlineFragmentResponse
+
+	{
+
+		dst := &retval.RandomItem
+		src := v.RandomItem
+		var err error
+		*dst, err = __marshalSimpleInlineFragmentRandomItemContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal SimpleInlineFragmentResponse.RandomItem: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 func SimpleInlineFragment(

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -213,7 +213,6 @@ func (v *SimpleInlineFragmentResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *SimpleInlineFragmentResponse) __premarshalJSON() (*__premarshalSimpleInlineFragmentResponse, error) {
-
 	var retval __premarshalSimpleInlineFragmentResponse
 
 	{

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -213,7 +213,6 @@ func (v *SimpleNamedFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
 }
 
 func (v *SimpleNamedFragmentRandomItemVideo) __premarshalJSON() (*__premarshalSimpleNamedFragmentRandomItemVideo, error) {
-
 	var retval __premarshalSimpleNamedFragmentRandomItemVideo
 
 	retval.Typename = v.Typename
@@ -371,7 +370,6 @@ func (v *SimpleNamedFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
 }
 
 func (v *SimpleNamedFragmentRandomLeafVideo) __premarshalJSON() (*__premarshalSimpleNamedFragmentRandomLeafVideo, error) {
-
 	var retval __premarshalSimpleNamedFragmentRandomLeafVideo
 
 	retval.Typename = v.Typename
@@ -451,7 +449,6 @@ func (v *SimpleNamedFragmentResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *SimpleNamedFragmentResponse) __premarshalJSON() (*__premarshalSimpleNamedFragmentResponse, error) {
-
 	var retval __premarshalSimpleNamedFragmentResponse
 
 	{

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -108,6 +108,46 @@ func __unmarshalSimpleNamedFragmentRandomItemContent(b []byte, v *SimpleNamedFra
 	}
 }
 
+func __marshalSimpleNamedFragmentRandomItemContent(v *SimpleNamedFragmentRandomItemContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *SimpleNamedFragmentRandomItemArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleNamedFragmentRandomItemArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *SimpleNamedFragmentRandomItemVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSimpleNamedFragmentRandomItemVideo
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *SimpleNamedFragmentRandomItemTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleNamedFragmentRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for SimpleNamedFragmentRandomItemContent: "%T"`, v)
+	}
+}
+
 // SimpleNamedFragmentRandomItemTopic includes the requested fields of the GraphQL type Topic.
 type SimpleNamedFragmentRandomItemTopic struct {
 	Typename string `json:"__typename"`
@@ -148,6 +188,41 @@ func (v *SimpleNamedFragmentRandomItemVideo) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalSimpleNamedFragmentRandomItemVideo struct {
+	Typename string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+
+	Duration int `json:"duration"`
+
+	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
+}
+
+func (v *SimpleNamedFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SimpleNamedFragmentRandomItemVideo) __premarshalJSON() (*__premarshalSimpleNamedFragmentRandomItemVideo, error) {
+
+	var retval __premarshalSimpleNamedFragmentRandomItemVideo
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Name = v.Name
+	retval.Url = v.VideoFields.Url
+	retval.Duration = v.VideoFields.Duration
+	retval.Thumbnail = v.VideoFields.Thumbnail
+	return &retval, nil
 }
 
 // SimpleNamedFragmentRandomLeafArticle includes the requested fields of the GraphQL type Article.
@@ -210,6 +285,38 @@ func __unmarshalSimpleNamedFragmentRandomLeafLeafContent(b []byte, v *SimpleName
 	}
 }
 
+func __marshalSimpleNamedFragmentRandomLeafLeafContent(v *SimpleNamedFragmentRandomLeafLeafContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *SimpleNamedFragmentRandomLeafArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleNamedFragmentRandomLeafArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *SimpleNamedFragmentRandomLeafVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalSimpleNamedFragmentRandomLeafVideo
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for SimpleNamedFragmentRandomLeafLeafContent: "%T"`, v)
+	}
+}
+
 // SimpleNamedFragmentRandomLeafVideo includes the requested fields of the GraphQL type Video.
 type SimpleNamedFragmentRandomLeafVideo struct {
 	Typename    string `json:"__typename"`
@@ -239,6 +346,41 @@ func (v *SimpleNamedFragmentRandomLeafVideo) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalSimpleNamedFragmentRandomLeafVideo struct {
+	Typename string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Name string `json:"name"`
+
+	Url string `json:"url"`
+
+	Duration int `json:"duration"`
+
+	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
+}
+
+func (v *SimpleNamedFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SimpleNamedFragmentRandomLeafVideo) __premarshalJSON() (*__premarshalSimpleNamedFragmentRandomLeafVideo, error) {
+
+	var retval __premarshalSimpleNamedFragmentRandomLeafVideo
+
+	retval.Typename = v.Typename
+	retval.Id = v.VideoFields.Id
+	retval.Name = v.VideoFields.Name
+	retval.Url = v.VideoFields.Url
+	retval.Duration = v.VideoFields.Duration
+	retval.Thumbnail = v.VideoFields.Thumbnail
+	return &retval, nil
 }
 
 // SimpleNamedFragmentResponse is returned by SimpleNamedFragment on success.
@@ -292,6 +434,51 @@ func (v *SimpleNamedFragmentResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalSimpleNamedFragmentResponse struct {
+	RandomItem json.RawMessage `json:"randomItem"`
+
+	RandomLeaf json.RawMessage `json:"randomLeaf"`
+}
+
+func (v *SimpleNamedFragmentResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *SimpleNamedFragmentResponse) __premarshalJSON() (*__premarshalSimpleNamedFragmentResponse, error) {
+
+	var retval __premarshalSimpleNamedFragmentResponse
+
+	{
+
+		dst := &retval.RandomItem
+		src := v.RandomItem
+		var err error
+		*dst, err = __marshalSimpleNamedFragmentRandomItemContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal SimpleNamedFragmentResponse.RandomItem: %w", err)
+		}
+	}
+	{
+
+		dst := &retval.RandomLeaf
+		src := v.RandomLeaf
+		var err error
+		*dst, err = __marshalSimpleNamedFragmentRandomLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal SimpleNamedFragmentResponse.RandomLeaf: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 // VideoFields includes the GraphQL fields of Video requested by the fragment VideoFields.

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -116,7 +116,6 @@ func (v *StructOptionRootTopicChildrenContentParentTopic) MarshalJSON() ([]byte,
 }
 
 func (v *StructOptionRootTopicChildrenContentParentTopic) __premarshalJSON() (*__premarshalStructOptionRootTopicChildrenContentParentTopic, error) {
-
 	var retval __premarshalStructOptionRootTopicChildrenContentParentTopic
 
 	retval.Id = v.Id
@@ -347,7 +346,6 @@ func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) 
 }
 
 func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) __premarshalJSON() (*__premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo, error) {
-
 	var retval __premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo
 
 	retval.Typename = v.Typename

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -99,6 +99,49 @@ func (v *StructOptionRootTopicChildrenContentParentTopic) UnmarshalJSON(b []byte
 	return nil
 }
 
+type __premarshalStructOptionRootTopicChildrenContentParentTopic struct {
+	Id testutil.ID `json:"id"`
+
+	Children []StructOptionRootTopicChildrenContentParentTopicChildrenContent `json:"children"`
+
+	InterfaceChildren []json.RawMessage `json:"interfaceChildren"`
+}
+
+func (v *StructOptionRootTopicChildrenContentParentTopic) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *StructOptionRootTopicChildrenContentParentTopic) __premarshalJSON() (*__premarshalStructOptionRootTopicChildrenContentParentTopic, error) {
+
+	var retval __premarshalStructOptionRootTopicChildrenContentParentTopic
+
+	retval.Id = v.Id
+	retval.Children = v.Children
+	{
+
+		dst := &retval.InterfaceChildren
+		src := v.InterfaceChildren
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal StructOptionRootTopicChildrenContentParentTopic.InterfaceChildren: %w", err)
+			}
+		}
+	}
+	return &retval, nil
+}
+
 // StructOptionRootTopicChildrenContentParentTopicChildrenContent includes the requested fields of the GraphQL type Content.
 // The GraphQL type's documentation follows.
 //
@@ -207,6 +250,46 @@ func __unmarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildren
 	}
 }
 
+func __marshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent(v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent: "%T"`, v)
+	}
+}
+
 // StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic includes the requested fields of the GraphQL type Topic.
 type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic struct {
 	Typename string `json:"__typename"`
@@ -245,6 +328,32 @@ func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) 
 		return err
 	}
 	return nil
+}
+
+type __premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo struct {
+	Typename string `json:"__typename"`
+
+	Id testutil.ID `json:"id"`
+
+	Duration int `json:"duration"`
+}
+
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) __premarshalJSON() (*__premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo, error) {
+
+	var retval __premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Duration = v.VideoFields.Duration
+	return &retval, nil
 }
 
 // StructOptionUser includes the requested fields of the GraphQL type User.

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -218,7 +218,6 @@ func (v *Resp) MarshalJSON() ([]byte, error) {
 }
 
 func (v *Resp) __premarshalJSON() (*__premarshalResp, error) {
-
 	var retval __premarshalResp
 
 	retval.User = v.User

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -97,6 +97,42 @@ func __unmarshalItem(b []byte, v *Item) error {
 	}
 }
 
+func __marshalItem(v *Item) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ItemArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ItemArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *ItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ItemVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case *ItemTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for Item: "%T"`, v)
+	}
+}
+
 // ItemArticle includes the requested fields of the GraphQL type Article.
 type ItemArticle struct {
 	Typename string `json:"__typename"`
@@ -163,6 +199,43 @@ func (v *Resp) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalResp struct {
+	User User `json:"user"`
+
+	RandomItem json.RawMessage `json:"randomItem"`
+
+	Users []User `json:"users"`
+}
+
+func (v *Resp) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *Resp) __premarshalJSON() (*__premarshalResp, error) {
+
+	var retval __premarshalResp
+
+	retval.User = v.User
+	{
+
+		dst := &retval.RandomItem
+		src := v.RandomItem
+		var err error
+		*dst, err = __marshalItem(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal Resp.RandomItem: %w", err)
+		}
+	}
+	retval.Users = v.Users
+	return &retval, nil
 }
 
 // User includes the requested fields of the GraphQL type User.

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -153,7 +153,6 @@ func (v *UnionNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UnionNoFragmentsQueryResponse) __premarshalJSON() (*__premarshalUnionNoFragmentsQueryResponse, error) {
-
 	var retval __premarshalUnionNoFragmentsQueryResponse
 
 	{

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -69,6 +69,34 @@ func __unmarshalUnionNoFragmentsQueryRandomLeafLeafContent(b []byte, v *UnionNoF
 	}
 }
 
+func __marshalUnionNoFragmentsQueryRandomLeafLeafContent(v *UnionNoFragmentsQueryRandomLeafLeafContent) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *UnionNoFragmentsQueryRandomLeafArticle:
+		typename = "Article"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*UnionNoFragmentsQueryRandomLeafArticle
+		}{typename, v}
+		return json.Marshal(result)
+	case *UnionNoFragmentsQueryRandomLeafVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*UnionNoFragmentsQueryRandomLeafVideo
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for UnionNoFragmentsQueryRandomLeafLeafContent: "%T"`, v)
+	}
+}
+
 // UnionNoFragmentsQueryRandomLeafVideo includes the requested fields of the GraphQL type Video.
 type UnionNoFragmentsQueryRandomLeafVideo struct {
 	Typename string `json:"__typename"`
@@ -110,6 +138,37 @@ func (v *UnionNoFragmentsQueryResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalUnionNoFragmentsQueryResponse struct {
+	RandomLeaf json.RawMessage `json:"randomLeaf"`
+}
+
+func (v *UnionNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UnionNoFragmentsQueryResponse) __premarshalJSON() (*__premarshalUnionNoFragmentsQueryResponse, error) {
+
+	var retval __premarshalUnionNoFragmentsQueryResponse
+
+	{
+
+		dst := &retval.RandomLeaf
+		src := v.RandomLeaf
+		var err error
+		*dst, err = __marshalUnionNoFragmentsQueryRandomLeafLeafContent(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal UnionNoFragmentsQueryResponse.RandomLeaf: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 func UnionNoFragmentsQuery(

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -99,7 +99,6 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
-
 	var retval __premarshalUserQueryInput
 
 	retval.Email = v.Email

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -41,18 +41,76 @@ type UserQueryInput struct {
 	Birthdate  time.Time        `json:"-"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*UserQueryInput
 		Birthdate json.RawMessage `json:"birthdate"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.UserQueryInput = v
+	firstPass.UserQueryInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
 
 	{
+		dst := &v.Birthdate
+		src := firstPass.Birthdate
+		if len(src) != 0 && string(src) != "null" {
+			err = testutil.UnmarshalDate(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal UserQueryInput.Birthdate: %w", err)
+			}
+		}
+	}
+	return nil
+}
 
-		dst := &fullObject.Birthdate
+type __premarshalUserQueryInput struct {
+	Email string `json:"email"`
+
+	Name string `json:"name"`
+
+	Id testutil.ID `json:"id"`
+
+	Role Role `json:"role"`
+
+	Names []string `json:"names"`
+
+	HasPokemon testutil.Pokemon `json:"hasPokemon"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error) {
+
+	var retval __premarshalUserQueryInput
+
+	retval.Email = v.Email
+	retval.Name = v.Name
+	retval.Id = v.Id
+	retval.Role = v.Role
+	retval.Names = v.Names
+	retval.HasPokemon = v.HasPokemon
+	{
+
+		dst := &retval.Birthdate
 		src := v.Birthdate
 		var err error
 		*dst, err = testutil.MarshalDate(
@@ -62,8 +120,7 @@ func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
 				"Unable to marshal UserQueryInput.Birthdate: %w", err)
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __unexportedInput is used internally by genqlient

--- a/generate/types.go
+++ b/generate/types.go
@@ -277,11 +277,11 @@ type selector struct {
 // Those rules don't work for us.  When unmarshaling, we want to fill in all
 // the potentially-matching fields (QT.A.Id and QT.B.Id in this case), and when
 // marshaling, we want to always marshal exactly one potentially-conflicting
-// field; we're happy to use the Go visibility rules when they apply. such field, choosing an
-// arbitrary one (in a stable manner) if needed.  For unmarshaling, our
-// QT.UnmarshalJSON ends up unmarshaling the same JSON object into QT, QT.A,
-// and QT.B, which gives us the behavior we want.  But for
-// marshaling, we need to resolve the conflicts: if we simply marshaled QT,
+// field; we're happy to use the Go visibility rules when they apply but we
+// need to always marshal one field, even if there's not a clear best choice.
+// For unmarshaling, our QT.UnmarshalJSON ends up unmarshaling the same JSON
+// object into QT, QT.A, and QT.B, which gives us the behavior we want.  But
+// for marshaling, we need to resolve the conflicts: if we simply marshaled QT,
 // QT.A, and QT.B, we'd have to do some JSON-surgery to join them, and we'd
 // probably end up with duplicate fields, which leads to unpredictable behavior
 // based on the reader.  That's no good.

--- a/generate/unmarshal.go.tmpl
+++ b/generate/unmarshal.go.tmpl
@@ -1,5 +1,23 @@
-{{/* (the blank lines at the start are intentional, to separate
-     UnmarshalJSON from the function it follows) */}}
+{{/* We need to generate UnmarshalJSON methods for some types that we want to
+     handle specially.  Specifically, we generate an UnmarshalJSON for each
+     struct with a field meeting any of these criteria:
+        - a field whose type is configured with a custom unmarshaler
+        - an embedded (anonymous) field; technically we only need an
+          UnmarshalJSON if the embedded type needs one, but it's easier to
+          generate it unconditionally
+        - a field of interface type
+     Additionally, since we add `json:"-"` to fields we handle specially, for
+     any field which requires a MarshalJSON, we also generate an UnmarshalJSON,
+     and vice versa.
+
+     Given that, we want to specially handle the above-described fields, but
+     unmarshal everything else normally.  To handle fields with custom
+     unmarshalers, first we unmarshal them into a json.RawMessage, then call
+     the custom unmarshaler.  Interface-typed fields are similar, except
+     instead of a custom unmarshaler we call the helper we've generated
+     (see unmarshal_helper.go.tmpl).  Embedded fields don't need the
+     json.RawMessage; we just unmarshal our input again into the embedded
+     field. */}}
 
 func (v *{{.GoName}}) UnmarshalJSON(b []byte) error {
     {{/* Standard convention for unmarshalers is to no-op on null. */}}
@@ -7,16 +25,14 @@ func (v *{{.GoName}}) UnmarshalJSON(b []byte) error {
         return nil
     }
 
-    {{/* We want to specially handle certain fields, but unmarshal everything
-         else normally.  To handle abstract fields and fields with custom
-         unmarshalers, first we unmarshal them into a json.RawMessage, and then
-         handle those further, below.  Embedded fields don't need the
-         json.RawMessage; we just use our input again.  Either way, we first
-         want to call json.Unmarshal on the receiver (v).  But if we do that
-         naively on a value of type `.Type`, it will call this function again,
-         and recurse infinitely.  So we make a wrapper type which embeds both
-         this type and NoUmnarshalJSON, which prevents either's UnmarshalJSON
-         method from being promoted.  For more on why this is so difficult, see
+    {{/* For our first pass, we ignore embedded fields, unmarshal all the
+         custom-unmarshaler or abstract fields into json.RawMessage, and
+         unmarshal everything else normally.  To do this, we want to call
+         json.Unmarshal on the receiver (v).  But if we do that naively on a
+         value of type <.GoName>, it will call this function again, and recurse
+         infinitely.  So we make a wrapper type which embeds both this type and
+         NoUmnarshalJSON, which prevents either's UnmarshalJSON method from
+         being promoted.  For more on why this is so difficult, see
          https://github.com/benjaminjkraft/notes/blob/master/go-json-interfaces.md.
          (Note there are a few different ways "hide" the method, but this one
          seems to be the best option that works if this type has embedded types
@@ -28,7 +44,7 @@ func (v *{{.GoName}}) UnmarshalJSON(b []byte) error {
     var firstPass struct{
         *{{.GoName}}
         {{range .Fields -}}
-        {{if and .NeedsUnmarshaler (not .IsEmbedded) -}}
+        {{if and .NeedsMarshaling (not .IsEmbedded) -}}
         {{.GoName}} {{repeat .GoType.SliceDepth "[]"}}{{ref "encoding/json.RawMessage"}} `json:"{{.JSONName}}"`
         {{end -}}
         {{end -}}
@@ -45,11 +61,16 @@ func (v *{{.GoName}}) UnmarshalJSON(b []byte) error {
 
     {{/* Now, handle the fields needing special handling. */}}
     {{range $field := .Fields -}}
-    {{if $field.NeedsUnmarshaler -}}
+    {{if $field.NeedsMarshaling -}}
     {{if $field.IsEmbedded -}}
     {{/* Embedded fields are easier: we just unmarshal the same input into
          them.  (They're also easier because they can't be lists, since they
-         arise from GraphQL fragment spreads.) */ -}}
+         arise from GraphQL fragment spreads.)
+         
+         Note that our behavior if you have two fields of the same name via
+         different embeds differs from ordinary json-unmarshaling: we unmarshal
+         into *all* of the fields.  See goStructType.FlattenedFields in
+         types.go for more discussion of embedding and visibility. */ -}}
     err = {{$field.Unmarshaler $.Generator}}(
         b, &v.{{$field.GoType.Unwrap.Reference}})
     if err != nil {
@@ -125,8 +146,8 @@ func (v *{{.GoName}}) UnmarshalJSON(b []byte) error {
         }
         {{end -}}
     }
-    {{end -}}{{/* end if/else .IsEmbedded */ -}}
-    {{end -}}{{/* end if .NeedsUnmarshaler */ -}}
+    {{end}}{{/* end if/else .IsEmbedded */ -}}
+    {{end}}{{/* end if .NeedsMarshaling */ -}}
     {{end}}{{/* end range .Fields */ -}}
 
     return nil

--- a/generate/unmarshal_helper.go.tmpl
+++ b/generate/unmarshal_helper.go.tmpl
@@ -1,5 +1,8 @@
-{{/* (the blank lines at the start are intentional, to separate
-     the helper from the function it follows) */}}
+{{/* This template generates a helper for each interface type genqlient must
+     unmarshal.  This helper is called by the UnmarshalJSON of each (struct)
+     type with a field of the interface type, similar to how it calls custom
+     unmarshalers.  The helper itself is fairly simple: it just parses out and
+     switches on __typename, then unmarshals into the relevant struct. */}}
 
 func __unmarshal{{.GoName}}(b []byte, v *{{.GoName}}) error {
     if string(b) == "null" {

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -52,6 +52,43 @@ func (v *AnimalFields) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalAnimalFields struct {
+	Id string `json:"id"`
+
+	Hair AnimalFieldsHairBeingsHair `json:"hair"`
+
+	Owner json.RawMessage `json:"owner"`
+}
+
+func (v *AnimalFields) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AnimalFields) __premarshalJSON() (*__premarshalAnimalFields, error) {
+
+	var retval __premarshalAnimalFields
+
+	retval.Id = v.Id
+	retval.Hair = v.Hair
+	{
+
+		dst := &retval.Owner
+		src := v.Owner
+		var err error
+		*dst, err = __marshalAnimalFieldsOwnerBeing(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal AnimalFields.Owner: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
 // AnimalFieldsHairBeingsHair includes the requested fields of the GraphQL type BeingsHair.
 type AnimalFieldsHairBeingsHair struct {
 	HasHair bool `json:"hasHair"`
@@ -121,6 +158,38 @@ func __unmarshalAnimalFieldsOwnerBeing(b []byte, v *AnimalFieldsOwnerBeing) erro
 	}
 }
 
+func __marshalAnimalFieldsOwnerBeing(v *AnimalFieldsOwnerBeing) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AnimalFieldsOwnerUser:
+		typename = "User"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalAnimalFieldsOwnerUser
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *AnimalFieldsOwnerAnimal:
+		typename = "Animal"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AnimalFieldsOwnerAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for AnimalFieldsOwnerBeing: "%T"`, v)
+	}
+}
+
 // AnimalFieldsOwnerUser includes the requested fields of the GraphQL type User.
 type AnimalFieldsOwnerUser struct {
 	Typename        string `json:"__typename"`
@@ -157,6 +226,35 @@ func (v *AnimalFieldsOwnerUser) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalAnimalFieldsOwnerUser struct {
+	Typename string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	LuckyNumber int `json:"luckyNumber"`
+
+	Hair MoreUserFieldsHair `json:"hair"`
+}
+
+func (v *AnimalFieldsOwnerUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AnimalFieldsOwnerUser) __premarshalJSON() (*__premarshalAnimalFieldsOwnerUser, error) {
+
+	var retval __premarshalAnimalFieldsOwnerUser
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.LuckyNumber = v.LuckyFieldsUser.LuckyNumber
+	retval.Hair = v.UserFields.MoreUserFields.Hair
+	return &retval, nil
 }
 
 // LuckyFields includes the GraphQL fields of Lucky requested by the fragment LuckyFields.
@@ -200,6 +298,30 @@ func __unmarshalLuckyFields(b []byte, v *LuckyFields) error {
 	}
 }
 
+func __marshalLuckyFields(v *LuckyFields) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *LuckyFieldsUser:
+		typename = "User"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalLuckyFieldsUser
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for LuckyFields: "%T"`, v)
+	}
+}
+
 // LuckyFields includes the GraphQL fields of User requested by the fragment LuckyFields.
 type LuckyFieldsUser struct {
 	MoreUserFields `json:"-"`
@@ -229,6 +351,32 @@ func (v *LuckyFieldsUser) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalLuckyFieldsUser struct {
+	LuckyNumber int `json:"luckyNumber"`
+
+	Id string `json:"id"`
+
+	Hair MoreUserFieldsHair `json:"hair"`
+}
+
+func (v *LuckyFieldsUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *LuckyFieldsUser) __premarshalJSON() (*__premarshalLuckyFieldsUser, error) {
+
+	var retval __premarshalLuckyFieldsUser
+
+	retval.LuckyNumber = v.LuckyNumber
+	retval.Id = v.MoreUserFields.Id
+	retval.Hair = v.MoreUserFields.Hair
+	return &retval, nil
 }
 
 // MoreUserFields includes the GraphQL fields of User requested by the fragment MoreUserFields.
@@ -286,23 +434,89 @@ func (v *UserFields) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalUserFields struct {
+	Id string `json:"id"`
+
+	LuckyNumber int `json:"luckyNumber"`
+
+	Hair MoreUserFieldsHair `json:"hair"`
+}
+
+func (v *UserFields) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *UserFields) __premarshalJSON() (*__premarshalUserFields, error) {
+
+	var retval __premarshalUserFields
+
+	retval.Id = v.Id
+	retval.LuckyNumber = v.LuckyFieldsUser.LuckyNumber
+	retval.Hair = v.MoreUserFields.Hair
+	return &retval, nil
+}
+
 // __queryWithCustomMarshalInput is used internally by genqlient
 type __queryWithCustomMarshalInput struct {
 	Date time.Time `json:"-"`
 }
 
-func (v *__queryWithCustomMarshalInput) MarshalJSON() ([]byte, error) {
+func (v *__queryWithCustomMarshalInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*__queryWithCustomMarshalInput
 		Date json.RawMessage `json:"date"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.__queryWithCustomMarshalInput = v
+	firstPass.__queryWithCustomMarshalInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Date
+		src := firstPass.Date
+		if len(src) != 0 && string(src) != "null" {
+			err = testutil.UnmarshalDate(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal __queryWithCustomMarshalInput.Date: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshal__queryWithCustomMarshalInput struct {
+	Date json.RawMessage `json:"date"`
+}
+
+func (v *__queryWithCustomMarshalInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *__queryWithCustomMarshalInput) __premarshalJSON() (*__premarshal__queryWithCustomMarshalInput, error) {
+
+	var retval __premarshal__queryWithCustomMarshalInput
 
 	{
 
-		dst := &fullObject.Date
+		dst := &retval.Date
 		src := v.Date
 		var err error
 		*dst, err = testutil.MarshalDate(
@@ -312,8 +526,7 @@ func (v *__queryWithCustomMarshalInput) MarshalJSON() ([]byte, error) {
 				"Unable to marshal __queryWithCustomMarshalInput.Date: %w", err)
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __queryWithCustomMarshalOptionalInput is used internally by genqlient
@@ -322,18 +535,61 @@ type __queryWithCustomMarshalOptionalInput struct {
 	Id   *string    `json:"id"`
 }
 
-func (v *__queryWithCustomMarshalOptionalInput) MarshalJSON() ([]byte, error) {
+func (v *__queryWithCustomMarshalOptionalInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*__queryWithCustomMarshalOptionalInput
 		Date json.RawMessage `json:"date"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.__queryWithCustomMarshalOptionalInput = v
+	firstPass.__queryWithCustomMarshalOptionalInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Date
+		src := firstPass.Date
+		if len(src) != 0 && string(src) != "null" {
+			*dst = new(time.Time)
+			err = testutil.UnmarshalDate(
+				src, *dst)
+			if err != nil {
+				return fmt.Errorf(
+					"Unable to unmarshal __queryWithCustomMarshalOptionalInput.Date: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshal__queryWithCustomMarshalOptionalInput struct {
+	Date json.RawMessage `json:"date"`
+
+	Id *string `json:"id"`
+}
+
+func (v *__queryWithCustomMarshalOptionalInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *__queryWithCustomMarshalOptionalInput) __premarshalJSON() (*__premarshal__queryWithCustomMarshalOptionalInput, error) {
+
+	var retval __premarshal__queryWithCustomMarshalOptionalInput
 
 	{
 
-		dst := &fullObject.Date
+		dst := &retval.Date
 		src := v.Date
 		if src != nil {
 			var err error
@@ -345,8 +601,8 @@ func (v *__queryWithCustomMarshalOptionalInput) MarshalJSON() ([]byte, error) {
 			}
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	retval.Id = v.Id
+	return &retval, nil
 }
 
 // __queryWithCustomMarshalSliceInput is used internally by genqlient
@@ -354,18 +610,64 @@ type __queryWithCustomMarshalSliceInput struct {
 	Dates []time.Time `json:"-"`
 }
 
-func (v *__queryWithCustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
+func (v *__queryWithCustomMarshalSliceInput) UnmarshalJSON(b []byte) error {
 
-	var fullObject struct {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
 		*__queryWithCustomMarshalSliceInput
 		Dates []json.RawMessage `json:"dates"`
-		graphql.NoMarshalJSON
+		graphql.NoUnmarshalJSON
 	}
-	fullObject.__queryWithCustomMarshalSliceInput = v
+	firstPass.__queryWithCustomMarshalSliceInput = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Dates
+		src := firstPass.Dates
+		*dst = make(
+			[]time.Time,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = testutil.UnmarshalDate(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"Unable to unmarshal __queryWithCustomMarshalSliceInput.Dates: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshal__queryWithCustomMarshalSliceInput struct {
+	Dates []json.RawMessage `json:"dates"`
+}
+
+func (v *__queryWithCustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *__queryWithCustomMarshalSliceInput) __premarshalJSON() (*__premarshal__queryWithCustomMarshalSliceInput, error) {
+
+	var retval __premarshal__queryWithCustomMarshalSliceInput
 
 	{
 
-		dst := &fullObject.Dates
+		dst := &retval.Dates
 		src := v.Dates
 		*dst = make(
 			[]json.RawMessage,
@@ -381,8 +683,7 @@ func (v *__queryWithCustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
 			}
 		}
 	}
-
-	return json.Marshal(&fullObject)
+	return &retval, nil
 }
 
 // __queryWithFragmentsInput is used internally by genqlient
@@ -476,6 +777,43 @@ func (v *queryWithCustomMarshalOptionalUserSearchUser) UnmarshalJSON(b []byte) e
 	return nil
 }
 
+type __premarshalqueryWithCustomMarshalOptionalUserSearchUser struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *queryWithCustomMarshalOptionalUserSearchUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithCustomMarshalOptionalUserSearchUser) __premarshalJSON() (*__premarshalqueryWithCustomMarshalOptionalUserSearchUser, error) {
+
+	var retval __premarshalqueryWithCustomMarshalOptionalUserSearchUser
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Birthdate
+		src := v.Birthdate
+		var err error
+		*dst, err = testutil.MarshalDate(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal queryWithCustomMarshalOptionalUserSearchUser.Birthdate: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
 // queryWithCustomMarshalResponse is returned by queryWithCustomMarshal on success.
 type queryWithCustomMarshalResponse struct {
 	UsersBornOn []queryWithCustomMarshalUsersBornOnUser `json:"usersBornOn"`
@@ -526,6 +864,43 @@ func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) UnmarshalJSON(b []byte
 	return nil
 }
 
+type __premarshalqueryWithCustomMarshalSliceUsersBornOnDatesUser struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) __premarshalJSON() (*__premarshalqueryWithCustomMarshalSliceUsersBornOnDatesUser, error) {
+
+	var retval __premarshalqueryWithCustomMarshalSliceUsersBornOnDatesUser
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Birthdate
+		src := v.Birthdate
+		var err error
+		*dst, err = testutil.MarshalDate(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal queryWithCustomMarshalSliceUsersBornOnDatesUser.Birthdate: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
 // queryWithCustomMarshalUsersBornOnUser includes the requested fields of the GraphQL type User.
 type queryWithCustomMarshalUsersBornOnUser struct {
 	Id        string    `json:"id"`
@@ -564,6 +939,43 @@ func (v *queryWithCustomMarshalUsersBornOnUser) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalqueryWithCustomMarshalUsersBornOnUser struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Birthdate json.RawMessage `json:"birthdate"`
+}
+
+func (v *queryWithCustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithCustomMarshalUsersBornOnUser) __premarshalJSON() (*__premarshalqueryWithCustomMarshalUsersBornOnUser, error) {
+
+	var retval __premarshalqueryWithCustomMarshalUsersBornOnUser
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	{
+
+		dst := &retval.Birthdate
+		src := v.Birthdate
+		var err error
+		*dst, err = testutil.MarshalDate(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal queryWithCustomMarshalUsersBornOnUser.Birthdate: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 // queryWithFragmentsBeingsAnimal includes the requested fields of the GraphQL type Animal.
@@ -607,6 +1019,52 @@ func (v *queryWithFragmentsBeingsAnimal) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalqueryWithFragmentsBeingsAnimal struct {
+	Typename string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Hair queryWithFragmentsBeingsAnimalHairBeingsHair `json:"hair"`
+
+	Species Species `json:"species"`
+
+	Owner json.RawMessage `json:"owner"`
+}
+
+func (v *queryWithFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithFragmentsBeingsAnimal) __premarshalJSON() (*__premarshalqueryWithFragmentsBeingsAnimal, error) {
+
+	var retval __premarshalqueryWithFragmentsBeingsAnimal
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Name = v.Name
+	retval.Hair = v.Hair
+	retval.Species = v.Species
+	{
+
+		dst := &retval.Owner
+		src := v.Owner
+		var err error
+		*dst, err = __marshalqueryWithFragmentsBeingsAnimalOwnerBeing(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal queryWithFragmentsBeingsAnimal.Owner: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 // queryWithFragmentsBeingsAnimalHairBeingsHair includes the requested fields of the GraphQL type BeingsHair.
@@ -689,6 +1147,34 @@ func __unmarshalqueryWithFragmentsBeingsAnimalOwnerBeing(b []byte, v *queryWithF
 	}
 }
 
+func __marshalqueryWithFragmentsBeingsAnimalOwnerBeing(v *queryWithFragmentsBeingsAnimalOwnerBeing) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *queryWithFragmentsBeingsAnimalOwnerUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithFragmentsBeingsAnimalOwnerUser
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithFragmentsBeingsAnimalOwnerAnimal:
+		typename = "Animal"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithFragmentsBeingsAnimalOwnerAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for queryWithFragmentsBeingsAnimalOwnerBeing: "%T"`, v)
+	}
+}
+
 // queryWithFragmentsBeingsAnimalOwnerUser includes the requested fields of the GraphQL type User.
 type queryWithFragmentsBeingsAnimalOwnerUser struct {
 	Typename    string `json:"__typename"`
@@ -763,6 +1249,38 @@ func __unmarshalqueryWithFragmentsBeingsBeing(b []byte, v *queryWithFragmentsBei
 	}
 }
 
+func __marshalqueryWithFragmentsBeingsBeing(v *queryWithFragmentsBeingsBeing) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *queryWithFragmentsBeingsUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithFragmentsBeingsUser
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithFragmentsBeingsAnimal:
+		typename = "Animal"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalqueryWithFragmentsBeingsAnimal
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for queryWithFragmentsBeingsBeing: "%T"`, v)
+	}
+}
+
 // queryWithFragmentsBeingsUser includes the requested fields of the GraphQL type User.
 type queryWithFragmentsBeingsUser struct {
 	Typename    string                           `json:"__typename"`
@@ -819,6 +1337,43 @@ func (v *queryWithFragmentsResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalqueryWithFragmentsResponse struct {
+	Beings []json.RawMessage `json:"beings"`
+}
+
+func (v *queryWithFragmentsResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithFragmentsResponse) __premarshalJSON() (*__premarshalqueryWithFragmentsResponse, error) {
+
+	var retval __premarshalqueryWithFragmentsResponse
+
+	{
+
+		dst := &retval.Beings
+		src := v.Beings
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalqueryWithFragmentsBeingsBeing(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal queryWithFragmentsResponse.Beings: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // queryWithInterfaceListFieldBeingsAnimal includes the requested fields of the GraphQL type Animal.
@@ -896,6 +1451,34 @@ func __unmarshalqueryWithInterfaceListFieldBeingsBeing(b []byte, v *queryWithInt
 	}
 }
 
+func __marshalqueryWithInterfaceListFieldBeingsBeing(v *queryWithInterfaceListFieldBeingsBeing) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *queryWithInterfaceListFieldBeingsUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceListFieldBeingsUser
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithInterfaceListFieldBeingsAnimal:
+		typename = "Animal"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceListFieldBeingsAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for queryWithInterfaceListFieldBeingsBeing: "%T"`, v)
+	}
+}
+
 // queryWithInterfaceListFieldBeingsUser includes the requested fields of the GraphQL type User.
 type queryWithInterfaceListFieldBeingsUser struct {
 	Typename string `json:"__typename"`
@@ -945,6 +1528,43 @@ func (v *queryWithInterfaceListFieldResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalqueryWithInterfaceListFieldResponse struct {
+	Beings []json.RawMessage `json:"beings"`
+}
+
+func (v *queryWithInterfaceListFieldResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithInterfaceListFieldResponse) __premarshalJSON() (*__premarshalqueryWithInterfaceListFieldResponse, error) {
+
+	var retval __premarshalqueryWithInterfaceListFieldResponse
+
+	{
+
+		dst := &retval.Beings
+		src := v.Beings
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalqueryWithInterfaceListFieldBeingsBeing(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal queryWithInterfaceListFieldResponse.Beings: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // queryWithInterfaceListPointerFieldBeingsAnimal includes the requested fields of the GraphQL type Animal.
@@ -1022,6 +1642,34 @@ func __unmarshalqueryWithInterfaceListPointerFieldBeingsBeing(b []byte, v *query
 	}
 }
 
+func __marshalqueryWithInterfaceListPointerFieldBeingsBeing(v *queryWithInterfaceListPointerFieldBeingsBeing) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *queryWithInterfaceListPointerFieldBeingsUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceListPointerFieldBeingsUser
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithInterfaceListPointerFieldBeingsAnimal:
+		typename = "Animal"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceListPointerFieldBeingsAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for queryWithInterfaceListPointerFieldBeingsBeing: "%T"`, v)
+	}
+}
+
 // queryWithInterfaceListPointerFieldBeingsUser includes the requested fields of the GraphQL type User.
 type queryWithInterfaceListPointerFieldBeingsUser struct {
 	Typename string `json:"__typename"`
@@ -1072,6 +1720,45 @@ func (v *queryWithInterfaceListPointerFieldResponse) UnmarshalJSON(b []byte) err
 		}
 	}
 	return nil
+}
+
+type __premarshalqueryWithInterfaceListPointerFieldResponse struct {
+	Beings []json.RawMessage `json:"beings"`
+}
+
+func (v *queryWithInterfaceListPointerFieldResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithInterfaceListPointerFieldResponse) __premarshalJSON() (*__premarshalqueryWithInterfaceListPointerFieldResponse, error) {
+
+	var retval __premarshalqueryWithInterfaceListPointerFieldResponse
+
+	{
+
+		dst := &retval.Beings
+		src := v.Beings
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if src != nil {
+				var err error
+				*dst, err = __marshalqueryWithInterfaceListPointerFieldBeingsBeing(
+					src)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"Unable to marshal queryWithInterfaceListPointerFieldResponse.Beings: %w", err)
+				}
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // queryWithInterfaceNoFragmentsBeing includes the requested fields of the GraphQL interface Being.
@@ -1142,6 +1829,34 @@ func __unmarshalqueryWithInterfaceNoFragmentsBeing(b []byte, v *queryWithInterfa
 	}
 }
 
+func __marshalqueryWithInterfaceNoFragmentsBeing(v *queryWithInterfaceNoFragmentsBeing) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *queryWithInterfaceNoFragmentsBeingUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceNoFragmentsBeingUser
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithInterfaceNoFragmentsBeingAnimal:
+		typename = "Animal"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceNoFragmentsBeingAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for queryWithInterfaceNoFragmentsBeing: "%T"`, v)
+	}
+}
+
 // queryWithInterfaceNoFragmentsBeingAnimal includes the requested fields of the GraphQL type Animal.
 type queryWithInterfaceNoFragmentsBeingAnimal struct {
 	Typename string `json:"__typename"`
@@ -1201,6 +1916,40 @@ func (v *queryWithInterfaceNoFragmentsResponse) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type __premarshalqueryWithInterfaceNoFragmentsResponse struct {
+	Being json.RawMessage `json:"being"`
+
+	Me queryWithInterfaceNoFragmentsMeUser `json:"me"`
+}
+
+func (v *queryWithInterfaceNoFragmentsResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithInterfaceNoFragmentsResponse) __premarshalJSON() (*__premarshalqueryWithInterfaceNoFragmentsResponse, error) {
+
+	var retval __premarshalqueryWithInterfaceNoFragmentsResponse
+
+	{
+
+		dst := &retval.Being
+		src := v.Being
+		var err error
+		*dst, err = __marshalqueryWithInterfaceNoFragmentsBeing(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal queryWithInterfaceNoFragmentsResponse.Being: %w", err)
+		}
+	}
+	retval.Me = v.Me
+	return &retval, nil
+}
+
 // queryWithNamedFragmentsBeingsAnimal includes the requested fields of the GraphQL type Animal.
 type queryWithNamedFragmentsBeingsAnimal struct {
 	Typename     string `json:"__typename"`
@@ -1231,6 +1980,46 @@ func (v *queryWithNamedFragmentsBeingsAnimal) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalqueryWithNamedFragmentsBeingsAnimal struct {
+	Typename string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Hair AnimalFieldsHairBeingsHair `json:"hair"`
+
+	Owner json.RawMessage `json:"owner"`
+}
+
+func (v *queryWithNamedFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithNamedFragmentsBeingsAnimal) __premarshalJSON() (*__premarshalqueryWithNamedFragmentsBeingsAnimal, error) {
+
+	var retval __premarshalqueryWithNamedFragmentsBeingsAnimal
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Hair = v.AnimalFields.Hair
+	{
+
+		dst := &retval.Owner
+		src := v.AnimalFields.Owner
+		var err error
+		*dst, err = __marshalAnimalFieldsOwnerBeing(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Unable to marshal queryWithNamedFragmentsBeingsAnimal.AnimalFields.Owner: %w", err)
+		}
+	}
+	return &retval, nil
 }
 
 // queryWithNamedFragmentsBeingsBeing includes the requested fields of the GraphQL interface Being.
@@ -1293,6 +2082,42 @@ func __unmarshalqueryWithNamedFragmentsBeingsBeing(b []byte, v *queryWithNamedFr
 	}
 }
 
+func __marshalqueryWithNamedFragmentsBeingsBeing(v *queryWithNamedFragmentsBeingsBeing) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *queryWithNamedFragmentsBeingsUser:
+		typename = "User"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalqueryWithNamedFragmentsBeingsUser
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *queryWithNamedFragmentsBeingsAnimal:
+		typename = "Animal"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalqueryWithNamedFragmentsBeingsAnimal
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`Unexpected concrete type for queryWithNamedFragmentsBeingsBeing: "%T"`, v)
+	}
+}
+
 // queryWithNamedFragmentsBeingsUser includes the requested fields of the GraphQL type User.
 type queryWithNamedFragmentsBeingsUser struct {
 	Typename   string `json:"__typename"`
@@ -1323,6 +2148,35 @@ func (v *queryWithNamedFragmentsBeingsUser) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	return nil
+}
+
+type __premarshalqueryWithNamedFragmentsBeingsUser struct {
+	Typename string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	LuckyNumber int `json:"luckyNumber"`
+
+	Hair MoreUserFieldsHair `json:"hair"`
+}
+
+func (v *queryWithNamedFragmentsBeingsUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithNamedFragmentsBeingsUser) __premarshalJSON() (*__premarshalqueryWithNamedFragmentsBeingsUser, error) {
+
+	var retval __premarshalqueryWithNamedFragmentsBeingsUser
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.LuckyNumber = v.UserFields.LuckyFieldsUser.LuckyNumber
+	retval.Hair = v.UserFields.MoreUserFields.Hair
+	return &retval, nil
 }
 
 // queryWithNamedFragmentsResponse is returned by queryWithNamedFragments on success.
@@ -1367,6 +2221,43 @@ func (v *queryWithNamedFragmentsResponse) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
+}
+
+type __premarshalqueryWithNamedFragmentsResponse struct {
+	Beings []json.RawMessage `json:"beings"`
+}
+
+func (v *queryWithNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *queryWithNamedFragmentsResponse) __premarshalJSON() (*__premarshalqueryWithNamedFragmentsResponse, error) {
+
+	var retval __premarshalqueryWithNamedFragmentsResponse
+
+	{
+
+		dst := &retval.Beings
+		src := v.Beings
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalqueryWithNamedFragmentsBeingsBeing(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Unable to marshal queryWithNamedFragmentsResponse.Beings: %w", err)
+			}
+		}
+	}
+	return &retval, nil
 }
 
 // queryWithOmitemptyResponse is returned by queryWithOmitempty on success.

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -69,7 +69,6 @@ func (v *AnimalFields) MarshalJSON() ([]byte, error) {
 }
 
 func (v *AnimalFields) __premarshalJSON() (*__premarshalAnimalFields, error) {
-
 	var retval __premarshalAnimalFields
 
 	retval.Id = v.Id
@@ -247,7 +246,6 @@ func (v *AnimalFieldsOwnerUser) MarshalJSON() ([]byte, error) {
 }
 
 func (v *AnimalFieldsOwnerUser) __premarshalJSON() (*__premarshalAnimalFieldsOwnerUser, error) {
-
 	var retval __premarshalAnimalFieldsOwnerUser
 
 	retval.Typename = v.Typename
@@ -370,7 +368,6 @@ func (v *LuckyFieldsUser) MarshalJSON() ([]byte, error) {
 }
 
 func (v *LuckyFieldsUser) __premarshalJSON() (*__premarshalLuckyFieldsUser, error) {
-
 	var retval __premarshalLuckyFieldsUser
 
 	retval.LuckyNumber = v.LuckyNumber
@@ -451,7 +448,6 @@ func (v *UserFields) MarshalJSON() ([]byte, error) {
 }
 
 func (v *UserFields) __premarshalJSON() (*__premarshalUserFields, error) {
-
 	var retval __premarshalUserFields
 
 	retval.Id = v.Id
@@ -511,7 +507,6 @@ func (v *__queryWithCustomMarshalInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *__queryWithCustomMarshalInput) __premarshalJSON() (*__premarshal__queryWithCustomMarshalInput, error) {
-
 	var retval __premarshal__queryWithCustomMarshalInput
 
 	{
@@ -584,7 +579,6 @@ func (v *__queryWithCustomMarshalOptionalInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *__queryWithCustomMarshalOptionalInput) __premarshalJSON() (*__premarshal__queryWithCustomMarshalOptionalInput, error) {
-
 	var retval __premarshal__queryWithCustomMarshalOptionalInput
 
 	{
@@ -662,7 +656,6 @@ func (v *__queryWithCustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
 }
 
 func (v *__queryWithCustomMarshalSliceInput) __premarshalJSON() (*__premarshal__queryWithCustomMarshalSliceInput, error) {
-
 	var retval __premarshal__queryWithCustomMarshalSliceInput
 
 	{
@@ -794,7 +787,6 @@ func (v *queryWithCustomMarshalOptionalUserSearchUser) MarshalJSON() ([]byte, er
 }
 
 func (v *queryWithCustomMarshalOptionalUserSearchUser) __premarshalJSON() (*__premarshalqueryWithCustomMarshalOptionalUserSearchUser, error) {
-
 	var retval __premarshalqueryWithCustomMarshalOptionalUserSearchUser
 
 	retval.Id = v.Id
@@ -881,7 +873,6 @@ func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) MarshalJSON() ([]byte,
 }
 
 func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) __premarshalJSON() (*__premarshalqueryWithCustomMarshalSliceUsersBornOnDatesUser, error) {
-
 	var retval __premarshalqueryWithCustomMarshalSliceUsersBornOnDatesUser
 
 	retval.Id = v.Id
@@ -958,7 +949,6 @@ func (v *queryWithCustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithCustomMarshalUsersBornOnUser) __premarshalJSON() (*__premarshalqueryWithCustomMarshalUsersBornOnUser, error) {
-
 	var retval __premarshalqueryWithCustomMarshalUsersBornOnUser
 
 	retval.Id = v.Id
@@ -1044,7 +1034,6 @@ func (v *queryWithFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithFragmentsBeingsAnimal) __premarshalJSON() (*__premarshalqueryWithFragmentsBeingsAnimal, error) {
-
 	var retval __premarshalqueryWithFragmentsBeingsAnimal
 
 	retval.Typename = v.Typename
@@ -1352,7 +1341,6 @@ func (v *queryWithFragmentsResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithFragmentsResponse) __premarshalJSON() (*__premarshalqueryWithFragmentsResponse, error) {
-
 	var retval __premarshalqueryWithFragmentsResponse
 
 	{
@@ -1543,7 +1531,6 @@ func (v *queryWithInterfaceListFieldResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithInterfaceListFieldResponse) __premarshalJSON() (*__premarshalqueryWithInterfaceListFieldResponse, error) {
-
 	var retval __premarshalqueryWithInterfaceListFieldResponse
 
 	{
@@ -1735,7 +1722,6 @@ func (v *queryWithInterfaceListPointerFieldResponse) MarshalJSON() ([]byte, erro
 }
 
 func (v *queryWithInterfaceListPointerFieldResponse) __premarshalJSON() (*__premarshalqueryWithInterfaceListPointerFieldResponse, error) {
-
 	var retval __premarshalqueryWithInterfaceListPointerFieldResponse
 
 	{
@@ -1931,7 +1917,6 @@ func (v *queryWithInterfaceNoFragmentsResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithInterfaceNoFragmentsResponse) __premarshalJSON() (*__premarshalqueryWithInterfaceNoFragmentsResponse, error) {
-
 	var retval __premarshalqueryWithInterfaceNoFragmentsResponse
 
 	{
@@ -2001,7 +1986,6 @@ func (v *queryWithNamedFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithNamedFragmentsBeingsAnimal) __premarshalJSON() (*__premarshalqueryWithNamedFragmentsBeingsAnimal, error) {
-
 	var retval __premarshalqueryWithNamedFragmentsBeingsAnimal
 
 	retval.Typename = v.Typename
@@ -2169,7 +2153,6 @@ func (v *queryWithNamedFragmentsBeingsUser) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithNamedFragmentsBeingsUser) __premarshalJSON() (*__premarshalqueryWithNamedFragmentsBeingsUser, error) {
-
 	var retval __premarshalqueryWithNamedFragmentsBeingsUser
 
 	retval.Typename = v.Typename
@@ -2236,7 +2219,6 @@ func (v *queryWithNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (v *queryWithNamedFragmentsResponse) __premarshalJSON() (*__premarshalqueryWithNamedFragmentsResponse, error) {
-
 	var retval __premarshalqueryWithNamedFragmentsResponse
 
 	{

--- a/internal/integration/roundtrip.go
+++ b/internal/integration/roundtrip.go
@@ -1,0 +1,111 @@
+package integration
+
+// Machinery for integration tests to round-trip check the JSON-marshalers and
+// unmarshalers we generate.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/stretchr/testify/assert"
+)
+
+// lastResponseTransport is an HTTP transport that keeps track of the last response
+// that passed through it.
+type lastResponseTransport struct {
+	wrapped          http.RoundTripper
+	lastResponseBody []byte
+}
+
+func (t *lastResponseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return resp, fmt.Errorf("roundtrip failed: unreadable body: %w", err)
+	}
+	t.lastResponseBody = body
+	// Restore the body for the next reader:
+	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	return resp, err
+}
+
+// roundtripClient is a graphql.Client that checks that
+//	unmarshal(marshal(req)) == req && marshal(unmarshal(resp)) == resp
+// for each request it processes.
+type roundtripClient struct {
+	wrapped   graphql.Client
+	transport *lastResponseTransport
+	t         *testing.T
+}
+
+// Put JSON in a stable and human-readable format.
+func (c *roundtripClient) formatJSON(b []byte) []byte {
+	// We don't care about key ordering, so do another roundtrip through
+	// interface{} to drop that.
+	var parsed interface{}
+	err := json.Unmarshal(b, &parsed)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+
+	// When marshaling, add indents to make things human-readable.
+	b, err = json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	return b
+}
+
+func (c *roundtripClient) roundtripResponse(resp interface{}) {
+	var graphqlResponse struct {
+		Data json.RawMessage `json:"data"`
+	}
+	err := json.Unmarshal(c.transport.lastResponseBody, &graphqlResponse)
+	if err != nil {
+		c.t.Error(err)
+		return
+	}
+	body := c.formatJSON(graphqlResponse.Data)
+
+	// resp is constructed to be unmarshal(body), so just use it
+	bodyAgain, err := json.Marshal(resp)
+	if err != nil {
+		c.t.Error(err)
+		return
+	}
+	bodyAgain = c.formatJSON(bodyAgain)
+
+	assert.Equal(c.t, string(body), string(bodyAgain))
+}
+
+func (c *roundtripClient) MakeRequest(ctx context.Context, opName, query string, retval, variables interface{}) error {
+	// TODO(benkraft): Also check the variables round-trip.  This is a bit less
+	// important since most of the code is the same (and input types are
+	// strictly simpler), and a bit hard to do because when asserting about
+	// structs we need to worry about things like equality of time.Time values.
+	err := c.wrapped.MakeRequest(ctx, opName, query, retval, variables)
+	if err != nil {
+		return err
+	}
+	c.roundtripResponse(retval)
+	return nil
+}
+
+func newRoundtripClient(t *testing.T, endpoint string) graphql.Client {
+	transport := &lastResponseTransport{wrapped: http.DefaultTransport}
+	return &roundtripClient{
+		wrapped:   graphql.NewClient(endpoint, &http.Client{Transport: transport}),
+		transport: transport,
+		t:         t,
+	}
+}

--- a/internal/testutil/types.go
+++ b/internal/testutil/types.go
@@ -31,6 +31,9 @@ func GetClientFromMyContext(ctx MyContext) (graphql.Client, error)     { return 
 const dateFormat = "2006-01-02"
 
 func MarshalDate(t *time.Time) ([]byte, error) {
+	if t == nil || t.IsZero() {
+		return []byte("null"), nil
+	}
 	return []byte(`"` + t.Format(dateFormat) + `"`), nil
 }
 

--- a/internal/testutil/types.go
+++ b/internal/testutil/types.go
@@ -31,6 +31,12 @@ func GetClientFromMyContext(ctx MyContext) (graphql.Client, error)     { return 
 const dateFormat = "2006-01-02"
 
 func MarshalDate(t *time.Time) ([]byte, error) {
+	// nil should never happen but we might as well check.  zero-time does
+	// happen because omitempty doesn't consider it zero; we'd prefer to write
+	// null than "0001-01-01".
+	//
+	// (I mean, we're tests.  Who cares!  But we may as well try to match what
+	// prod code would want.)
 	if t == nil || t.IsZero() {
 		return []byte("null"), nil
 	}


### PR DESCRIPTION
## Summary:
When genqlient generates output types, it generates whatever code is
necessary to unmarshal them.  Conversely, when it generates input types,
it generates whatever code is necessary to marshal.  This is all that's
needed for genqlient itself: it never needs to marshal output types or
unmarshal input types.

But maybe you do!  (For example, to put the responses in a cache, which
is the use case that @csilvers hit at Khan, although there are others
one can imagine.)  While we can't support every serialization format you
might want (at least not without adding plugins or some such), it's not
unreasonable to expect that since genqlient can read JSON, it can write
it too.  Sadly, in the past this was not true for types requiring custom
unmarshaling logic, for several reasons.

In this commit I implement logic to always write both marshalers and
unmarshalers whenever they're needed to be able to correctly round-trip
the types, even though genqlient doesn't do so.  I wasn't starting from
scratch, since of course we already write both marshalers and
unmarshalers in some cases.  But this ended up requiring surprisingly
large changes on the marshaling side, mostly to correctly support
embedding (which we use for named fragments).

Specifically, as the comments in `types.go` discuss, the most difficult
issue is spreads with duplicate fields, which translate to Go embedded
fields which end up hidden from the json-marshaler.  Ultimately, I had
to do things quite differently from unmarshaling, and essentially
flatten the type when we write marshaler.  But in the end it's not so
ugly -- indeed arguably it's cleaner!  Mainly it's just different.

One thing to note is that we do marshal `__typename` based on
what we know about the types; users need not fill it in (and if they
do we'll ignore it).  This seemed to me to be a better UX, and
didn't add much complexity.

In general, I begin to wonder whether using `encoding/json` at all is
really right for genqlient: we're doing a lot of work to appease it,
despite knowing what our types look like.  I think it would still be a
significant increase in lines of code to roll our own, but that code
would perhaps be simpler, and would surely be faster (although if we
just want the speed gains we could use another JSON-generator library,
see also #47).  Anyway, something to think about in the future.

## Test plan:
make tesc
