### PR TITLE
Add getter methods to all fields, not just where needed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,11 @@ When releasing a new version:
 
 ### New features:
 
+- genqlient now generates getter methods for all fields, even those which do not implement a genqlient-generated interface; this can be useful for callers who wish to define their own interface and have several unrelated genqlient types which have the same fields implement it.
+
 ### Bug fixes:
+
+- In certain very rare cases involving duplicate fields in fragment spreads, genqlient would generate code that failed to compile due to duplicate methods not getting promoted; genqlient now generates correct types.  (See #126 for a more complete description.)
 
 ## v0.3.0
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -366,7 +366,21 @@ query GetMonopolyPlayers {
 ```
 and genqlient will skip the indirection and give the field `Winner` type `MonopolyUser` directly.  This is often much more convenient if you put all the fields in the fragment, like the first query did.  See the [options documentation](genqlient_directive.graphql) for more details.
 
-**Type names:** Finally, if you always want exactly the same fields, you can use the simpler but more restrictive genqlient option `typename`:
+**Interfaces:** For each struct field it generates, genqlient also generates an interface method.  If you want to share code between two types which to GraphQL are unrelated, you can define an interface containing that getter method, and genqlient's struct types will implement it.  (Depending on your exact query, you may need to do a type-assertion from a genqlient-generated interface to yours.)  For example, in the above query you could simply do:
+```go
+type MonopolyUser interface {
+    GetId() string
+    GetName() string
+}
+
+func FormatUser(user MonopolyUser) { ... }
+
+FormatUser(resp.Game.Winner)
+```
+
+In general in such cases it's better to change the GraphQL schema to show how the types are related, and use one of the other mechanisms, but this option is useful for schemas where you can't do that, or in the meantime.
+
+**Type names:** Finally, if you always want exactly the same fields on exactly the same types, and don't want to deal with interfaces at all, you can use the simpler but more restrictive genqlient option `typename`:
 
 ```graphql
 query GetMonopolyPlayers {

--- a/example/generated.go
+++ b/example/generated.go
@@ -14,11 +14,17 @@ type __getUserInput struct {
 	Login string `json:"Login"`
 }
 
+// GetLogin returns __getUserInput.Login, and is useful for accessing the field via an interface.
+func (v *__getUserInput) GetLogin() string { return v.Login }
+
 // getUserResponse is returned by getUser on success.
 type getUserResponse struct {
 	// Lookup a user by login.
 	User getUserUser `json:"user"`
 }
+
+// GetUser returns getUserResponse.User, and is useful for accessing the field via an interface.
+func (v *getUserResponse) GetUser() getUserUser { return v.User }
 
 // getUserUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -31,11 +37,20 @@ type getUserUser struct {
 	CreatedAt time.Time `json:"createdAt"`
 }
 
+// GetTheirName returns getUserUser.TheirName, and is useful for accessing the field via an interface.
+func (v *getUserUser) GetTheirName() string { return v.TheirName }
+
+// GetCreatedAt returns getUserUser.CreatedAt, and is useful for accessing the field via an interface.
+func (v *getUserUser) GetCreatedAt() time.Time { return v.CreatedAt }
+
 // getViewerResponse is returned by getViewer on success.
 type getViewerResponse struct {
 	// The currently authenticated user.
 	Viewer getViewerViewerUser `json:"viewer"`
 }
+
+// GetViewer returns getViewerResponse.Viewer, and is useful for accessing the field via an interface.
+func (v *getViewerResponse) GetViewer() getViewerViewerUser { return v.Viewer }
 
 // getViewerViewerUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -47,6 +62,12 @@ type getViewerViewerUser struct {
 	// Identifies the date and time when the object was created.
 	CreatedAt time.Time `json:"createdAt"`
 }
+
+// GetMyName returns getViewerViewerUser.MyName, and is useful for accessing the field via an interface.
+func (v *getViewerViewerUser) GetMyName() string { return v.MyName }
+
+// GetCreatedAt returns getViewerViewerUser.CreatedAt, and is useful for accessing the field via an interface.
+func (v *getViewerViewerUser) GetCreatedAt() time.Time { return v.CreatedAt }
 
 func getViewer(
 	ctx context.Context,

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -16,10 +16,28 @@ type ComplexInlineFragmentsConflictingStuffArticle struct {
 	Thumbnail ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail `json:"thumbnail"`
 }
 
+// GetTypename returns ComplexInlineFragmentsConflictingStuffArticle.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffArticle) GetTypename() string { return v.Typename }
+
+// GetThumbnail returns ComplexInlineFragmentsConflictingStuffArticle.Thumbnail, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffArticle) GetThumbnail() ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail {
+	return v.Thumbnail
+}
+
 // ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail includes the requested fields of the GraphQL type StuffThumbnail.
 type ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail struct {
 	Id           testutil.ID `json:"id"`
 	ThumbnailUrl string      `json:"thumbnailUrl"`
+}
+
+// GetId returns ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetThumbnailUrl returns ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail.ThumbnailUrl, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) GetThumbnailUrl() string {
+	return v.ThumbnailUrl
 }
 
 // ComplexInlineFragmentsConflictingStuffContent includes the requested fields of the GraphQL interface Content.
@@ -39,21 +57,10 @@ type ComplexInlineFragmentsConflictingStuffContent interface {
 
 func (v *ComplexInlineFragmentsConflictingStuffArticle) implementsGraphQLInterfaceComplexInlineFragmentsConflictingStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsConflictingStuffContent.
-func (v *ComplexInlineFragmentsConflictingStuffArticle) GetTypename() string { return v.Typename }
-
 func (v *ComplexInlineFragmentsConflictingStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsConflictingStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsConflictingStuffContent.
-func (v *ComplexInlineFragmentsConflictingStuffVideo) GetTypename() string { return v.Typename }
-
 func (v *ComplexInlineFragmentsConflictingStuffTopic) implementsGraphQLInterfaceComplexInlineFragmentsConflictingStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsConflictingStuffContent.
-func (v *ComplexInlineFragmentsConflictingStuffTopic) GetTypename() string { return v.Typename }
 
 func __unmarshalComplexInlineFragmentsConflictingStuffContent(b []byte, v *ComplexInlineFragmentsConflictingStuffContent) error {
 	if string(b) == "null" {
@@ -128,10 +135,21 @@ type ComplexInlineFragmentsConflictingStuffTopic struct {
 	Typename string `json:"__typename"`
 }
 
+// GetTypename returns ComplexInlineFragmentsConflictingStuffTopic.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffTopic) GetTypename() string { return v.Typename }
+
 // ComplexInlineFragmentsConflictingStuffVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsConflictingStuffVideo struct {
 	Typename  string                                               `json:"__typename"`
 	Thumbnail ComplexInlineFragmentsConflictingStuffVideoThumbnail `json:"thumbnail"`
+}
+
+// GetTypename returns ComplexInlineFragmentsConflictingStuffVideo.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffVideo) GetTypename() string { return v.Typename }
+
+// GetThumbnail returns ComplexInlineFragmentsConflictingStuffVideo.Thumbnail, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffVideo) GetThumbnail() ComplexInlineFragmentsConflictingStuffVideoThumbnail {
+	return v.Thumbnail
 }
 
 // ComplexInlineFragmentsConflictingStuffVideoThumbnail includes the requested fields of the GraphQL type Thumbnail.
@@ -140,10 +158,21 @@ type ComplexInlineFragmentsConflictingStuffVideoThumbnail struct {
 	TimestampSec int         `json:"timestampSec"`
 }
 
+// GetId returns ComplexInlineFragmentsConflictingStuffVideoThumbnail.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffVideoThumbnail) GetId() testutil.ID { return v.Id }
+
+// GetTimestampSec returns ComplexInlineFragmentsConflictingStuffVideoThumbnail.TimestampSec, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsConflictingStuffVideoThumbnail) GetTimestampSec() int {
+	return v.TimestampSec
+}
+
 // ComplexInlineFragmentsNestedStuffArticle includes the requested fields of the GraphQL type Article.
 type ComplexInlineFragmentsNestedStuffArticle struct {
 	Typename string `json:"__typename"`
 }
+
+// GetTypename returns ComplexInlineFragmentsNestedStuffArticle.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffArticle) GetTypename() string { return v.Typename }
 
 // ComplexInlineFragmentsNestedStuffContent includes the requested fields of the GraphQL interface Content.
 //
@@ -162,21 +191,10 @@ type ComplexInlineFragmentsNestedStuffContent interface {
 
 func (v *ComplexInlineFragmentsNestedStuffArticle) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffContent.
-func (v *ComplexInlineFragmentsNestedStuffArticle) GetTypename() string { return v.Typename }
-
 func (v *ComplexInlineFragmentsNestedStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffContent.
-func (v *ComplexInlineFragmentsNestedStuffVideo) GetTypename() string { return v.Typename }
-
 func (v *ComplexInlineFragmentsNestedStuffTopic) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffContent.
-func (v *ComplexInlineFragmentsNestedStuffTopic) GetTypename() string { return v.Typename }
 
 func __unmarshalComplexInlineFragmentsNestedStuffContent(b []byte, v *ComplexInlineFragmentsNestedStuffContent) error {
 	if string(b) == "null" {
@@ -254,6 +272,14 @@ func __marshalComplexInlineFragmentsNestedStuffContent(v *ComplexInlineFragments
 type ComplexInlineFragmentsNestedStuffTopic struct {
 	Typename string                                                  `json:"__typename"`
 	Children []ComplexInlineFragmentsNestedStuffTopicChildrenContent `json:"-"`
+}
+
+// GetTypename returns ComplexInlineFragmentsNestedStuffTopic.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopic) GetTypename() string { return v.Typename }
+
+// GetChildren returns ComplexInlineFragmentsNestedStuffTopic.Children, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopic) GetChildren() []ComplexInlineFragmentsNestedStuffTopicChildrenContent {
+	return v.Children
 }
 
 func (v *ComplexInlineFragmentsNestedStuffTopic) UnmarshalJSON(b []byte) error {
@@ -343,9 +369,30 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticle struct {
 	Parent ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic `json:"parent"`
 }
 
+// GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+
+// GetText returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Text, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetText() string { return v.Text }
+
+// GetParent returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Parent, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetParent() ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic {
+	return v.Parent
+}
+
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic includes the requested fields of the GraphQL type Topic.
 type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic struct {
 	Children []ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent `json:"-"`
+}
+
+// GetChildren returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic.Children, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) GetChildren() []ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent {
+	return v.Children
 }
 
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) UnmarshalJSON(b []byte) error {
@@ -431,6 +478,21 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 	Name string      `json:"name"`
 }
 
+// GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetName() string {
+	return v.Name
+}
+
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent is implemented by the following types:
@@ -455,56 +517,9 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetId() testutil.ID {
-	return v.Id
-}
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetName() string {
-	return v.Name
-}
-
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetId() testutil.ID {
-	return v.Id
-}
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetName() string {
-	return v.Name
-}
-
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent() {
-}
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetId() testutil.ID {
-	return v.Id
-}
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetName() string {
-	return v.Name
 }
 
 func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent(b []byte, v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent) error {
@@ -583,6 +598,21 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 	Name string      `json:"name"`
 }
 
+// GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetName() string {
+	return v.Name
+}
+
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo struct {
 	Typename string `json:"__typename"`
@@ -591,10 +621,35 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 	Name string      `json:"name"`
 }
 
+// GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetName() string {
+	return v.Name
+}
+
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic includes the requested fields of the GraphQL type Topic.
 type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic struct {
 	Name   string                                                                        `json:"name"`
 	Parent ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic `json:"parent"`
+}
+
+// GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) GetName() string {
+	return v.Name
+}
+
+// GetParent returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic.Parent, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) GetParent() ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic {
+	return v.Parent
 }
 
 // ComplexInlineFragmentsNestedStuffTopicChildrenContent includes the requested fields of the GraphQL interface Content.
@@ -619,32 +674,10 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenContent interface {
 
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetId() testutil.ID { return v.Id }
-
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetId() testutil.ID { return v.Id }
-
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsNestedStuffTopicChildrenContent.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetId() testutil.ID { return v.Id }
 
 func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenContent(b []byte, v *ComplexInlineFragmentsNestedStuffTopicChildrenContent) error {
 	if string(b) == "null" {
@@ -721,6 +754,12 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenTopic struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+
 // ComplexInlineFragmentsNestedStuffTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsNestedStuffTopicChildrenVideo struct {
 	Typename string `json:"__typename"`
@@ -728,10 +767,19 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenVideo struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+
 // ComplexInlineFragmentsNestedStuffVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsNestedStuffVideo struct {
 	Typename string `json:"__typename"`
 }
+
+// GetTypename returns ComplexInlineFragmentsNestedStuffVideo.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsNestedStuffVideo) GetTypename() string { return v.Typename }
 
 // ComplexInlineFragmentsRandomItemArticle includes the requested fields of the GraphQL type Article.
 type ComplexInlineFragmentsRandomItemArticle struct {
@@ -741,6 +789,18 @@ type ComplexInlineFragmentsRandomItemArticle struct {
 	Text string      `json:"text"`
 	Name string      `json:"name"`
 }
+
+// GetTypename returns ComplexInlineFragmentsRandomItemArticle.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemArticle) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsRandomItemArticle.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemArticle) GetId() testutil.ID { return v.Id }
+
+// GetText returns ComplexInlineFragmentsRandomItemArticle.Text, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemArticle) GetText() string { return v.Text }
+
+// GetName returns ComplexInlineFragmentsRandomItemArticle.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemArticle) GetName() string { return v.Name }
 
 // ComplexInlineFragmentsRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
@@ -766,39 +826,10 @@ type ComplexInlineFragmentsRandomItemContent interface {
 
 func (v *ComplexInlineFragmentsRandomItemArticle) implementsGraphQLInterfaceComplexInlineFragmentsRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemArticle) GetName() string { return v.Name }
-
 func (v *ComplexInlineFragmentsRandomItemVideo) implementsGraphQLInterfaceComplexInlineFragmentsRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemVideo) GetName() string { return v.Name }
-
 func (v *ComplexInlineFragmentsRandomItemTopic) implementsGraphQLInterfaceComplexInlineFragmentsRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsRandomItemContent.
-func (v *ComplexInlineFragmentsRandomItemTopic) GetName() string { return v.Name }
 
 func __unmarshalComplexInlineFragmentsRandomItemContent(b []byte, v *ComplexInlineFragmentsRandomItemContent) error {
 	if string(b) == "null" {
@@ -876,6 +907,15 @@ type ComplexInlineFragmentsRandomItemTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns ComplexInlineFragmentsRandomItemTopic.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemTopic) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsRandomItemTopic.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns ComplexInlineFragmentsRandomItemTopic.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemTopic) GetName() string { return v.Name }
+
 // ComplexInlineFragmentsRandomItemVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsRandomItemVideo struct {
 	Typename string `json:"__typename"`
@@ -884,6 +924,18 @@ type ComplexInlineFragmentsRandomItemVideo struct {
 	Name     string      `json:"name"`
 	Duration int         `json:"duration"`
 }
+
+// GetTypename returns ComplexInlineFragmentsRandomItemVideo.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemVideo) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsRandomItemVideo.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns ComplexInlineFragmentsRandomItemVideo.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemVideo) GetName() string { return v.Name }
+
+// GetDuration returns ComplexInlineFragmentsRandomItemVideo.Duration, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRandomItemVideo) GetDuration() int { return v.Duration }
 
 // ComplexInlineFragmentsRepeatedStuffArticle includes the requested fields of the GraphQL type Article.
 type ComplexInlineFragmentsRepeatedStuffArticle struct {
@@ -897,6 +949,27 @@ type ComplexInlineFragmentsRepeatedStuffArticle struct {
 	Text      string      `json:"text"`
 	OtherName string      `json:"otherName"`
 }
+
+// GetTypename returns ComplexInlineFragmentsRepeatedStuffArticle.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsRepeatedStuffArticle.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetId() testutil.ID { return v.Id }
+
+// GetUrl returns ComplexInlineFragmentsRepeatedStuffArticle.Url, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetUrl() string { return v.Url }
+
+// GetOtherId returns ComplexInlineFragmentsRepeatedStuffArticle.OtherId, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherId() testutil.ID { return v.OtherId }
+
+// GetName returns ComplexInlineFragmentsRepeatedStuffArticle.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetName() string { return v.Name }
+
+// GetText returns ComplexInlineFragmentsRepeatedStuffArticle.Text, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetText() string { return v.Text }
+
+// GetOtherName returns ComplexInlineFragmentsRepeatedStuffArticle.OtherName, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherName() string { return v.OtherName }
 
 // ComplexInlineFragmentsRepeatedStuffContent includes the requested fields of the GraphQL interface Content.
 //
@@ -931,66 +1004,10 @@ type ComplexInlineFragmentsRepeatedStuffContent interface {
 
 func (v *ComplexInlineFragmentsRepeatedStuffArticle) implementsGraphQLInterfaceComplexInlineFragmentsRepeatedStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetId() testutil.ID { return v.Id }
-
-// GetUrl is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetUrl() string { return v.Url }
-
-// GetOtherId is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherId() testutil.ID { return v.OtherId }
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetName() string { return v.Name }
-
-// GetOtherName is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherName() string { return v.OtherName }
-
 func (v *ComplexInlineFragmentsRepeatedStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsRepeatedStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetId() testutil.ID { return v.Id }
-
-// GetUrl is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetUrl() string { return v.Url }
-
-// GetOtherId is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherId() testutil.ID { return v.OtherId }
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetName() string { return v.Name }
-
-// GetOtherName is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherName() string { return v.OtherName }
-
 func (v *ComplexInlineFragmentsRepeatedStuffTopic) implementsGraphQLInterfaceComplexInlineFragmentsRepeatedStuffContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetId() testutil.ID { return v.Id }
-
-// GetUrl is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetUrl() string { return v.Url }
-
-// GetOtherId is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherId() testutil.ID { return v.OtherId }
-
-// GetName is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetName() string { return v.Name }
-
-// GetOtherName is a part of, and documented with, the interface ComplexInlineFragmentsRepeatedStuffContent.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherName() string { return v.OtherName }
 
 func __unmarshalComplexInlineFragmentsRepeatedStuffContent(b []byte, v *ComplexInlineFragmentsRepeatedStuffContent) error {
 	if string(b) == "null" {
@@ -1072,6 +1089,24 @@ type ComplexInlineFragmentsRepeatedStuffTopic struct {
 	OtherName string      `json:"otherName"`
 }
 
+// GetTypename returns ComplexInlineFragmentsRepeatedStuffTopic.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsRepeatedStuffTopic.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetId() testutil.ID { return v.Id }
+
+// GetUrl returns ComplexInlineFragmentsRepeatedStuffTopic.Url, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetUrl() string { return v.Url }
+
+// GetOtherId returns ComplexInlineFragmentsRepeatedStuffTopic.OtherId, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherId() testutil.ID { return v.OtherId }
+
+// GetName returns ComplexInlineFragmentsRepeatedStuffTopic.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetName() string { return v.Name }
+
+// GetOtherName returns ComplexInlineFragmentsRepeatedStuffTopic.OtherName, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherName() string { return v.OtherName }
+
 // ComplexInlineFragmentsRepeatedStuffVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsRepeatedStuffVideo struct {
 	Typename string `json:"__typename"`
@@ -1085,6 +1120,27 @@ type ComplexInlineFragmentsRepeatedStuffVideo struct {
 	Duration  int         `json:"duration"`
 }
 
+// GetTypename returns ComplexInlineFragmentsRepeatedStuffVideo.Typename, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetTypename() string { return v.Typename }
+
+// GetId returns ComplexInlineFragmentsRepeatedStuffVideo.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetId() testutil.ID { return v.Id }
+
+// GetUrl returns ComplexInlineFragmentsRepeatedStuffVideo.Url, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetUrl() string { return v.Url }
+
+// GetOtherId returns ComplexInlineFragmentsRepeatedStuffVideo.OtherId, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherId() testutil.ID { return v.OtherId }
+
+// GetName returns ComplexInlineFragmentsRepeatedStuffVideo.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetName() string { return v.Name }
+
+// GetOtherName returns ComplexInlineFragmentsRepeatedStuffVideo.OtherName, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherName() string { return v.OtherName }
+
+// GetDuration returns ComplexInlineFragmentsRepeatedStuffVideo.Duration, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetDuration() int { return v.Duration }
+
 // ComplexInlineFragmentsResponse is returned by ComplexInlineFragments on success.
 type ComplexInlineFragmentsResponse struct {
 	Root             ComplexInlineFragmentsRootTopic               `json:"root"`
@@ -1092,6 +1148,29 @@ type ComplexInlineFragmentsResponse struct {
 	RepeatedStuff    ComplexInlineFragmentsRepeatedStuffContent    `json:"-"`
 	ConflictingStuff ComplexInlineFragmentsConflictingStuffContent `json:"-"`
 	NestedStuff      ComplexInlineFragmentsNestedStuffContent      `json:"-"`
+}
+
+// GetRoot returns ComplexInlineFragmentsResponse.Root, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsResponse) GetRoot() ComplexInlineFragmentsRootTopic { return v.Root }
+
+// GetRandomItem returns ComplexInlineFragmentsResponse.RandomItem, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsResponse) GetRandomItem() ComplexInlineFragmentsRandomItemContent {
+	return v.RandomItem
+}
+
+// GetRepeatedStuff returns ComplexInlineFragmentsResponse.RepeatedStuff, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsResponse) GetRepeatedStuff() ComplexInlineFragmentsRepeatedStuffContent {
+	return v.RepeatedStuff
+}
+
+// GetConflictingStuff returns ComplexInlineFragmentsResponse.ConflictingStuff, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsResponse) GetConflictingStuff() ComplexInlineFragmentsConflictingStuffContent {
+	return v.ConflictingStuff
+}
+
+// GetNestedStuff returns ComplexInlineFragmentsResponse.NestedStuff, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsResponse) GetNestedStuff() ComplexInlineFragmentsNestedStuffContent {
+	return v.NestedStuff
 }
 
 func (v *ComplexInlineFragmentsResponse) UnmarshalJSON(b []byte) error {
@@ -1251,6 +1330,15 @@ type ComplexInlineFragmentsRootTopic struct {
 	SchoolGrade string      `json:"schoolGrade"`
 	Name        string      `json:"name"`
 }
+
+// GetId returns ComplexInlineFragmentsRootTopic.Id, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRootTopic) GetId() testutil.ID { return v.Id }
+
+// GetSchoolGrade returns ComplexInlineFragmentsRootTopic.SchoolGrade, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRootTopic) GetSchoolGrade() string { return v.SchoolGrade }
+
+// GetName returns ComplexInlineFragmentsRootTopic.Name, and is useful for accessing the field via an interface.
+func (v *ComplexInlineFragmentsRootTopic) GetName() string { return v.Name }
 
 // We test all the spread cases from docs/DESIGN.md, see there for more context
 // on each, as well as various other nonsense.  But for abstract-in-abstract

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -15,6 +15,21 @@ type ComplexNamedFragmentsResponse struct {
 	QueryFragment `json:"-"`
 }
 
+// GetRandomItem returns ComplexNamedFragmentsResponse.RandomItem, and is useful for accessing the field via an interface.
+func (v *ComplexNamedFragmentsResponse) GetRandomItem() InnerQueryFragmentRandomItemContent {
+	return v.QueryFragment.InnerQueryFragment.RandomItem
+}
+
+// GetRandomLeaf returns ComplexNamedFragmentsResponse.RandomLeaf, and is useful for accessing the field via an interface.
+func (v *ComplexNamedFragmentsResponse) GetRandomLeaf() InnerQueryFragmentRandomLeafLeafContent {
+	return v.QueryFragment.InnerQueryFragment.RandomLeaf
+}
+
+// GetOtherLeaf returns ComplexNamedFragmentsResponse.OtherLeaf, and is useful for accessing the field via an interface.
+func (v *ComplexNamedFragmentsResponse) GetOtherLeaf() InnerQueryFragmentOtherLeafLeafContent {
+	return v.QueryFragment.InnerQueryFragment.OtherLeaf
+}
+
 func (v *ComplexNamedFragmentsResponse) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -116,28 +131,8 @@ type ContentFields interface {
 }
 
 func (v *ContentFieldsArticle) implementsGraphQLInterfaceContentFields() {}
-
-// GetName is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsArticle) GetName() string { return v.Name }
-
-// GetUrl is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsArticle) GetUrl() string { return v.Url }
-
-func (v *ContentFieldsVideo) implementsGraphQLInterfaceContentFields() {}
-
-// GetName is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsVideo) GetName() string { return v.Name }
-
-// GetUrl is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsVideo) GetUrl() string { return v.Url }
-
-func (v *ContentFieldsTopic) implementsGraphQLInterfaceContentFields() {}
-
-// GetName is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsTopic) GetName() string { return v.Name }
-
-// GetUrl is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsTopic) GetUrl() string { return v.Url }
+func (v *ContentFieldsVideo) implementsGraphQLInterfaceContentFields()   {}
+func (v *ContentFieldsTopic) implementsGraphQLInterfaceContentFields()   {}
 
 func __unmarshalContentFields(b []byte, v *ContentFields) error {
 	if string(b) == "null" {
@@ -216,6 +211,12 @@ type ContentFieldsArticle struct {
 	Url  string `json:"url"`
 }
 
+// GetName returns ContentFieldsArticle.Name, and is useful for accessing the field via an interface.
+func (v *ContentFieldsArticle) GetName() string { return v.Name }
+
+// GetUrl returns ContentFieldsArticle.Url, and is useful for accessing the field via an interface.
+func (v *ContentFieldsArticle) GetUrl() string { return v.Url }
+
 // ContentFields includes the GraphQL fields of Topic requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
 //
@@ -224,6 +225,12 @@ type ContentFieldsTopic struct {
 	Name string `json:"name"`
 	Url  string `json:"url"`
 }
+
+// GetName returns ContentFieldsTopic.Name, and is useful for accessing the field via an interface.
+func (v *ContentFieldsTopic) GetName() string { return v.Name }
+
+// GetUrl returns ContentFieldsTopic.Url, and is useful for accessing the field via an interface.
+func (v *ContentFieldsTopic) GetUrl() string { return v.Url }
 
 // ContentFields includes the GraphQL fields of Video requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -234,6 +241,12 @@ type ContentFieldsVideo struct {
 	Url  string `json:"url"`
 }
 
+// GetName returns ContentFieldsVideo.Name, and is useful for accessing the field via an interface.
+func (v *ContentFieldsVideo) GetName() string { return v.Name }
+
+// GetUrl returns ContentFieldsVideo.Url, and is useful for accessing the field via an interface.
+func (v *ContentFieldsVideo) GetUrl() string { return v.Url }
+
 // InnerQueryFragment includes the GraphQL fields of Query requested by the fragment InnerQueryFragment.
 // The GraphQL type's documentation follows.
 //
@@ -242,6 +255,19 @@ type InnerQueryFragment struct {
 	RandomItem InnerQueryFragmentRandomItemContent     `json:"-"`
 	RandomLeaf InnerQueryFragmentRandomLeafLeafContent `json:"-"`
 	OtherLeaf  InnerQueryFragmentOtherLeafLeafContent  `json:"-"`
+}
+
+// GetRandomItem returns InnerQueryFragment.RandomItem, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragment) GetRandomItem() InnerQueryFragmentRandomItemContent { return v.RandomItem }
+
+// GetRandomLeaf returns InnerQueryFragment.RandomLeaf, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragment) GetRandomLeaf() InnerQueryFragmentRandomLeafLeafContent {
+	return v.RandomLeaf
+}
+
+// GetOtherLeaf returns InnerQueryFragment.OtherLeaf, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragment) GetOtherLeaf() InnerQueryFragmentOtherLeafLeafContent {
+	return v.OtherLeaf
 }
 
 func (v *InnerQueryFragment) UnmarshalJSON(b []byte) error {
@@ -369,6 +395,15 @@ type InnerQueryFragmentOtherLeafArticle struct {
 	ContentFieldsArticle `json:"-"`
 }
 
+// GetTypename returns InnerQueryFragmentOtherLeafArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafArticle) GetTypename() string { return v.Typename }
+
+// GetName returns InnerQueryFragmentOtherLeafArticle.Name, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafArticle) GetName() string { return v.ContentFieldsArticle.Name }
+
+// GetUrl returns InnerQueryFragmentOtherLeafArticle.Url, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafArticle) GetUrl() string { return v.ContentFieldsArticle.Url }
+
 func (v *InnerQueryFragmentOtherLeafArticle) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -435,15 +470,8 @@ type InnerQueryFragmentOtherLeafLeafContent interface {
 
 func (v *InnerQueryFragmentOtherLeafArticle) implementsGraphQLInterfaceInnerQueryFragmentOtherLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InnerQueryFragmentOtherLeafLeafContent.
-func (v *InnerQueryFragmentOtherLeafArticle) GetTypename() string { return v.Typename }
-
 func (v *InnerQueryFragmentOtherLeafVideo) implementsGraphQLInterfaceInnerQueryFragmentOtherLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InnerQueryFragmentOtherLeafLeafContent.
-func (v *InnerQueryFragmentOtherLeafVideo) GetTypename() string { return v.Typename }
 
 func __unmarshalInnerQueryFragmentOtherLeafLeafContent(b []byte, v *InnerQueryFragmentOtherLeafLeafContent) error {
 	if string(b) == "null" {
@@ -517,6 +545,23 @@ type InnerQueryFragmentOtherLeafVideo struct {
 	ContentFieldsVideo `json:"-"`
 }
 
+// GetTypename returns InnerQueryFragmentOtherLeafVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InnerQueryFragmentOtherLeafVideo.Id, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafVideo) GetId() *testutil.ID { return v.MoreVideoFields.Id }
+
+// GetParent returns InnerQueryFragmentOtherLeafVideo.Parent, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafVideo) GetParent() *MoreVideoFieldsParentTopic {
+	return v.MoreVideoFields.Parent
+}
+
+// GetName returns InnerQueryFragmentOtherLeafVideo.Name, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafVideo) GetName() string { return v.ContentFieldsVideo.Name }
+
+// GetUrl returns InnerQueryFragmentOtherLeafVideo.Url, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentOtherLeafVideo) GetUrl() string { return v.ContentFieldsVideo.Url }
+
 func (v *InnerQueryFragmentOtherLeafVideo) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -586,6 +631,18 @@ type InnerQueryFragmentRandomItemArticle struct {
 	Name                 string      `json:"name"`
 	ContentFieldsArticle `json:"-"`
 }
+
+// GetTypename returns InnerQueryFragmentRandomItemArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemArticle) GetTypename() string { return v.Typename }
+
+// GetId returns InnerQueryFragmentRandomItemArticle.Id, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns InnerQueryFragmentRandomItemArticle.Name, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemArticle) GetName() string { return v.Name }
+
+// GetUrl returns InnerQueryFragmentRandomItemArticle.Url, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemArticle) GetUrl() string { return v.ContentFieldsArticle.Url }
 
 func (v *InnerQueryFragmentRandomItemArticle) UnmarshalJSON(b []byte) error {
 
@@ -665,39 +722,10 @@ type InnerQueryFragmentRandomItemContent interface {
 
 func (v *InnerQueryFragmentRandomItemArticle) implementsGraphQLInterfaceInnerQueryFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemArticle) GetName() string { return v.Name }
-
 func (v *InnerQueryFragmentRandomItemVideo) implementsGraphQLInterfaceInnerQueryFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemVideo) GetName() string { return v.Name }
-
 func (v *InnerQueryFragmentRandomItemTopic) implementsGraphQLInterfaceInnerQueryFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InnerQueryFragmentRandomItemContent.
-func (v *InnerQueryFragmentRandomItemTopic) GetName() string { return v.Name }
 
 func __unmarshalInnerQueryFragmentRandomItemContent(b []byte, v *InnerQueryFragmentRandomItemContent) error {
 	if string(b) == "null" {
@@ -788,6 +816,18 @@ type InnerQueryFragmentRandomItemTopic struct {
 	ContentFieldsTopic `json:"-"`
 }
 
+// GetTypename returns InnerQueryFragmentRandomItemTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemTopic) GetTypename() string { return v.Typename }
+
+// GetId returns InnerQueryFragmentRandomItemTopic.Id, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InnerQueryFragmentRandomItemTopic.Name, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemTopic) GetName() string { return v.Name }
+
+// GetUrl returns InnerQueryFragmentRandomItemTopic.Url, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemTopic) GetUrl() string { return v.ContentFieldsTopic.Url }
+
 func (v *InnerQueryFragmentRandomItemTopic) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -849,6 +889,26 @@ type InnerQueryFragmentRandomItemVideo struct {
 	Name               string      `json:"name"`
 	VideoFields        `json:"-"`
 	ContentFieldsVideo `json:"-"`
+}
+
+// GetTypename returns InnerQueryFragmentRandomItemVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InnerQueryFragmentRandomItemVideo.Id, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns InnerQueryFragmentRandomItemVideo.Name, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemVideo) GetName() string { return v.Name }
+
+// GetUrl returns InnerQueryFragmentRandomItemVideo.Url, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemVideo) GetUrl() string { return v.VideoFields.Url }
+
+// GetDuration returns InnerQueryFragmentRandomItemVideo.Duration, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemVideo) GetDuration() int { return v.VideoFields.Duration }
+
+// GetThumbnail returns InnerQueryFragmentRandomItemVideo.Thumbnail, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomItemVideo) GetThumbnail() VideoFieldsThumbnail {
+	return v.VideoFields.Thumbnail
 }
 
 func (v *InnerQueryFragmentRandomItemVideo) UnmarshalJSON(b []byte) error {
@@ -921,6 +981,15 @@ type InnerQueryFragmentRandomLeafArticle struct {
 	ContentFieldsArticle `json:"-"`
 }
 
+// GetTypename returns InnerQueryFragmentRandomLeafArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafArticle) GetTypename() string { return v.Typename }
+
+// GetName returns InnerQueryFragmentRandomLeafArticle.Name, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafArticle) GetName() string { return v.ContentFieldsArticle.Name }
+
+// GetUrl returns InnerQueryFragmentRandomLeafArticle.Url, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafArticle) GetUrl() string { return v.ContentFieldsArticle.Url }
+
 func (v *InnerQueryFragmentRandomLeafArticle) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -987,15 +1056,8 @@ type InnerQueryFragmentRandomLeafLeafContent interface {
 
 func (v *InnerQueryFragmentRandomLeafArticle) implementsGraphQLInterfaceInnerQueryFragmentRandomLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InnerQueryFragmentRandomLeafLeafContent.
-func (v *InnerQueryFragmentRandomLeafArticle) GetTypename() string { return v.Typename }
-
 func (v *InnerQueryFragmentRandomLeafVideo) implementsGraphQLInterfaceInnerQueryFragmentRandomLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InnerQueryFragmentRandomLeafLeafContent.
-func (v *InnerQueryFragmentRandomLeafVideo) GetTypename() string { return v.Typename }
 
 func __unmarshalInnerQueryFragmentRandomLeafLeafContent(b []byte, v *InnerQueryFragmentRandomLeafLeafContent) error {
 	if string(b) == "null" {
@@ -1068,6 +1130,31 @@ type InnerQueryFragmentRandomLeafVideo struct {
 	VideoFields        `json:"-"`
 	MoreVideoFields    `json:"-"`
 	ContentFieldsVideo `json:"-"`
+}
+
+// GetTypename returns InnerQueryFragmentRandomLeafVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InnerQueryFragmentRandomLeafVideo.Id, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafVideo) GetId() testutil.ID { return v.VideoFields.Id }
+
+// GetName returns InnerQueryFragmentRandomLeafVideo.Name, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafVideo) GetName() string { return v.VideoFields.Name }
+
+// GetUrl returns InnerQueryFragmentRandomLeafVideo.Url, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafVideo) GetUrl() string { return v.VideoFields.Url }
+
+// GetDuration returns InnerQueryFragmentRandomLeafVideo.Duration, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafVideo) GetDuration() int { return v.VideoFields.Duration }
+
+// GetThumbnail returns InnerQueryFragmentRandomLeafVideo.Thumbnail, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafVideo) GetThumbnail() VideoFieldsThumbnail {
+	return v.VideoFields.Thumbnail
+}
+
+// GetParent returns InnerQueryFragmentRandomLeafVideo.Parent, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragmentRandomLeafVideo) GetParent() *MoreVideoFieldsParentTopic {
+	return v.MoreVideoFields.Parent
 }
 
 func (v *InnerQueryFragmentRandomLeafVideo) UnmarshalJSON(b []byte) error {
@@ -1149,12 +1236,29 @@ type MoreVideoFields struct {
 	Parent *MoreVideoFieldsParentTopic `json:"parent"`
 }
 
+// GetId returns MoreVideoFields.Id, and is useful for accessing the field via an interface.
+func (v *MoreVideoFields) GetId() *testutil.ID { return v.Id }
+
+// GetParent returns MoreVideoFields.Parent, and is useful for accessing the field via an interface.
+func (v *MoreVideoFields) GetParent() *MoreVideoFieldsParentTopic { return v.Parent }
+
 // MoreVideoFieldsParentTopic includes the requested fields of the GraphQL type Topic.
 type MoreVideoFieldsParentTopic struct {
 	Name               *string `json:"name"`
 	Url                *string `json:"url"`
 	ContentFieldsTopic `json:"-"`
 	Children           []MoreVideoFieldsParentTopicChildrenContent `json:"-"`
+}
+
+// GetName returns MoreVideoFieldsParentTopic.Name, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopic) GetName() *string { return v.Name }
+
+// GetUrl returns MoreVideoFieldsParentTopic.Url, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopic) GetUrl() *string { return v.Url }
+
+// GetChildren returns MoreVideoFieldsParentTopic.Children, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopic) GetChildren() []MoreVideoFieldsParentTopicChildrenContent {
+	return v.Children
 }
 
 func (v *MoreVideoFieldsParentTopic) UnmarshalJSON(b []byte) error {
@@ -1249,6 +1353,9 @@ type MoreVideoFieldsParentTopicChildrenArticle struct {
 	Typename *string `json:"__typename"`
 }
 
+// GetTypename returns MoreVideoFieldsParentTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenArticle) GetTypename() *string { return v.Typename }
+
 // MoreVideoFieldsParentTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
 // MoreVideoFieldsParentTopicChildrenContent is implemented by the following types:
@@ -1266,21 +1373,10 @@ type MoreVideoFieldsParentTopicChildrenContent interface {
 
 func (v *MoreVideoFieldsParentTopicChildrenArticle) implementsGraphQLInterfaceMoreVideoFieldsParentTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface MoreVideoFieldsParentTopicChildrenContent.
-func (v *MoreVideoFieldsParentTopicChildrenArticle) GetTypename() *string { return v.Typename }
-
 func (v *MoreVideoFieldsParentTopicChildrenVideo) implementsGraphQLInterfaceMoreVideoFieldsParentTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface MoreVideoFieldsParentTopicChildrenContent.
-func (v *MoreVideoFieldsParentTopicChildrenVideo) GetTypename() *string { return v.Typename }
-
 func (v *MoreVideoFieldsParentTopicChildrenTopic) implementsGraphQLInterfaceMoreVideoFieldsParentTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface MoreVideoFieldsParentTopicChildrenContent.
-func (v *MoreVideoFieldsParentTopicChildrenTopic) GetTypename() *string { return v.Typename }
 
 func __unmarshalMoreVideoFieldsParentTopicChildrenContent(b []byte, v *MoreVideoFieldsParentTopicChildrenContent) error {
 	if string(b) == "null" {
@@ -1359,10 +1455,33 @@ type MoreVideoFieldsParentTopicChildrenTopic struct {
 	Typename *string `json:"__typename"`
 }
 
+// GetTypename returns MoreVideoFieldsParentTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenTopic) GetTypename() *string { return v.Typename }
+
 // MoreVideoFieldsParentTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type MoreVideoFieldsParentTopicChildrenVideo struct {
 	Typename    *string `json:"__typename"`
 	VideoFields `json:"-"`
+}
+
+// GetTypename returns MoreVideoFieldsParentTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetTypename() *string { return v.Typename }
+
+// GetId returns MoreVideoFieldsParentTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetId() testutil.ID { return v.VideoFields.Id }
+
+// GetName returns MoreVideoFieldsParentTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetName() string { return v.VideoFields.Name }
+
+// GetUrl returns MoreVideoFieldsParentTopicChildrenVideo.Url, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetUrl() string { return v.VideoFields.Url }
+
+// GetDuration returns MoreVideoFieldsParentTopicChildrenVideo.Duration, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetDuration() int { return v.VideoFields.Duration }
+
+// GetThumbnail returns MoreVideoFieldsParentTopicChildrenVideo.Thumbnail, and is useful for accessing the field via an interface.
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetThumbnail() VideoFieldsThumbnail {
+	return v.VideoFields.Thumbnail
 }
 
 func (v *MoreVideoFieldsParentTopicChildrenVideo) UnmarshalJSON(b []byte) error {
@@ -1430,6 +1549,21 @@ func (v *MoreVideoFieldsParentTopicChildrenVideo) __premarshalJSON() (*__premars
 // Query's description is probably ignored by almost all callers.
 type QueryFragment struct {
 	InnerQueryFragment `json:"-"`
+}
+
+// GetRandomItem returns QueryFragment.RandomItem, and is useful for accessing the field via an interface.
+func (v *QueryFragment) GetRandomItem() InnerQueryFragmentRandomItemContent {
+	return v.InnerQueryFragment.RandomItem
+}
+
+// GetRandomLeaf returns QueryFragment.RandomLeaf, and is useful for accessing the field via an interface.
+func (v *QueryFragment) GetRandomLeaf() InnerQueryFragmentRandomLeafLeafContent {
+	return v.InnerQueryFragment.RandomLeaf
+}
+
+// GetOtherLeaf returns QueryFragment.OtherLeaf, and is useful for accessing the field via an interface.
+func (v *QueryFragment) GetOtherLeaf() InnerQueryFragmentOtherLeafLeafContent {
+	return v.InnerQueryFragment.OtherLeaf
 }
 
 func (v *QueryFragment) UnmarshalJSON(b []byte) error {
@@ -1526,6 +1660,21 @@ type VideoFields struct {
 	ContentFieldsVideo `json:"-"`
 }
 
+// GetId returns VideoFields.Id, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetId() testutil.ID { return v.Id }
+
+// GetName returns VideoFields.Name, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetName() string { return v.Name }
+
+// GetUrl returns VideoFields.Url, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetUrl() string { return v.Url }
+
+// GetDuration returns VideoFields.Duration, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetDuration() int { return v.Duration }
+
+// GetThumbnail returns VideoFields.Thumbnail, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetThumbnail() VideoFieldsThumbnail { return v.Thumbnail }
+
 func (v *VideoFields) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -1586,6 +1735,9 @@ func (v *VideoFields) __premarshalJSON() (*__premarshalVideoFields, error) {
 type VideoFieldsThumbnail struct {
 	Id testutil.ID `json:"id"`
 }
+
+// GetId returns VideoFieldsThumbnail.Id, and is useful for accessing the field via an interface.
+func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
 func ComplexNamedFragments(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -16,6 +16,9 @@ type CustomMarshalResponse struct {
 	UsersBornOn []CustomMarshalUsersBornOnUser `json:"usersBornOn"`
 }
 
+// GetUsersBornOn returns CustomMarshalResponse.UsersBornOn, and is useful for accessing the field via an interface.
+func (v *CustomMarshalResponse) GetUsersBornOn() []CustomMarshalUsersBornOnUser { return v.UsersBornOn }
+
 // CustomMarshalUsersBornOnUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,12 @@ type CustomMarshalUsersBornOnUser struct {
 	Id        testutil.ID `json:"id"`
 	Birthdate time.Time   `json:"-"`
 }
+
+// GetId returns CustomMarshalUsersBornOnUser.Id, and is useful for accessing the field via an interface.
+func (v *CustomMarshalUsersBornOnUser) GetId() testutil.ID { return v.Id }
+
+// GetBirthdate returns CustomMarshalUsersBornOnUser.Birthdate, and is useful for accessing the field via an interface.
+func (v *CustomMarshalUsersBornOnUser) GetBirthdate() time.Time { return v.Birthdate }
 
 func (v *CustomMarshalUsersBornOnUser) UnmarshalJSON(b []byte) error {
 
@@ -98,6 +107,9 @@ func (v *CustomMarshalUsersBornOnUser) __premarshalJSON() (*__premarshalCustomMa
 type __CustomMarshalInput struct {
 	Date time.Time `json:"-"`
 }
+
+// GetDate returns __CustomMarshalInput.Date, and is useful for accessing the field via an interface.
+func (v *__CustomMarshalInput) GetDate() time.Time { return v.Date }
 
 func (v *__CustomMarshalInput) UnmarshalJSON(b []byte) error {
 

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -17,11 +17,25 @@ type CustomMarshalSliceResponse struct {
 	WithPointer                     bool `json:"withPointer"`
 }
 
+// GetAcceptsListOfListOfListsOfDates returns CustomMarshalSliceResponse.AcceptsListOfListOfListsOfDates, and is useful for accessing the field via an interface.
+func (v *CustomMarshalSliceResponse) GetAcceptsListOfListOfListsOfDates() bool {
+	return v.AcceptsListOfListOfListsOfDates
+}
+
+// GetWithPointer returns CustomMarshalSliceResponse.WithPointer, and is useful for accessing the field via an interface.
+func (v *CustomMarshalSliceResponse) GetWithPointer() bool { return v.WithPointer }
+
 // __CustomMarshalSliceInput is used internally by genqlient
 type __CustomMarshalSliceInput struct {
 	Datesss  [][][]time.Time  `json:"-"`
 	Datesssp [][][]*time.Time `json:"-"`
 }
+
+// GetDatesss returns __CustomMarshalSliceInput.Datesss, and is useful for accessing the field via an interface.
+func (v *__CustomMarshalSliceInput) GetDatesss() [][][]time.Time { return v.Datesss }
+
+// GetDatesssp returns __CustomMarshalSliceInput.Datesssp, and is useful for accessing the field via an interface.
+func (v *__CustomMarshalSliceInput) GetDatesssp() [][][]*time.Time { return v.Datesssp }
 
 func (v *__CustomMarshalSliceInput) UnmarshalJSON(b []byte) error {
 

--- a/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
@@ -14,10 +14,19 @@ type __convertTimezoneInput struct {
 	Tz string    `json:"tz"`
 }
 
+// GetDt returns __convertTimezoneInput.Dt, and is useful for accessing the field via an interface.
+func (v *__convertTimezoneInput) GetDt() time.Time { return v.Dt }
+
+// GetTz returns __convertTimezoneInput.Tz, and is useful for accessing the field via an interface.
+func (v *__convertTimezoneInput) GetTz() string { return v.Tz }
+
 // convertTimezoneResponse is returned by convertTimezone on success.
 type convertTimezoneResponse struct {
 	Convert time.Time `json:"convert"`
 }
+
+// GetConvert returns convertTimezoneResponse.Convert, and is useful for accessing the field via an interface.
+func (v *convertTimezoneResponse) GetConvert() time.Time { return v.Convert }
 
 func convertTimezone(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
@@ -12,6 +12,14 @@ type EmptyInterfaceResponse struct {
 	GetComplexJunk []map[string]*[]*map[string]interface{} `json:"getComplexJunk"`
 }
 
+// GetGetJunk returns EmptyInterfaceResponse.GetJunk, and is useful for accessing the field via an interface.
+func (v *EmptyInterfaceResponse) GetGetJunk() interface{} { return v.GetJunk }
+
+// GetGetComplexJunk returns EmptyInterfaceResponse.GetComplexJunk, and is useful for accessing the field via an interface.
+func (v *EmptyInterfaceResponse) GetGetComplexJunk() []map[string]*[]*map[string]interface{} {
+	return v.GetComplexJunk
+}
+
 func EmptyInterface(
 	client graphql.Client,
 ) (*EmptyInterfaceResponse, error) {

--- a/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
@@ -17,6 +17,12 @@ type ChildVideoFields struct {
 	Name string      `json:"name"`
 }
 
+// GetId returns ChildVideoFields.Id, and is useful for accessing the field via an interface.
+func (v *ChildVideoFields) GetId() testutil.ID { return v.Id }
+
+// GetName returns ChildVideoFields.Name, and is useful for accessing the field via an interface.
+func (v *ChildVideoFields) GetName() string { return v.Name }
+
 // ContentFields includes the GraphQL fields of Content requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
 //
@@ -35,28 +41,8 @@ type ContentFields interface {
 }
 
 func (v *ContentFieldsArticle) implementsGraphQLInterfaceContentFields() {}
-
-// GetName is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsArticle) GetName() string { return v.Name }
-
-// GetUrl is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsArticle) GetUrl() string { return v.Url }
-
-func (v *ContentFieldsVideo) implementsGraphQLInterfaceContentFields() {}
-
-// GetName is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsVideo) GetName() string { return v.Name }
-
-// GetUrl is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsVideo) GetUrl() string { return v.Url }
-
-func (v *ContentFieldsTopic) implementsGraphQLInterfaceContentFields() {}
-
-// GetName is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsTopic) GetName() string { return v.Name }
-
-// GetUrl is a part of, and documented with, the interface ContentFields.
-func (v *ContentFieldsTopic) GetUrl() string { return v.Url }
+func (v *ContentFieldsVideo) implementsGraphQLInterfaceContentFields()   {}
+func (v *ContentFieldsTopic) implementsGraphQLInterfaceContentFields()   {}
 
 func __unmarshalContentFields(b []byte, v *ContentFields) error {
 	if string(b) == "null" {
@@ -135,6 +121,12 @@ type ContentFieldsArticle struct {
 	Url  string `json:"url"`
 }
 
+// GetName returns ContentFieldsArticle.Name, and is useful for accessing the field via an interface.
+func (v *ContentFieldsArticle) GetName() string { return v.Name }
+
+// GetUrl returns ContentFieldsArticle.Url, and is useful for accessing the field via an interface.
+func (v *ContentFieldsArticle) GetUrl() string { return v.Url }
+
 // ContentFields includes the GraphQL fields of Topic requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
 //
@@ -143,6 +135,12 @@ type ContentFieldsTopic struct {
 	Name string `json:"name"`
 	Url  string `json:"url"`
 }
+
+// GetName returns ContentFieldsTopic.Name, and is useful for accessing the field via an interface.
+func (v *ContentFieldsTopic) GetName() string { return v.Name }
+
+// GetUrl returns ContentFieldsTopic.Url, and is useful for accessing the field via an interface.
+func (v *ContentFieldsTopic) GetUrl() string { return v.Url }
 
 // ContentFields includes the GraphQL fields of Video requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -153,6 +151,12 @@ type ContentFieldsVideo struct {
 	Url  string `json:"url"`
 }
 
+// GetName returns ContentFieldsVideo.Name, and is useful for accessing the field via an interface.
+func (v *ContentFieldsVideo) GetName() string { return v.Name }
+
+// GetUrl returns ContentFieldsVideo.Url, and is useful for accessing the field via an interface.
+func (v *ContentFieldsVideo) GetUrl() string { return v.Url }
+
 // InnerQueryFragment includes the GraphQL fields of Query requested by the fragment InnerQueryFragment.
 // The GraphQL type's documentation follows.
 //
@@ -162,6 +166,15 @@ type InnerQueryFragment struct {
 	RandomItem  ContentFields      `json:"-"`
 	OtherVideo  ContentFieldsVideo `json:"otherVideo"`
 }
+
+// GetRandomVideo returns InnerQueryFragment.RandomVideo, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragment) GetRandomVideo() VideoFields { return v.RandomVideo }
+
+// GetRandomItem returns InnerQueryFragment.RandomItem, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragment) GetRandomItem() ContentFields { return v.RandomItem }
+
+// GetOtherVideo returns InnerQueryFragment.OtherVideo, and is useful for accessing the field via an interface.
+func (v *InnerQueryFragment) GetOtherVideo() ContentFieldsVideo { return v.OtherVideo }
 
 func (v *InnerQueryFragment) UnmarshalJSON(b []byte) error {
 
@@ -239,10 +252,19 @@ type VideoFields struct {
 	Parent VideoFieldsParentTopic `json:"parent"`
 }
 
+// GetId returns VideoFields.Id, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetId() testutil.ID { return v.Id }
+
+// GetParent returns VideoFields.Parent, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetParent() VideoFieldsParentTopic { return v.Parent }
+
 // VideoFieldsParentTopic includes the requested fields of the GraphQL type Topic.
 type VideoFieldsParentTopic struct {
 	VideoChildren []ChildVideoFields `json:"videoChildren"`
 }
+
+// GetVideoChildren returns VideoFieldsParentTopic.VideoChildren, and is useful for accessing the field via an interface.
+func (v *VideoFieldsParentTopic) GetVideoChildren() []ChildVideoFields { return v.VideoChildren }
 
 func ComplexNamedFragments(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
@@ -13,6 +13,11 @@ type InputEnumQueryResponse struct {
 	UsersWithRole []InputEnumQueryUsersWithRoleUser `json:"usersWithRole"`
 }
 
+// GetUsersWithRole returns InputEnumQueryResponse.UsersWithRole, and is useful for accessing the field via an interface.
+func (v *InputEnumQueryResponse) GetUsersWithRole() []InputEnumQueryUsersWithRoleUser {
+	return v.UsersWithRole
+}
+
 // InputEnumQueryUsersWithRoleUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -23,6 +28,9 @@ type InputEnumQueryUsersWithRoleUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id testutil.ID `json:"id"`
 }
+
+// GetId returns InputEnumQueryUsersWithRoleUser.Id, and is useful for accessing the field via an interface.
+func (v *InputEnumQueryUsersWithRoleUser) GetId() testutil.ID { return v.Id }
 
 // Role is a type a user may have.
 type Role string
@@ -42,6 +50,9 @@ const (
 type __InputEnumQueryInput struct {
 	Role Role `json:"role"`
 }
+
+// GetRole returns __InputEnumQueryInput.Role, and is useful for accessing the field via an interface.
+func (v *__InputEnumQueryInput) GetRole() Role { return v.Role }
 
 func InputEnumQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -20,6 +20,9 @@ type InputObjectQueryResponse struct {
 	User InputObjectQueryUser `json:"user"`
 }
 
+// GetUser returns InputObjectQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *InputObjectQueryResponse) GetUser() InputObjectQueryUser { return v.User }
+
 // InputObjectQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -30,6 +33,9 @@ type InputObjectQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id testutil.ID `json:"id"`
 }
+
+// GetId returns InputObjectQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *InputObjectQueryUser) GetId() testutil.ID { return v.Id }
 
 // Role is a type a user may have.
 type Role string
@@ -60,6 +66,27 @@ type UserQueryInput struct {
 	HasPokemon testutil.Pokemon `json:"hasPokemon"`
 	Birthdate  time.Time        `json:"-"`
 }
+
+// GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetEmail() string { return v.Email }
+
+// GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetName() string { return v.Name }
+
+// GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+
+// GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetRole() Role { return v.Role }
+
+// GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetNames() []string { return v.Names }
+
+// GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+
+// GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -146,6 +173,9 @@ func (v *UserQueryInput) __premarshalJSON() (*__premarshalUserQueryInput, error)
 type __InputObjectQueryInput struct {
 	Query UserQueryInput `json:"query"`
 }
+
+// GetQuery returns __InputObjectQueryInput.Query, and is useful for accessing the field via an interface.
+func (v *__InputObjectQueryInput) GetQuery() UserQueryInput { return v.Query }
 
 func InputObjectQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -16,12 +16,31 @@ type InterfaceListFieldResponse struct {
 	WithPointer *InterfaceListFieldWithPointerTopic `json:"withPointer"`
 }
 
+// GetRoot returns InterfaceListFieldResponse.Root, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldResponse) GetRoot() InterfaceListFieldRootTopic { return v.Root }
+
+// GetWithPointer returns InterfaceListFieldResponse.WithPointer, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldResponse) GetWithPointer() *InterfaceListFieldWithPointerTopic {
+	return v.WithPointer
+}
+
 // InterfaceListFieldRootTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceListFieldRootTopic struct {
 	// ID is documented in the Content interface.
 	Id       testutil.ID                                  `json:"id"`
 	Name     string                                       `json:"name"`
 	Children []InterfaceListFieldRootTopicChildrenContent `json:"-"`
+}
+
+// GetId returns InterfaceListFieldRootTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldRootTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopic) GetName() string { return v.Name }
+
+// GetChildren returns InterfaceListFieldRootTopic.Children, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopic) GetChildren() []InterfaceListFieldRootTopicChildrenContent {
+	return v.Children
 }
 
 func (v *InterfaceListFieldRootTopic) UnmarshalJSON(b []byte) error {
@@ -113,6 +132,15 @@ type InterfaceListFieldRootTopicChildrenArticle struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListFieldRootTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenArticle) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListFieldRootTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldRootTopicChildrenArticle.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenArticle) GetName() string { return v.Name }
+
 // InterfaceListFieldRootTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
 // InterfaceListFieldRootTopicChildrenContent is implemented by the following types:
@@ -137,39 +165,10 @@ type InterfaceListFieldRootTopicChildrenContent interface {
 
 func (v *InterfaceListFieldRootTopicChildrenArticle) implementsGraphQLInterfaceInterfaceListFieldRootTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenArticle) GetName() string { return v.Name }
-
 func (v *InterfaceListFieldRootTopicChildrenVideo) implementsGraphQLInterfaceInterfaceListFieldRootTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenVideo) GetName() string { return v.Name }
-
 func (v *InterfaceListFieldRootTopicChildrenTopic) implementsGraphQLInterfaceInterfaceListFieldRootTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListFieldRootTopicChildrenContent.
-func (v *InterfaceListFieldRootTopicChildrenTopic) GetName() string { return v.Name }
 
 func __unmarshalInterfaceListFieldRootTopicChildrenContent(b []byte, v *InterfaceListFieldRootTopicChildrenContent) error {
 	if string(b) == "null" {
@@ -247,6 +246,15 @@ type InterfaceListFieldRootTopicChildrenTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListFieldRootTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenTopic) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListFieldRootTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldRootTopicChildrenTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenTopic) GetName() string { return v.Name }
+
 // InterfaceListFieldRootTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type InterfaceListFieldRootTopicChildrenVideo struct {
 	Typename string `json:"__typename"`
@@ -255,12 +263,32 @@ type InterfaceListFieldRootTopicChildrenVideo struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListFieldRootTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListFieldRootTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldRootTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldRootTopicChildrenVideo) GetName() string { return v.Name }
+
 // InterfaceListFieldWithPointerTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceListFieldWithPointerTopic struct {
 	// ID is documented in the Content interface.
 	Id       testutil.ID                                         `json:"id"`
 	Name     string                                              `json:"name"`
 	Children []InterfaceListFieldWithPointerTopicChildrenContent `json:"-"`
+}
+
+// GetId returns InterfaceListFieldWithPointerTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldWithPointerTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopic) GetName() string { return v.Name }
+
+// GetChildren returns InterfaceListFieldWithPointerTopic.Children, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopic) GetChildren() []InterfaceListFieldWithPointerTopicChildrenContent {
+	return v.Children
 }
 
 func (v *InterfaceListFieldWithPointerTopic) UnmarshalJSON(b []byte) error {
@@ -352,6 +380,15 @@ type InterfaceListFieldWithPointerTopicChildrenArticle struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListFieldWithPointerTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListFieldWithPointerTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldWithPointerTopicChildrenArticle.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetName() string { return v.Name }
+
 // InterfaceListFieldWithPointerTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
 // InterfaceListFieldWithPointerTopicChildrenContent is implemented by the following types:
@@ -376,39 +413,10 @@ type InterfaceListFieldWithPointerTopicChildrenContent interface {
 
 func (v *InterfaceListFieldWithPointerTopicChildrenArticle) implementsGraphQLInterfaceInterfaceListFieldWithPointerTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetName() string { return v.Name }
-
 func (v *InterfaceListFieldWithPointerTopicChildrenVideo) implementsGraphQLInterfaceInterfaceListFieldWithPointerTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetName() string { return v.Name }
-
 func (v *InterfaceListFieldWithPointerTopicChildrenTopic) implementsGraphQLInterfaceInterfaceListFieldWithPointerTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListFieldWithPointerTopicChildrenContent.
-func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetName() string { return v.Name }
 
 func __unmarshalInterfaceListFieldWithPointerTopicChildrenContent(b []byte, v *InterfaceListFieldWithPointerTopicChildrenContent) error {
 	if string(b) == "null" {
@@ -486,6 +494,15 @@ type InterfaceListFieldWithPointerTopicChildrenTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListFieldWithPointerTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListFieldWithPointerTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldWithPointerTopicChildrenTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetName() string { return v.Name }
+
 // InterfaceListFieldWithPointerTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type InterfaceListFieldWithPointerTopicChildrenVideo struct {
 	Typename string `json:"__typename"`
@@ -493,6 +510,15 @@ type InterfaceListFieldWithPointerTopicChildrenVideo struct {
 	Id   testutil.ID `json:"id"`
 	Name string      `json:"name"`
 }
+
+// GetTypename returns InterfaceListFieldWithPointerTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListFieldWithPointerTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceListFieldWithPointerTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetName() string { return v.Name }
 
 func InterfaceListField(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -34,56 +34,9 @@ type InterfaceListOfListOfListsFieldListOfListsOfListsOfContent interface {
 
 func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldListOfListsOfListsOfContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetId() testutil.ID {
-	return v.Id
-}
-
-// GetName is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetName() string {
-	return v.Name
-}
-
 func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldListOfListsOfListsOfContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetId() testutil.ID {
-	return v.Id
-}
-
-// GetName is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetName() string {
-	return v.Name
-}
-
 func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldListOfListsOfListsOfContent() {
-}
-
-// GetTypename is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetId() testutil.ID {
-	return v.Id
-}
-
-// GetName is a part of, and documented with, the interface InterfaceListOfListOfListsFieldListOfListsOfListsOfContent.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetName() string {
-	return v.Name
 }
 
 func __unmarshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(b []byte, v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContent) error {
@@ -162,12 +115,42 @@ type InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetName returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetName() string {
+	return v.Name
+}
+
 // InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic struct {
 	Typename string `json:"__typename"`
 	// ID is the identifier of the content.
 	Id   testutil.ID `json:"id"`
 	Name string      `json:"name"`
+}
+
+// GetTypename returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetName returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetName() string {
+	return v.Name
 }
 
 // InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo includes the requested fields of the GraphQL type Video.
@@ -178,10 +161,35 @@ type InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetName returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetName() string {
+	return v.Name
+}
+
 // InterfaceListOfListOfListsFieldResponse is returned by InterfaceListOfListOfListsField on success.
 type InterfaceListOfListOfListsFieldResponse struct {
 	ListOfListsOfListsOfContent [][][]InterfaceListOfListOfListsFieldListOfListsOfListsOfContent `json:"-"`
 	WithPointer                 [][][]*InterfaceListOfListOfListsFieldWithPointerContent         `json:"-"`
+}
+
+// GetListOfListsOfListsOfContent returns InterfaceListOfListOfListsFieldResponse.ListOfListsOfListsOfContent, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldResponse) GetListOfListsOfListsOfContent() [][][]InterfaceListOfListOfListsFieldListOfListsOfListsOfContent {
+	return v.ListOfListsOfListsOfContent
+}
+
+// GetWithPointer returns InterfaceListOfListOfListsFieldResponse.WithPointer, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldResponse) GetWithPointer() [][][]*InterfaceListOfListOfListsFieldWithPointerContent {
+	return v.WithPointer
 }
 
 func (v *InterfaceListOfListOfListsFieldResponse) UnmarshalJSON(b []byte) error {
@@ -358,6 +366,15 @@ type InterfaceListOfListOfListsFieldWithPointerArticle struct {
 	Name *string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListOfListOfListsFieldWithPointerArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListOfListOfListsFieldWithPointerArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetId() *testutil.ID { return v.Id }
+
+// GetName returns InterfaceListOfListOfListsFieldWithPointerArticle.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetName() *string { return v.Name }
+
 // InterfaceListOfListOfListsFieldWithPointerContent includes the requested fields of the GraphQL interface Content.
 //
 // InterfaceListOfListOfListsFieldWithPointerContent is implemented by the following types:
@@ -382,39 +399,10 @@ type InterfaceListOfListOfListsFieldWithPointerContent interface {
 
 func (v *InterfaceListOfListOfListsFieldWithPointerArticle) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldWithPointerContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetId() *testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetName() *string { return v.Name }
-
 func (v *InterfaceListOfListOfListsFieldWithPointerVideo) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldWithPointerContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetId() *testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetName() *string { return v.Name }
-
 func (v *InterfaceListOfListOfListsFieldWithPointerTopic) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldWithPointerContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetId() *testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceListOfListOfListsFieldWithPointerContent.
-func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetName() *string { return v.Name }
 
 func __unmarshalInterfaceListOfListOfListsFieldWithPointerContent(b []byte, v *InterfaceListOfListOfListsFieldWithPointerContent) error {
 	if string(b) == "null" {
@@ -492,6 +480,15 @@ type InterfaceListOfListOfListsFieldWithPointerTopic struct {
 	Name *string      `json:"name"`
 }
 
+// GetTypename returns InterfaceListOfListOfListsFieldWithPointerTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListOfListOfListsFieldWithPointerTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetId() *testutil.ID { return v.Id }
+
+// GetName returns InterfaceListOfListOfListsFieldWithPointerTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetName() *string { return v.Name }
+
 // InterfaceListOfListOfListsFieldWithPointerVideo includes the requested fields of the GraphQL type Video.
 type InterfaceListOfListOfListsFieldWithPointerVideo struct {
 	Typename string `json:"__typename"`
@@ -499,6 +496,15 @@ type InterfaceListOfListOfListsFieldWithPointerVideo struct {
 	Id   *testutil.ID `json:"id"`
 	Name *string      `json:"name"`
 }
+
+// GetTypename returns InterfaceListOfListOfListsFieldWithPointerVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceListOfListOfListsFieldWithPointerVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetId() *testutil.ID { return v.Id }
+
+// GetName returns InterfaceListOfListOfListsFieldWithPointerVideo.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetName() *string { return v.Name }
 
 func InterfaceListOfListOfListsField(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -15,11 +15,22 @@ type InterfaceNestingResponse struct {
 	Root InterfaceNestingRootTopic `json:"root"`
 }
 
+// GetRoot returns InterfaceNestingResponse.Root, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingResponse) GetRoot() InterfaceNestingRootTopic { return v.Root }
+
 // InterfaceNestingRootTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceNestingRootTopic struct {
 	// ID is documented in the Content interface.
 	Id       testutil.ID                                `json:"id"`
 	Children []InterfaceNestingRootTopicChildrenContent `json:"-"`
+}
+
+// GetId returns InterfaceNestingRootTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopic) GetId() testutil.ID { return v.Id }
+
+// GetChildren returns InterfaceNestingRootTopic.Children, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopic) GetChildren() []InterfaceNestingRootTopicChildrenContent {
+	return v.Children
 }
 
 func (v *InterfaceNestingRootTopic) UnmarshalJSON(b []byte) error {
@@ -108,6 +119,17 @@ type InterfaceNestingRootTopicChildrenArticle struct {
 	Parent InterfaceNestingRootTopicChildrenContentParentTopic `json:"parent"`
 }
 
+// GetTypename returns InterfaceNestingRootTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenArticle) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNestingRootTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+
+// GetParent returns InterfaceNestingRootTopicChildrenArticle.Parent, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenArticle) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
+	return v.Parent
+}
+
 // InterfaceNestingRootTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
 // InterfaceNestingRootTopicChildrenContent is implemented by the following types:
@@ -132,44 +154,9 @@ type InterfaceNestingRootTopicChildrenContent interface {
 
 func (v *InterfaceNestingRootTopicChildrenArticle) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenArticle) GetId() testutil.ID { return v.Id }
-
-// GetParent is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenArticle) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
-	return v.Parent
-}
-
 func (v *InterfaceNestingRootTopicChildrenVideo) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenVideo) GetId() testutil.ID { return v.Id }
-
-// GetParent is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenVideo) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
-	return v.Parent
-}
-
 func (v *InterfaceNestingRootTopicChildrenTopic) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContent() {
-}
-
-// GetTypename is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenTopic) GetId() testutil.ID { return v.Id }
-
-// GetParent is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenTopic) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
-	return v.Parent
 }
 
 func __unmarshalInterfaceNestingRootTopicChildrenContent(b []byte, v *InterfaceNestingRootTopicChildrenContent) error {
@@ -245,6 +232,14 @@ type InterfaceNestingRootTopicChildrenContentParentTopic struct {
 	// ID is documented in the Content interface.
 	Id       testutil.ID                                                          `json:"id"`
 	Children []InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent `json:"-"`
+}
+
+// GetId returns InterfaceNestingRootTopicChildrenContentParentTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopic) GetId() testutil.ID { return v.Id }
+
+// GetChildren returns InterfaceNestingRootTopicChildrenContentParentTopic.Children, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopic) GetChildren() []InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent {
+	return v.Children
 }
 
 func (v *InterfaceNestingRootTopicChildrenContentParentTopic) UnmarshalJSON(b []byte) error {
@@ -332,6 +327,16 @@ type InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetTypename returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetId() testutil.ID {
+	return v.Id
+}
+
 // InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
 // InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent is implemented by the following types:
@@ -354,41 +359,9 @@ type InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent interfac
 
 func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetId() testutil.ID {
-	return v.Id
-}
-
 func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetId() testutil.ID {
-	return v.Id
-}
-
 func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent() {
-}
-
-// GetTypename is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetId() testutil.ID {
-	return v.Id
 }
 
 func __unmarshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent(b []byte, v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent) error {
@@ -466,11 +439,31 @@ type InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetTypename returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetId() testutil.ID {
+	return v.Id
+}
+
 // InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo struct {
 	Typename string `json:"__typename"`
 	// ID is the identifier of the content.
 	Id testutil.ID `json:"id"`
+}
+
+// GetTypename returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetId() testutil.ID {
+	return v.Id
 }
 
 // InterfaceNestingRootTopicChildrenTopic includes the requested fields of the GraphQL type Topic.
@@ -481,12 +474,34 @@ type InterfaceNestingRootTopicChildrenTopic struct {
 	Parent InterfaceNestingRootTopicChildrenContentParentTopic `json:"parent"`
 }
 
+// GetTypename returns InterfaceNestingRootTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenTopic) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNestingRootTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+
+// GetParent returns InterfaceNestingRootTopicChildrenTopic.Parent, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenTopic) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
+	return v.Parent
+}
+
 // InterfaceNestingRootTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNestingRootTopicChildrenVideo struct {
 	Typename string `json:"__typename"`
 	// ID is the identifier of the content.
 	Id     testutil.ID                                         `json:"id"`
 	Parent InterfaceNestingRootTopicChildrenContentParentTopic `json:"parent"`
+}
+
+// GetTypename returns InterfaceNestingRootTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNestingRootTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+
+// GetParent returns InterfaceNestingRootTopicChildrenVideo.Parent, and is useful for accessing the field via an interface.
+func (v *InterfaceNestingRootTopicChildrenVideo) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
+	return v.Parent
 }
 
 func InterfaceNesting(

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -18,6 +18,15 @@ type InterfaceNoFragmentsQueryRandomItemArticle struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceNoFragmentsQueryRandomItemArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNoFragmentsQueryRandomItemArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryRandomItemArticle.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetName() string { return v.Name }
+
 // InterfaceNoFragmentsQueryRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
 // InterfaceNoFragmentsQueryRandomItemContent is implemented by the following types:
@@ -42,39 +51,10 @@ type InterfaceNoFragmentsQueryRandomItemContent interface {
 
 func (v *InterfaceNoFragmentsQueryRandomItemArticle) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetName() string { return v.Name }
-
 func (v *InterfaceNoFragmentsQueryRandomItemVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetName() string { return v.Name }
-
 func (v *InterfaceNoFragmentsQueryRandomItemTopic) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemContent.
-func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetName() string { return v.Name }
 
 func __unmarshalInterfaceNoFragmentsQueryRandomItemContent(b []byte, v *InterfaceNoFragmentsQueryRandomItemContent) error {
 	if string(b) == "null" {
@@ -152,6 +132,15 @@ type InterfaceNoFragmentsQueryRandomItemTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceNoFragmentsQueryRandomItemTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNoFragmentsQueryRandomItemTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryRandomItemTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetName() string { return v.Name }
+
 // InterfaceNoFragmentsQueryRandomItemVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNoFragmentsQueryRandomItemVideo struct {
 	Typename string `json:"__typename"`
@@ -160,6 +149,15 @@ type InterfaceNoFragmentsQueryRandomItemVideo struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceNoFragmentsQueryRandomItemVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNoFragmentsQueryRandomItemVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryRandomItemVideo.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetName() string { return v.Name }
+
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle includes the requested fields of the GraphQL type Article.
 type InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle struct {
 	Typename string `json:"__typename"`
@@ -167,6 +165,17 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle struct {
 	Id   testutil.ID `json:"id"`
 	Name string      `json:"name"`
 }
+
+// GetTypename returns InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetName() string { return v.Name }
 
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameContent includes the requested fields of the GraphQL interface Content.
 //
@@ -192,45 +201,10 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameContent interface {
 
 func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemWithTypeNameContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetName() string { return v.Name }
-
 func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemWithTypeNameContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetName() string { return v.Name }
-
 func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemWithTypeNameContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryRandomItemWithTypeNameContent.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetName() string { return v.Name }
 
 func __unmarshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(b []byte, v *InterfaceNoFragmentsQueryRandomItemWithTypeNameContent) error {
 	if string(b) == "null" {
@@ -308,6 +282,17 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetName() string { return v.Name }
+
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo struct {
 	Typename string `json:"__typename"`
@@ -316,12 +301,43 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetName() string { return v.Name }
+
 // InterfaceNoFragmentsQueryResponse is returned by InterfaceNoFragmentsQuery on success.
 type InterfaceNoFragmentsQueryResponse struct {
 	Root                   InterfaceNoFragmentsQueryRootTopic                     `json:"root"`
 	RandomItem             InterfaceNoFragmentsQueryRandomItemContent             `json:"-"`
 	RandomItemWithTypeName InterfaceNoFragmentsQueryRandomItemWithTypeNameContent `json:"-"`
 	WithPointer            *InterfaceNoFragmentsQueryWithPointerContent           `json:"-"`
+}
+
+// GetRoot returns InterfaceNoFragmentsQueryResponse.Root, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryResponse) GetRoot() InterfaceNoFragmentsQueryRootTopic {
+	return v.Root
+}
+
+// GetRandomItem returns InterfaceNoFragmentsQueryResponse.RandomItem, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryResponse) GetRandomItem() InterfaceNoFragmentsQueryRandomItemContent {
+	return v.RandomItem
+}
+
+// GetRandomItemWithTypeName returns InterfaceNoFragmentsQueryResponse.RandomItemWithTypeName, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryResponse) GetRandomItemWithTypeName() InterfaceNoFragmentsQueryRandomItemWithTypeNameContent {
+	return v.RandomItemWithTypeName
+}
+
+// GetWithPointer returns InterfaceNoFragmentsQueryResponse.WithPointer, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryResponse) GetWithPointer() *InterfaceNoFragmentsQueryWithPointerContent {
+	return v.WithPointer
 }
 
 func (v *InterfaceNoFragmentsQueryResponse) UnmarshalJSON(b []byte) error {
@@ -456,6 +472,12 @@ type InterfaceNoFragmentsQueryRootTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetId returns InterfaceNoFragmentsQueryRootTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRootTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryRootTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryRootTopic) GetName() string { return v.Name }
+
 // InterfaceNoFragmentsQueryWithPointerArticle includes the requested fields of the GraphQL type Article.
 type InterfaceNoFragmentsQueryWithPointerArticle struct {
 	Typename string `json:"__typename"`
@@ -463,6 +485,15 @@ type InterfaceNoFragmentsQueryWithPointerArticle struct {
 	Id   *testutil.ID `json:"id"`
 	Name *string      `json:"name"`
 }
+
+// GetTypename returns InterfaceNoFragmentsQueryWithPointerArticle.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNoFragmentsQueryWithPointerArticle.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetId() *testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryWithPointerArticle.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetName() *string { return v.Name }
 
 // InterfaceNoFragmentsQueryWithPointerContent includes the requested fields of the GraphQL interface Content.
 //
@@ -488,39 +519,10 @@ type InterfaceNoFragmentsQueryWithPointerContent interface {
 
 func (v *InterfaceNoFragmentsQueryWithPointerArticle) implementsGraphQLInterfaceInterfaceNoFragmentsQueryWithPointerContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetId() *testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetName() *string { return v.Name }
-
 func (v *InterfaceNoFragmentsQueryWithPointerVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryWithPointerContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetId() *testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetName() *string { return v.Name }
-
 func (v *InterfaceNoFragmentsQueryWithPointerTopic) implementsGraphQLInterfaceInterfaceNoFragmentsQueryWithPointerContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetId() *testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface InterfaceNoFragmentsQueryWithPointerContent.
-func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetName() *string { return v.Name }
 
 func __unmarshalInterfaceNoFragmentsQueryWithPointerContent(b []byte, v *InterfaceNoFragmentsQueryWithPointerContent) error {
 	if string(b) == "null" {
@@ -598,6 +600,15 @@ type InterfaceNoFragmentsQueryWithPointerTopic struct {
 	Name *string      `json:"name"`
 }
 
+// GetTypename returns InterfaceNoFragmentsQueryWithPointerTopic.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNoFragmentsQueryWithPointerTopic.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetId() *testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryWithPointerTopic.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetName() *string { return v.Name }
+
 // InterfaceNoFragmentsQueryWithPointerVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNoFragmentsQueryWithPointerVideo struct {
 	Typename string `json:"__typename"`
@@ -605,6 +616,15 @@ type InterfaceNoFragmentsQueryWithPointerVideo struct {
 	Id   *testutil.ID `json:"id"`
 	Name *string      `json:"name"`
 }
+
+// GetTypename returns InterfaceNoFragmentsQueryWithPointerVideo.Typename, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetTypename() string { return v.Typename }
+
+// GetId returns InterfaceNoFragmentsQueryWithPointerVideo.Id, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetId() *testutil.ID { return v.Id }
+
+// GetName returns InterfaceNoFragmentsQueryWithPointerVideo.Name, and is useful for accessing the field via an interface.
+func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetName() *string { return v.Name }
 
 func InterfaceNoFragmentsQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
@@ -16,6 +16,9 @@ type ListInputQueryResponse struct {
 	User ListInputQueryUser `json:"user"`
 }
 
+// GetUser returns ListInputQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *ListInputQueryResponse) GetUser() ListInputQueryUser { return v.User }
+
 // ListInputQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,10 +30,16 @@ type ListInputQueryUser struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetId returns ListInputQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *ListInputQueryUser) GetId() testutil.ID { return v.Id }
+
 // __ListInputQueryInput is used internally by genqlient
 type __ListInputQueryInput struct {
 	Names []string `json:"names"`
 }
+
+// GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
+func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
 
 func ListInputQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
@@ -11,6 +11,11 @@ type ListOfListsOfListsResponse struct {
 	ListOfListsOfLists [][][]string `json:"listOfListsOfLists"`
 }
 
+// GetListOfListsOfLists returns ListOfListsOfListsResponse.ListOfListsOfLists, and is useful for accessing the field via an interface.
+func (v *ListOfListsOfListsResponse) GetListOfListsOfLists() [][][]string {
+	return v.ListOfListsOfLists
+}
+
 func ListOfListsOfLists(
 	client graphql.Client,
 ) (*ListOfListsOfListsResponse, error) {

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -27,6 +27,27 @@ type MyInput struct {
 	Birthdate  *time.Time        `json:"-"`
 }
 
+// GetEmail returns MyInput.Email, and is useful for accessing the field via an interface.
+func (v *MyInput) GetEmail() *string { return v.Email }
+
+// GetName returns MyInput.Name, and is useful for accessing the field via an interface.
+func (v *MyInput) GetName() *string { return v.Name }
+
+// GetId returns MyInput.Id, and is useful for accessing the field via an interface.
+func (v *MyInput) GetId() *testutil.ID { return v.Id }
+
+// GetRole returns MyInput.Role, and is useful for accessing the field via an interface.
+func (v *MyInput) GetRole() *Role { return v.Role }
+
+// GetNames returns MyInput.Names, and is useful for accessing the field via an interface.
+func (v *MyInput) GetNames() []*string { return v.Names }
+
+// GetHasPokemon returns MyInput.HasPokemon, and is useful for accessing the field via an interface.
+func (v *MyInput) GetHasPokemon() *testutil.Pokemon { return v.HasPokemon }
+
+// GetBirthdate returns MyInput.Birthdate, and is useful for accessing the field via an interface.
+func (v *MyInput) GetBirthdate() *time.Time { return v.Birthdate }
+
 func (v *MyInput) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -121,6 +142,14 @@ type MyMultipleDirectivesResponse struct {
 	Users []*MyMultipleDirectivesResponseUsersUser `json:"users"`
 }
 
+// GetUser returns MyMultipleDirectivesResponse.User, and is useful for accessing the field via an interface.
+func (v *MyMultipleDirectivesResponse) GetUser() *MyMultipleDirectivesResponseUser { return v.User }
+
+// GetUsers returns MyMultipleDirectivesResponse.Users, and is useful for accessing the field via an interface.
+func (v *MyMultipleDirectivesResponse) GetUsers() []*MyMultipleDirectivesResponseUsersUser {
+	return v.Users
+}
+
 // MyMultipleDirectivesResponseUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -132,6 +161,9 @@ type MyMultipleDirectivesResponseUser struct {
 	Id *testutil.ID `json:"id"`
 }
 
+// GetId returns MyMultipleDirectivesResponseUser.Id, and is useful for accessing the field via an interface.
+func (v *MyMultipleDirectivesResponseUser) GetId() *testutil.ID { return v.Id }
+
 // MyMultipleDirectivesResponseUsersUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -142,6 +174,9 @@ type MyMultipleDirectivesResponseUsersUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id *testutil.ID `json:"id"`
 }
+
+// GetId returns MyMultipleDirectivesResponseUsersUser.Id, and is useful for accessing the field via an interface.
+func (v *MyMultipleDirectivesResponseUsersUser) GetId() *testutil.ID { return v.Id }
 
 // Role is a type a user may have.
 type Role string
@@ -172,6 +207,27 @@ type UserQueryInput struct {
 	HasPokemon *testutil.Pokemon `json:"hasPokemon,omitempty"`
 	Birthdate  *time.Time        `json:"-"`
 }
+
+// GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetEmail() *string { return v.Email }
+
+// GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetName() *string { return v.Name }
+
+// GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetId() *testutil.ID { return v.Id }
+
+// GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetRole() *Role { return v.Role }
+
+// GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetNames() []*string { return v.Names }
+
+// GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetHasPokemon() *testutil.Pokemon { return v.HasPokemon }
+
+// GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetBirthdate() *time.Time { return v.Birthdate }
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -262,6 +318,12 @@ type __MultipleDirectivesInput struct {
 	Query   MyInput           `json:"query,omitempty"`
 	Queries []*UserQueryInput `json:"queries,omitempty"`
 }
+
+// GetQuery returns __MultipleDirectivesInput.Query, and is useful for accessing the field via an interface.
+func (v *__MultipleDirectivesInput) GetQuery() MyInput { return v.Query }
+
+// GetQueries returns __MultipleDirectivesInput.Queries, and is useful for accessing the field via an interface.
+func (v *__MultipleDirectivesInput) GetQueries() []*UserQueryInput { return v.Queries }
 
 func MultipleDirectives(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -23,6 +23,18 @@ type OmitEmptyQueryResponse struct {
 	Convert2     time.Time                 `json:"convert2"`
 }
 
+// GetUser returns OmitEmptyQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *OmitEmptyQueryResponse) GetUser() OmitEmptyQueryUser { return v.User }
+
+// GetUsers returns OmitEmptyQueryResponse.Users, and is useful for accessing the field via an interface.
+func (v *OmitEmptyQueryResponse) GetUsers() []OmitEmptyQueryUsersUser { return v.Users }
+
+// GetMaybeConvert returns OmitEmptyQueryResponse.MaybeConvert, and is useful for accessing the field via an interface.
+func (v *OmitEmptyQueryResponse) GetMaybeConvert() time.Time { return v.MaybeConvert }
+
+// GetConvert2 returns OmitEmptyQueryResponse.Convert2, and is useful for accessing the field via an interface.
+func (v *OmitEmptyQueryResponse) GetConvert2() time.Time { return v.Convert2 }
+
 // OmitEmptyQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -34,6 +46,9 @@ type OmitEmptyQueryUser struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetId returns OmitEmptyQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *OmitEmptyQueryUser) GetId() testutil.ID { return v.Id }
+
 // OmitEmptyQueryUsersUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -44,6 +59,9 @@ type OmitEmptyQueryUsersUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id testutil.ID `json:"id"`
 }
+
+// GetId returns OmitEmptyQueryUsersUser.Id, and is useful for accessing the field via an interface.
+func (v *OmitEmptyQueryUsersUser) GetId() testutil.ID { return v.Id }
 
 // Role is a type a user may have.
 type Role string
@@ -74,6 +92,27 @@ type UserQueryInput struct {
 	HasPokemon testutil.Pokemon `json:"hasPokemon,omitempty"`
 	Birthdate  time.Time        `json:"-"`
 }
+
+// GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetEmail() string { return v.Email }
+
+// GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetName() string { return v.Name }
+
+// GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+
+// GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetRole() Role { return v.Role }
+
+// GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetNames() []string { return v.Names }
+
+// GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+
+// GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -164,6 +203,21 @@ type __OmitEmptyQueryInput struct {
 	Tz            string           `json:"tz,omitempty"`
 	TzNoOmitEmpty string           `json:"tzNoOmitEmpty"`
 }
+
+// GetQuery returns __OmitEmptyQueryInput.Query, and is useful for accessing the field via an interface.
+func (v *__OmitEmptyQueryInput) GetQuery() UserQueryInput { return v.Query }
+
+// GetQueries returns __OmitEmptyQueryInput.Queries, and is useful for accessing the field via an interface.
+func (v *__OmitEmptyQueryInput) GetQueries() []UserQueryInput { return v.Queries }
+
+// GetDt returns __OmitEmptyQueryInput.Dt, and is useful for accessing the field via an interface.
+func (v *__OmitEmptyQueryInput) GetDt() time.Time { return v.Dt }
+
+// GetTz returns __OmitEmptyQueryInput.Tz, and is useful for accessing the field via an interface.
+func (v *__OmitEmptyQueryInput) GetTz() string { return v.Tz }
+
+// GetTzNoOmitEmpty returns __OmitEmptyQueryInput.TzNoOmitEmpty, and is useful for accessing the field via an interface.
+func (v *__OmitEmptyQueryInput) GetTzNoOmitEmpty() string { return v.TzNoOmitEmpty }
 
 func OmitEmptyQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -22,6 +22,9 @@ type PointersQueryOtherUser struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetId returns PointersQueryOtherUser.Id, and is useful for accessing the field via an interface.
+func (v *PointersQueryOtherUser) GetId() testutil.ID { return v.Id }
+
 // PointersQueryResponse is returned by PointersQuery on success.
 type PointersQueryResponse struct {
 	// user looks up a user by some stuff.
@@ -37,6 +40,15 @@ type PointersQueryResponse struct {
 	MaybeConvert *time.Time              `json:"maybeConvert"`
 }
 
+// GetUser returns PointersQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *PointersQueryResponse) GetUser() *PointersQueryUser { return v.User }
+
+// GetOtherUser returns PointersQueryResponse.OtherUser, and is useful for accessing the field via an interface.
+func (v *PointersQueryResponse) GetOtherUser() *PointersQueryOtherUser { return v.OtherUser }
+
+// GetMaybeConvert returns PointersQueryResponse.MaybeConvert, and is useful for accessing the field via an interface.
+func (v *PointersQueryResponse) GetMaybeConvert() *time.Time { return v.MaybeConvert }
+
 // PointersQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -51,6 +63,21 @@ type PointersQueryUser struct {
 	Emails      []*string    `json:"emails"`
 	EmailsNoPtr []string     `json:"emailsNoPtr"`
 }
+
+// GetId returns PointersQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetId() *testutil.ID { return v.Id }
+
+// GetRoles returns PointersQueryUser.Roles, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetRoles() []*Role { return v.Roles }
+
+// GetName returns PointersQueryUser.Name, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetName() *string { return v.Name }
+
+// GetEmails returns PointersQueryUser.Emails, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetEmails() []*string { return v.Emails }
+
+// GetEmailsNoPtr returns PointersQueryUser.EmailsNoPtr, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetEmailsNoPtr() []string { return v.EmailsNoPtr }
 
 // Role is a type a user may have.
 type Role string
@@ -81,6 +108,27 @@ type UserQueryInput struct {
 	HasPokemon *testutil.Pokemon `json:"hasPokemon"`
 	Birthdate  *time.Time        `json:"-"`
 }
+
+// GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetEmail() *string { return v.Email }
+
+// GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetName() *string { return v.Name }
+
+// GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+
+// GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetRole() *Role { return v.Role }
+
+// GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetNames() []*string { return v.Names }
+
+// GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetHasPokemon() *testutil.Pokemon { return v.HasPokemon }
+
+// GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetBirthdate() *time.Time { return v.Birthdate }
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -172,6 +220,15 @@ type __PointersQueryInput struct {
 	Dt    time.Time       `json:"dt"`
 	Tz    *string         `json:"tz"`
 }
+
+// GetQuery returns __PointersQueryInput.Query, and is useful for accessing the field via an interface.
+func (v *__PointersQueryInput) GetQuery() *UserQueryInput { return v.Query }
+
+// GetDt returns __PointersQueryInput.Dt, and is useful for accessing the field via an interface.
+func (v *__PointersQueryInput) GetDt() time.Time { return v.Dt }
+
+// GetTz returns __PointersQueryInput.Tz, and is useful for accessing the field via an interface.
+func (v *__PointersQueryInput) GetTz() *string { return v.Tz }
 
 func PointersQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -22,6 +22,9 @@ type PointersQueryOtherUser struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetId returns PointersQueryOtherUser.Id, and is useful for accessing the field via an interface.
+func (v *PointersQueryOtherUser) GetId() testutil.ID { return v.Id }
+
 // PointersQueryResponse is returned by PointersQuery on success.
 type PointersQueryResponse struct {
 	// user looks up a user by some stuff.
@@ -37,6 +40,15 @@ type PointersQueryResponse struct {
 	MaybeConvert time.Time               `json:"maybeConvert"`
 }
 
+// GetUser returns PointersQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *PointersQueryResponse) GetUser() *PointersQueryUser { return v.User }
+
+// GetOtherUser returns PointersQueryResponse.OtherUser, and is useful for accessing the field via an interface.
+func (v *PointersQueryResponse) GetOtherUser() *PointersQueryOtherUser { return v.OtherUser }
+
+// GetMaybeConvert returns PointersQueryResponse.MaybeConvert, and is useful for accessing the field via an interface.
+func (v *PointersQueryResponse) GetMaybeConvert() time.Time { return v.MaybeConvert }
+
 // PointersQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -51,6 +63,21 @@ type PointersQueryUser struct {
 	Emails      []*string   `json:"emails"`
 	EmailsNoPtr []*string   `json:"emailsNoPtr"`
 }
+
+// GetId returns PointersQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetId() testutil.ID { return v.Id }
+
+// GetRoles returns PointersQueryUser.Roles, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetRoles() []Role { return v.Roles }
+
+// GetName returns PointersQueryUser.Name, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetName() *string { return v.Name }
+
+// GetEmails returns PointersQueryUser.Emails, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetEmails() []*string { return v.Emails }
+
+// GetEmailsNoPtr returns PointersQueryUser.EmailsNoPtr, and is useful for accessing the field via an interface.
+func (v *PointersQueryUser) GetEmailsNoPtr() []*string { return v.EmailsNoPtr }
 
 // Role is a type a user may have.
 type Role string
@@ -81,6 +108,27 @@ type UserQueryInput struct {
 	HasPokemon testutil.Pokemon `json:"hasPokemon"`
 	Birthdate  time.Time        `json:"-"`
 }
+
+// GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetEmail() string { return v.Email }
+
+// GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetName() string { return v.Name }
+
+// GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+
+// GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetRole() Role { return v.Role }
+
+// GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetNames() []string { return v.Names }
+
+// GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+
+// GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -169,6 +217,15 @@ type __PointersQueryInput struct {
 	Dt    *time.Time      `json:"dt"`
 	Tz    string          `json:"tz"`
 }
+
+// GetQuery returns __PointersQueryInput.Query, and is useful for accessing the field via an interface.
+func (v *__PointersQueryInput) GetQuery() *UserQueryInput { return v.Query }
+
+// GetDt returns __PointersQueryInput.Dt, and is useful for accessing the field via an interface.
+func (v *__PointersQueryInput) GetDt() *time.Time { return v.Dt }
+
+// GetTz returns __PointersQueryInput.Tz, and is useful for accessing the field via an interface.
+func (v *__PointersQueryInput) GetTz() string { return v.Tz }
 
 func PointersQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
@@ -16,6 +16,9 @@ type GetPokemonSiblingsResponse struct {
 	User GetPokemonSiblingsUser `json:"user"`
 }
 
+// GetUser returns GetPokemonSiblingsResponse.User, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsResponse) GetUser() GetPokemonSiblingsUser { return v.User }
+
 // GetPokemonSiblingsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -31,16 +34,42 @@ type GetPokemonSiblingsUser struct {
 	GenqlientPokemon []GetPokemonSiblingsUserGenqlientPokemon `json:"genqlientPokemon"`
 }
 
+// GetId returns GetPokemonSiblingsUser.Id, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUser) GetId() string { return v.Id }
+
+// GetRoles returns GetPokemonSiblingsUser.Roles, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUser) GetRoles() []string { return v.Roles }
+
+// GetName returns GetPokemonSiblingsUser.Name, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUser) GetName() string { return v.Name }
+
+// GetPokemon returns GetPokemonSiblingsUser.Pokemon, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUser) GetPokemon() []testutil.Pokemon { return v.Pokemon }
+
+// GetGenqlientPokemon returns GetPokemonSiblingsUser.GenqlientPokemon, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUser) GetGenqlientPokemon() []GetPokemonSiblingsUserGenqlientPokemon {
+	return v.GenqlientPokemon
+}
+
 // GetPokemonSiblingsUserGenqlientPokemon includes the requested fields of the GraphQL type Pokemon.
 type GetPokemonSiblingsUserGenqlientPokemon struct {
 	Species string `json:"species"`
 	Level   int    `json:"level"`
 }
 
+// GetSpecies returns GetPokemonSiblingsUserGenqlientPokemon.Species, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUserGenqlientPokemon) GetSpecies() string { return v.Species }
+
+// GetLevel returns GetPokemonSiblingsUserGenqlientPokemon.Level, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUserGenqlientPokemon) GetLevel() int { return v.Level }
+
 // __GetPokemonSiblingsInput is used internally by genqlient
 type __GetPokemonSiblingsInput struct {
 	Input testutil.Pokemon `json:"input"`
 }
+
+// GetInput returns __GetPokemonSiblingsInput.Input, and is useful for accessing the field via an interface.
+func (v *__GetPokemonSiblingsInput) GetInput() testutil.Pokemon { return v.Input }
 
 func GetPokemonSiblings(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
@@ -16,6 +16,9 @@ type QueryWithAliasResponse struct {
 	User QueryWithAliasUser `json:"User"`
 }
 
+// GetUser returns QueryWithAliasResponse.User, and is useful for accessing the field via an interface.
+func (v *QueryWithAliasResponse) GetUser() QueryWithAliasUser { return v.User }
+
 // QueryWithAliasUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -30,6 +33,12 @@ type QueryWithAliasUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	OtherID testutil.ID `json:"otherID"`
 }
+
+// GetID returns QueryWithAliasUser.ID, and is useful for accessing the field via an interface.
+func (v *QueryWithAliasUser) GetID() testutil.ID { return v.ID }
+
+// GetOtherID returns QueryWithAliasUser.OtherID, and is useful for accessing the field via an interface.
+func (v *QueryWithAliasUser) GetOtherID() testutil.ID { return v.OtherID }
 
 func QueryWithAlias(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
@@ -16,6 +16,9 @@ type QueryWithDoubleAliasResponse struct {
 	User QueryWithDoubleAliasUser `json:"user"`
 }
 
+// GetUser returns QueryWithDoubleAliasResponse.User, and is useful for accessing the field via an interface.
+func (v *QueryWithDoubleAliasResponse) GetUser() QueryWithDoubleAliasUser { return v.User }
+
 // QueryWithDoubleAliasUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -30,6 +33,12 @@ type QueryWithDoubleAliasUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	AlsoID testutil.ID `json:"AlsoID"`
 }
+
+// GetID returns QueryWithDoubleAliasUser.ID, and is useful for accessing the field via an interface.
+func (v *QueryWithDoubleAliasUser) GetID() testutil.ID { return v.ID }
+
+// GetAlsoID returns QueryWithDoubleAliasUser.AlsoID, and is useful for accessing the field via an interface.
+func (v *QueryWithDoubleAliasUser) GetAlsoID() testutil.ID { return v.AlsoID }
 
 func QueryWithDoubleAlias(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
@@ -14,6 +14,9 @@ type QueryWithEnumsOtherUser struct {
 	Roles []Role `json:"roles"`
 }
 
+// GetRoles returns QueryWithEnumsOtherUser.Roles, and is useful for accessing the field via an interface.
+func (v *QueryWithEnumsOtherUser) GetRoles() []Role { return v.Roles }
+
 // QueryWithEnumsResponse is returned by QueryWithEnums on success.
 type QueryWithEnumsResponse struct {
 	// user looks up a user by some stuff.
@@ -28,6 +31,12 @@ type QueryWithEnumsResponse struct {
 	OtherUser QueryWithEnumsOtherUser `json:"otherUser"`
 }
 
+// GetUser returns QueryWithEnumsResponse.User, and is useful for accessing the field via an interface.
+func (v *QueryWithEnumsResponse) GetUser() QueryWithEnumsUser { return v.User }
+
+// GetOtherUser returns QueryWithEnumsResponse.OtherUser, and is useful for accessing the field via an interface.
+func (v *QueryWithEnumsResponse) GetOtherUser() QueryWithEnumsOtherUser { return v.OtherUser }
+
 // QueryWithEnumsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -35,6 +44,9 @@ type QueryWithEnumsResponse struct {
 type QueryWithEnumsUser struct {
 	Roles []Role `json:"roles"`
 }
+
+// GetRoles returns QueryWithEnumsUser.Roles, and is useful for accessing the field via an interface.
+func (v *QueryWithEnumsUser) GetRoles() []Role { return v.Roles }
 
 // Role is a type a user may have.
 type Role string

--- a/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
@@ -15,6 +15,9 @@ type QueryWithSlicesResponse struct {
 	User QueryWithSlicesUser `json:"user"`
 }
 
+// GetUser returns QueryWithSlicesResponse.User, and is useful for accessing the field via an interface.
+func (v *QueryWithSlicesResponse) GetUser() QueryWithSlicesUser { return v.User }
+
 // QueryWithSlicesUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -25,6 +28,18 @@ type QueryWithSlicesUser struct {
 	EmailsWithNulls       []string `json:"emailsWithNulls"`
 	EmailsWithNullsOrNull []string `json:"emailsWithNullsOrNull"`
 }
+
+// GetEmails returns QueryWithSlicesUser.Emails, and is useful for accessing the field via an interface.
+func (v *QueryWithSlicesUser) GetEmails() []string { return v.Emails }
+
+// GetEmailsOrNull returns QueryWithSlicesUser.EmailsOrNull, and is useful for accessing the field via an interface.
+func (v *QueryWithSlicesUser) GetEmailsOrNull() []string { return v.EmailsOrNull }
+
+// GetEmailsWithNulls returns QueryWithSlicesUser.EmailsWithNulls, and is useful for accessing the field via an interface.
+func (v *QueryWithSlicesUser) GetEmailsWithNulls() []string { return v.EmailsWithNulls }
+
+// GetEmailsWithNullsOrNull returns QueryWithSlicesUser.EmailsWithNullsOrNull, and is useful for accessing the field via an interface.
+func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []string { return v.EmailsWithNullsOrNull }
 
 func QueryWithSlices(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
@@ -15,6 +15,9 @@ type QueryWithStructsResponse struct {
 	User QueryWithStructsUser `json:"user"`
 }
 
+// GetUser returns QueryWithStructsResponse.User, and is useful for accessing the field via an interface.
+func (v *QueryWithStructsResponse) GetUser() QueryWithStructsUser { return v.User }
+
 // QueryWithStructsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -23,11 +26,22 @@ type QueryWithStructsUser struct {
 	AuthMethods []QueryWithStructsUserAuthMethodsAuthMethod `json:"authMethods"`
 }
 
+// GetAuthMethods returns QueryWithStructsUser.AuthMethods, and is useful for accessing the field via an interface.
+func (v *QueryWithStructsUser) GetAuthMethods() []QueryWithStructsUserAuthMethodsAuthMethod {
+	return v.AuthMethods
+}
+
 // QueryWithStructsUserAuthMethodsAuthMethod includes the requested fields of the GraphQL type AuthMethod.
 type QueryWithStructsUserAuthMethodsAuthMethod struct {
 	Provider string `json:"provider"`
 	Email    string `json:"email"`
 }
+
+// GetProvider returns QueryWithStructsUserAuthMethodsAuthMethod.Provider, and is useful for accessing the field via an interface.
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() string { return v.Provider }
+
+// GetEmail returns QueryWithStructsUserAuthMethodsAuthMethod.Email, and is useful for accessing the field via an interface.
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() string { return v.Email }
 
 func QueryWithStructs(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
@@ -12,9 +12,17 @@ type RecursionRecurRecursive struct {
 	Rec RecursionRecurRecursiveRecRecursive `json:"rec"`
 }
 
+// GetRec returns RecursionRecurRecursive.Rec, and is useful for accessing the field via an interface.
+func (v *RecursionRecurRecursive) GetRec() RecursionRecurRecursiveRecRecursive { return v.Rec }
+
 // RecursionRecurRecursiveRecRecursive includes the requested fields of the GraphQL type Recursive.
 type RecursionRecurRecursiveRecRecursive struct {
 	Rec RecursionRecurRecursiveRecRecursiveRecRecursive `json:"rec"`
+}
+
+// GetRec returns RecursionRecurRecursiveRecRecursive.Rec, and is useful for accessing the field via an interface.
+func (v *RecursionRecurRecursiveRecRecursive) GetRec() RecursionRecurRecursiveRecRecursiveRecRecursive {
+	return v.Rec
 }
 
 // RecursionRecurRecursiveRecRecursiveRecRecursive includes the requested fields of the GraphQL type Recursive.
@@ -22,9 +30,19 @@ type RecursionRecurRecursiveRecRecursiveRecRecursive struct {
 	Rec RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive `json:"rec"`
 }
 
+// GetRec returns RecursionRecurRecursiveRecRecursiveRecRecursive.Rec, and is useful for accessing the field via an interface.
+func (v *RecursionRecurRecursiveRecRecursiveRecRecursive) GetRec() RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive {
+	return v.Rec
+}
+
 // RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive includes the requested fields of the GraphQL type Recursive.
 type RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive struct {
 	Id testutil.ID `json:"id"`
+}
+
+// GetId returns RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive.Id, and is useful for accessing the field via an interface.
+func (v *RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive) GetId() testutil.ID {
+	return v.Id
 }
 
 // RecursionResponse is returned by Recursion on success.
@@ -32,14 +50,23 @@ type RecursionResponse struct {
 	Recur RecursionRecurRecursive `json:"recur"`
 }
 
+// GetRecur returns RecursionResponse.Recur, and is useful for accessing the field via an interface.
+func (v *RecursionResponse) GetRecur() RecursionRecurRecursive { return v.Recur }
+
 type RecursiveInput struct {
 	Rec []RecursiveInput `json:"rec"`
 }
+
+// GetRec returns RecursiveInput.Rec, and is useful for accessing the field via an interface.
+func (v *RecursiveInput) GetRec() []RecursiveInput { return v.Rec }
 
 // __RecursionInput is used internally by genqlient
 type __RecursionInput struct {
 	Input RecursiveInput `json:"input"`
 }
+
+// GetInput returns __RecursionInput.Input, and is useful for accessing the field via an interface.
+func (v *__RecursionInput) GetInput() RecursiveInput { return v.Input }
 
 func Recursion(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -19,6 +19,18 @@ type SimpleInlineFragmentRandomItemArticle struct {
 	Text string      `json:"text"`
 }
 
+// GetTypename returns SimpleInlineFragmentRandomItemArticle.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemArticle) GetTypename() string { return v.Typename }
+
+// GetId returns SimpleInlineFragmentRandomItemArticle.Id, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns SimpleInlineFragmentRandomItemArticle.Name, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemArticle) GetName() string { return v.Name }
+
+// GetText returns SimpleInlineFragmentRandomItemArticle.Text, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemArticle) GetText() string { return v.Text }
+
 // SimpleInlineFragmentRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
 // SimpleInlineFragmentRandomItemContent is implemented by the following types:
@@ -43,39 +55,10 @@ type SimpleInlineFragmentRandomItemContent interface {
 
 func (v *SimpleInlineFragmentRandomItemArticle) implementsGraphQLInterfaceSimpleInlineFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemArticle) GetName() string { return v.Name }
-
 func (v *SimpleInlineFragmentRandomItemVideo) implementsGraphQLInterfaceSimpleInlineFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemVideo) GetName() string { return v.Name }
-
 func (v *SimpleInlineFragmentRandomItemTopic) implementsGraphQLInterfaceSimpleInlineFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface SimpleInlineFragmentRandomItemContent.
-func (v *SimpleInlineFragmentRandomItemTopic) GetName() string { return v.Name }
 
 func __unmarshalSimpleInlineFragmentRandomItemContent(b []byte, v *SimpleInlineFragmentRandomItemContent) error {
 	if string(b) == "null" {
@@ -153,6 +136,15 @@ type SimpleInlineFragmentRandomItemTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns SimpleInlineFragmentRandomItemTopic.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemTopic) GetTypename() string { return v.Typename }
+
+// GetId returns SimpleInlineFragmentRandomItemTopic.Id, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns SimpleInlineFragmentRandomItemTopic.Name, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemTopic) GetName() string { return v.Name }
+
 // SimpleInlineFragmentRandomItemVideo includes the requested fields of the GraphQL type Video.
 type SimpleInlineFragmentRandomItemVideo struct {
 	Typename string `json:"__typename"`
@@ -162,9 +154,26 @@ type SimpleInlineFragmentRandomItemVideo struct {
 	Duration int         `json:"duration"`
 }
 
+// GetTypename returns SimpleInlineFragmentRandomItemVideo.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemVideo) GetTypename() string { return v.Typename }
+
+// GetId returns SimpleInlineFragmentRandomItemVideo.Id, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns SimpleInlineFragmentRandomItemVideo.Name, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemVideo) GetName() string { return v.Name }
+
+// GetDuration returns SimpleInlineFragmentRandomItemVideo.Duration, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentRandomItemVideo) GetDuration() int { return v.Duration }
+
 // SimpleInlineFragmentResponse is returned by SimpleInlineFragment on success.
 type SimpleInlineFragmentResponse struct {
 	RandomItem SimpleInlineFragmentRandomItemContent `json:"-"`
+}
+
+// GetRandomItem returns SimpleInlineFragmentResponse.RandomItem, and is useful for accessing the field via an interface.
+func (v *SimpleInlineFragmentResponse) GetRandomItem() SimpleInlineFragmentRandomItemContent {
+	return v.RandomItem
 }
 
 func (v *SimpleInlineFragmentResponse) UnmarshalJSON(b []byte) error {

--- a/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
@@ -16,6 +16,9 @@ type SimpleInputQueryResponse struct {
 	User SimpleInputQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleInputQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleInputQueryResponse) GetUser() SimpleInputQueryUser { return v.User }
+
 // SimpleInputQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,10 +30,16 @@ type SimpleInputQueryUser struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetId returns SimpleInputQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleInputQueryUser) GetId() testutil.ID { return v.Id }
+
 // __SimpleInputQueryInput is used internally by genqlient
 type __SimpleInputQueryInput struct {
 	Name string `json:"name"`
 }
+
+// GetName returns __SimpleInputQueryInput.Name, and is useful for accessing the field via an interface.
+func (v *__SimpleInputQueryInput) GetName() string { return v.Name }
 
 func SimpleInputQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
@@ -19,15 +19,27 @@ type SimpleMutationCreateUser struct {
 	Name string      `json:"name"`
 }
 
+// GetId returns SimpleMutationCreateUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleMutationCreateUser) GetId() testutil.ID { return v.Id }
+
+// GetName returns SimpleMutationCreateUser.Name, and is useful for accessing the field via an interface.
+func (v *SimpleMutationCreateUser) GetName() string { return v.Name }
+
 // SimpleMutationResponse is returned by SimpleMutation on success.
 type SimpleMutationResponse struct {
 	CreateUser SimpleMutationCreateUser `json:"createUser"`
 }
 
+// GetCreateUser returns SimpleMutationResponse.CreateUser, and is useful for accessing the field via an interface.
+func (v *SimpleMutationResponse) GetCreateUser() SimpleMutationCreateUser { return v.CreateUser }
+
 // __SimpleMutationInput is used internally by genqlient
 type __SimpleMutationInput struct {
 	Name string `json:"name"`
 }
+
+// GetName returns __SimpleMutationInput.Name, and is useful for accessing the field via an interface.
+func (v *__SimpleMutationInput) GetName() string { return v.Name }
 
 // SimpleMutation creates a user.
 //

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -18,6 +18,15 @@ type SimpleNamedFragmentRandomItemArticle struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns SimpleNamedFragmentRandomItemArticle.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemArticle) GetTypename() string { return v.Typename }
+
+// GetId returns SimpleNamedFragmentRandomItemArticle.Id, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns SimpleNamedFragmentRandomItemArticle.Name, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemArticle) GetName() string { return v.Name }
+
 // SimpleNamedFragmentRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
 // SimpleNamedFragmentRandomItemContent is implemented by the following types:
@@ -42,39 +51,10 @@ type SimpleNamedFragmentRandomItemContent interface {
 
 func (v *SimpleNamedFragmentRandomItemArticle) implementsGraphQLInterfaceSimpleNamedFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemArticle) GetName() string { return v.Name }
-
 func (v *SimpleNamedFragmentRandomItemVideo) implementsGraphQLInterfaceSimpleNamedFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemVideo) GetName() string { return v.Name }
-
 func (v *SimpleNamedFragmentRandomItemTopic) implementsGraphQLInterfaceSimpleNamedFragmentRandomItemContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface SimpleNamedFragmentRandomItemContent.
-func (v *SimpleNamedFragmentRandomItemTopic) GetName() string { return v.Name }
 
 func __unmarshalSimpleNamedFragmentRandomItemContent(b []byte, v *SimpleNamedFragmentRandomItemContent) error {
 	if string(b) == "null" {
@@ -156,6 +136,15 @@ type SimpleNamedFragmentRandomItemTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns SimpleNamedFragmentRandomItemTopic.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemTopic) GetTypename() string { return v.Typename }
+
+// GetId returns SimpleNamedFragmentRandomItemTopic.Id, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns SimpleNamedFragmentRandomItemTopic.Name, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemTopic) GetName() string { return v.Name }
+
 // SimpleNamedFragmentRandomItemVideo includes the requested fields of the GraphQL type Video.
 type SimpleNamedFragmentRandomItemVideo struct {
 	Typename string `json:"__typename"`
@@ -163,6 +152,26 @@ type SimpleNamedFragmentRandomItemVideo struct {
 	Id          testutil.ID `json:"id"`
 	Name        string      `json:"name"`
 	VideoFields `json:"-"`
+}
+
+// GetTypename returns SimpleNamedFragmentRandomItemVideo.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemVideo) GetTypename() string { return v.Typename }
+
+// GetId returns SimpleNamedFragmentRandomItemVideo.Id, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns SimpleNamedFragmentRandomItemVideo.Name, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemVideo) GetName() string { return v.Name }
+
+// GetUrl returns SimpleNamedFragmentRandomItemVideo.Url, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemVideo) GetUrl() string { return v.VideoFields.Url }
+
+// GetDuration returns SimpleNamedFragmentRandomItemVideo.Duration, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemVideo) GetDuration() int { return v.VideoFields.Duration }
+
+// GetThumbnail returns SimpleNamedFragmentRandomItemVideo.Thumbnail, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomItemVideo) GetThumbnail() VideoFieldsThumbnail {
+	return v.VideoFields.Thumbnail
 }
 
 func (v *SimpleNamedFragmentRandomItemVideo) UnmarshalJSON(b []byte) error {
@@ -229,6 +238,9 @@ type SimpleNamedFragmentRandomLeafArticle struct {
 	Typename string `json:"__typename"`
 }
 
+// GetTypename returns SimpleNamedFragmentRandomLeafArticle.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomLeafArticle) GetTypename() string { return v.Typename }
+
 // SimpleNamedFragmentRandomLeafLeafContent includes the requested fields of the GraphQL interface LeafContent.
 //
 // SimpleNamedFragmentRandomLeafLeafContent is implemented by the following types:
@@ -245,15 +257,8 @@ type SimpleNamedFragmentRandomLeafLeafContent interface {
 
 func (v *SimpleNamedFragmentRandomLeafArticle) implementsGraphQLInterfaceSimpleNamedFragmentRandomLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleNamedFragmentRandomLeafLeafContent.
-func (v *SimpleNamedFragmentRandomLeafArticle) GetTypename() string { return v.Typename }
-
 func (v *SimpleNamedFragmentRandomLeafVideo) implementsGraphQLInterfaceSimpleNamedFragmentRandomLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface SimpleNamedFragmentRandomLeafLeafContent.
-func (v *SimpleNamedFragmentRandomLeafVideo) GetTypename() string { return v.Typename }
 
 func __unmarshalSimpleNamedFragmentRandomLeafLeafContent(b []byte, v *SimpleNamedFragmentRandomLeafLeafContent) error {
 	if string(b) == "null" {
@@ -322,6 +327,26 @@ type SimpleNamedFragmentRandomLeafVideo struct {
 	VideoFields `json:"-"`
 }
 
+// GetTypename returns SimpleNamedFragmentRandomLeafVideo.Typename, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomLeafVideo) GetTypename() string { return v.Typename }
+
+// GetId returns SimpleNamedFragmentRandomLeafVideo.Id, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomLeafVideo) GetId() testutil.ID { return v.VideoFields.Id }
+
+// GetName returns SimpleNamedFragmentRandomLeafVideo.Name, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomLeafVideo) GetName() string { return v.VideoFields.Name }
+
+// GetUrl returns SimpleNamedFragmentRandomLeafVideo.Url, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomLeafVideo) GetUrl() string { return v.VideoFields.Url }
+
+// GetDuration returns SimpleNamedFragmentRandomLeafVideo.Duration, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomLeafVideo) GetDuration() int { return v.VideoFields.Duration }
+
+// GetThumbnail returns SimpleNamedFragmentRandomLeafVideo.Thumbnail, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentRandomLeafVideo) GetThumbnail() VideoFieldsThumbnail {
+	return v.VideoFields.Thumbnail
+}
+
 func (v *SimpleNamedFragmentRandomLeafVideo) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -385,6 +410,16 @@ func (v *SimpleNamedFragmentRandomLeafVideo) __premarshalJSON() (*__premarshalSi
 type SimpleNamedFragmentResponse struct {
 	RandomItem SimpleNamedFragmentRandomItemContent     `json:"-"`
 	RandomLeaf SimpleNamedFragmentRandomLeafLeafContent `json:"-"`
+}
+
+// GetRandomItem returns SimpleNamedFragmentResponse.RandomItem, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentResponse) GetRandomItem() SimpleNamedFragmentRandomItemContent {
+	return v.RandomItem
+}
+
+// GetRandomLeaf returns SimpleNamedFragmentResponse.RandomLeaf, and is useful for accessing the field via an interface.
+func (v *SimpleNamedFragmentResponse) GetRandomLeaf() SimpleNamedFragmentRandomLeafLeafContent {
+	return v.RandomLeaf
 }
 
 func (v *SimpleNamedFragmentResponse) UnmarshalJSON(b []byte) error {
@@ -488,10 +523,28 @@ type VideoFields struct {
 	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
 }
 
+// GetId returns VideoFields.Id, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetId() testutil.ID { return v.Id }
+
+// GetName returns VideoFields.Name, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetName() string { return v.Name }
+
+// GetUrl returns VideoFields.Url, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetUrl() string { return v.Url }
+
+// GetDuration returns VideoFields.Duration, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetDuration() int { return v.Duration }
+
+// GetThumbnail returns VideoFields.Thumbnail, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetThumbnail() VideoFieldsThumbnail { return v.Thumbnail }
+
 // VideoFieldsThumbnail includes the requested fields of the GraphQL type Thumbnail.
 type VideoFieldsThumbnail struct {
 	Id testutil.ID `json:"id"`
 }
+
+// GetId returns VideoFieldsThumbnail.Id, and is useful for accessing the field via an interface.
+func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
 func SimpleNamedFragment(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
@@ -16,6 +16,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -26,6 +29,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id testutil.ID `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
 
 func SimpleQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -34,11 +34,25 @@ type StructOptionResponse struct {
 	User StructOptionUser `json:"user"`
 }
 
+// GetRoot returns StructOptionResponse.Root, and is useful for accessing the field via an interface.
+func (v *StructOptionResponse) GetRoot() StructOptionRootTopic { return v.Root }
+
+// GetUser returns StructOptionResponse.User, and is useful for accessing the field via an interface.
+func (v *StructOptionResponse) GetUser() StructOptionUser { return v.User }
+
 // StructOptionRootTopic includes the requested fields of the GraphQL type Topic.
 type StructOptionRootTopic struct {
 	// ID is documented in the Content interface.
 	Id       testutil.ID                            `json:"id"`
 	Children []StructOptionRootTopicChildrenContent `json:"children"`
+}
+
+// GetId returns StructOptionRootTopic.Id, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopic) GetId() testutil.ID { return v.Id }
+
+// GetChildren returns StructOptionRootTopic.Children, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopic) GetChildren() []StructOptionRootTopicChildrenContent {
+	return v.Children
 }
 
 // StructOptionRootTopicChildrenContent includes the requested fields of the GraphQL type Content.
@@ -52,12 +66,36 @@ type StructOptionRootTopicChildrenContent struct {
 	Parent StructOptionRootTopicChildrenContentParentTopic `json:"parent"`
 }
 
+// GetTypename returns StructOptionRootTopicChildrenContent.Typename, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContent) GetTypename() string { return v.Typename }
+
+// GetId returns StructOptionRootTopicChildrenContent.Id, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContent) GetId() testutil.ID { return v.Id }
+
+// GetParent returns StructOptionRootTopicChildrenContent.Parent, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContent) GetParent() StructOptionRootTopicChildrenContentParentTopic {
+	return v.Parent
+}
+
 // StructOptionRootTopicChildrenContentParentTopic includes the requested fields of the GraphQL type Topic.
 type StructOptionRootTopicChildrenContentParentTopic struct {
 	// ID is documented in the Content interface.
 	Id                testutil.ID                                                               `json:"id"`
 	Children          []StructOptionRootTopicChildrenContentParentTopicChildrenContent          `json:"children"`
 	InterfaceChildren []StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent `json:"-"`
+}
+
+// GetId returns StructOptionRootTopicChildrenContentParentTopic.Id, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopic) GetId() testutil.ID { return v.Id }
+
+// GetChildren returns StructOptionRootTopicChildrenContentParentTopic.Children, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopic) GetChildren() []StructOptionRootTopicChildrenContentParentTopicChildrenContent {
+	return v.Children
+}
+
+// GetInterfaceChildren returns StructOptionRootTopicChildrenContentParentTopic.InterfaceChildren, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopic) GetInterfaceChildren() []StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent {
+	return v.InterfaceChildren
 }
 
 func (v *StructOptionRootTopicChildrenContentParentTopic) UnmarshalJSON(b []byte) error {
@@ -151,11 +189,31 @@ type StructOptionRootTopicChildrenContentParentTopicChildrenContent struct {
 	Id testutil.ID `json:"id"`
 }
 
+// GetTypename returns StructOptionRootTopicChildrenContentParentTopicChildrenContent.Typename, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicChildrenContent) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns StructOptionRootTopicChildrenContentParentTopicChildrenContent.Id, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicChildrenContent) GetId() testutil.ID {
+	return v.Id
+}
+
 // StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle includes the requested fields of the GraphQL type Article.
 type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle struct {
 	Typename string `json:"__typename"`
 	// ID is the identifier of the content.
 	Id testutil.ID `json:"id"`
+}
+
+// GetTypename returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle.Typename, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle.Id, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetId() testutil.ID {
+	return v.Id
 }
 
 // StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent includes the requested fields of the GraphQL interface Content.
@@ -180,41 +238,9 @@ type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent int
 
 func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) implementsGraphQLInterfaceStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetId() testutil.ID {
-	return v.Id
-}
-
 func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) implementsGraphQLInterfaceStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetId() testutil.ID {
-	return v.Id
-}
-
 func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) implementsGraphQLInterfaceStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent() {
-}
-
-// GetTypename is a part of, and documented with, the interface StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetTypename() string {
-	return v.Typename
-}
-
-// GetId is a part of, and documented with, the interface StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetId() testutil.ID {
-	return v.Id
 }
 
 func __unmarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent(b []byte, v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent) error {
@@ -296,12 +322,37 @@ type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic struc
 	Id testutil.ID `json:"id"`
 }
 
+// GetTypename returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic.Typename, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic.Id, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetId() testutil.ID {
+	return v.Id
+}
+
 // StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo includes the requested fields of the GraphQL type Video.
 type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo struct {
 	Typename string `json:"__typename"`
 	// ID is the identifier of the content.
 	Id          testutil.ID `json:"id"`
 	VideoFields `json:"-"`
+}
+
+// GetTypename returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo.Typename, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetTypename() string {
+	return v.Typename
+}
+
+// GetId returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo.Id, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetId() testutil.ID {
+	return v.Id
+}
+
+// GetDuration returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo.Duration, and is useful for accessing the field via an interface.
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetDuration() int {
+	return v.VideoFields.Duration
 }
 
 func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) UnmarshalJSON(b []byte) error {
@@ -362,10 +413,16 @@ type StructOptionUser struct {
 	Roles []Role `json:"roles"`
 }
 
+// GetRoles returns StructOptionUser.Roles, and is useful for accessing the field via an interface.
+func (v *StructOptionUser) GetRoles() []Role { return v.Roles }
+
 // VideoFields includes the GraphQL fields of Video requested by the fragment VideoFields.
 type VideoFields struct {
 	Duration int `json:"duration"`
 }
+
+// GetDuration returns VideoFields.Duration, and is useful for accessing the field via an interface.
+func (v *VideoFields) GetDuration() int { return v.Duration }
 
 func StructOption(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
@@ -16,6 +16,9 @@ type TypeNameQueryResponse struct {
 	User TypeNameQueryUser `json:"user"`
 }
 
+// GetUser returns TypeNameQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *TypeNameQueryResponse) GetUser() TypeNameQueryUser { return v.User }
+
 // TypeNameQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,12 @@ type TypeNameQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id testutil.ID `json:"id"`
 }
+
+// GetTypename returns TypeNameQueryUser.Typename, and is useful for accessing the field via an interface.
+func (v *TypeNameQueryUser) GetTypename() string { return v.Typename }
+
+// GetId returns TypeNameQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *TypeNameQueryUser) GetId() testutil.ID { return v.Id }
 
 func TypeNameQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -33,37 +33,8 @@ type Item interface {
 }
 
 func (v *ItemArticle) implementsGraphQLInterfaceItem() {}
-
-// GetTypename is a part of, and documented with, the interface Item.
-func (v *ItemArticle) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface Item.
-func (v *ItemArticle) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface Item.
-func (v *ItemArticle) GetName() string { return v.Name }
-
-func (v *ItemVideo) implementsGraphQLInterfaceItem() {}
-
-// GetTypename is a part of, and documented with, the interface Item.
-func (v *ItemVideo) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface Item.
-func (v *ItemVideo) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface Item.
-func (v *ItemVideo) GetName() string { return v.Name }
-
-func (v *ItemTopic) implementsGraphQLInterfaceItem() {}
-
-// GetTypename is a part of, and documented with, the interface Item.
-func (v *ItemTopic) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface Item.
-func (v *ItemTopic) GetId() testutil.ID { return v.Id }
-
-// GetName is a part of, and documented with, the interface Item.
-func (v *ItemTopic) GetName() string { return v.Name }
+func (v *ItemVideo) implementsGraphQLInterfaceItem()   {}
+func (v *ItemTopic) implementsGraphQLInterfaceItem()   {}
 
 func __unmarshalItem(b []byte, v *Item) error {
 	if string(b) == "null" {
@@ -141,6 +112,15 @@ type ItemArticle struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns ItemArticle.Typename, and is useful for accessing the field via an interface.
+func (v *ItemArticle) GetTypename() string { return v.Typename }
+
+// GetId returns ItemArticle.Id, and is useful for accessing the field via an interface.
+func (v *ItemArticle) GetId() testutil.ID { return v.Id }
+
+// GetName returns ItemArticle.Name, and is useful for accessing the field via an interface.
+func (v *ItemArticle) GetName() string { return v.Name }
+
 // ItemTopic includes the requested fields of the GraphQL type Topic.
 type ItemTopic struct {
 	Typename string `json:"__typename"`
@@ -149,6 +129,15 @@ type ItemTopic struct {
 	Name string      `json:"name"`
 }
 
+// GetTypename returns ItemTopic.Typename, and is useful for accessing the field via an interface.
+func (v *ItemTopic) GetTypename() string { return v.Typename }
+
+// GetId returns ItemTopic.Id, and is useful for accessing the field via an interface.
+func (v *ItemTopic) GetId() testutil.ID { return v.Id }
+
+// GetName returns ItemTopic.Name, and is useful for accessing the field via an interface.
+func (v *ItemTopic) GetName() string { return v.Name }
+
 // ItemVideo includes the requested fields of the GraphQL type Video.
 type ItemVideo struct {
 	Typename string `json:"__typename"`
@@ -156,6 +145,15 @@ type ItemVideo struct {
 	Id   testutil.ID `json:"id"`
 	Name string      `json:"name"`
 }
+
+// GetTypename returns ItemVideo.Typename, and is useful for accessing the field via an interface.
+func (v *ItemVideo) GetTypename() string { return v.Typename }
+
+// GetId returns ItemVideo.Id, and is useful for accessing the field via an interface.
+func (v *ItemVideo) GetId() testutil.ID { return v.Id }
+
+// GetName returns ItemVideo.Name, and is useful for accessing the field via an interface.
+func (v *ItemVideo) GetName() string { return v.Name }
 
 // Resp is returned by TypeNames on success.
 type Resp struct {
@@ -167,6 +165,15 @@ type Resp struct {
 	RandomItem Item   `json:"-"`
 	Users      []User `json:"users"`
 }
+
+// GetUser returns Resp.User, and is useful for accessing the field via an interface.
+func (v *Resp) GetUser() User { return v.User }
+
+// GetRandomItem returns Resp.RandomItem, and is useful for accessing the field via an interface.
+func (v *Resp) GetRandomItem() Item { return v.RandomItem }
+
+// GetUsers returns Resp.Users, and is useful for accessing the field via an interface.
+func (v *Resp) GetUsers() []User { return v.Users }
 
 func (v *Resp) UnmarshalJSON(b []byte) error {
 
@@ -248,6 +255,12 @@ type User struct {
 	Id   testutil.ID `json:"id"`
 	Name string      `json:"name"`
 }
+
+// GetId returns User.Id, and is useful for accessing the field via an interface.
+func (v *User) GetId() testutil.ID { return v.Id }
+
+// GetName returns User.Name, and is useful for accessing the field via an interface.
+func (v *User) GetName() string { return v.Name }
 
 func TypeNames(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -14,6 +14,9 @@ type UnionNoFragmentsQueryRandomLeafArticle struct {
 	Typename string `json:"__typename"`
 }
 
+// GetTypename returns UnionNoFragmentsQueryRandomLeafArticle.Typename, and is useful for accessing the field via an interface.
+func (v *UnionNoFragmentsQueryRandomLeafArticle) GetTypename() string { return v.Typename }
+
 // UnionNoFragmentsQueryRandomLeafLeafContent includes the requested fields of the GraphQL interface LeafContent.
 //
 // UnionNoFragmentsQueryRandomLeafLeafContent is implemented by the following types:
@@ -30,15 +33,8 @@ type UnionNoFragmentsQueryRandomLeafLeafContent interface {
 
 func (v *UnionNoFragmentsQueryRandomLeafArticle) implementsGraphQLInterfaceUnionNoFragmentsQueryRandomLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface UnionNoFragmentsQueryRandomLeafLeafContent.
-func (v *UnionNoFragmentsQueryRandomLeafArticle) GetTypename() string { return v.Typename }
-
 func (v *UnionNoFragmentsQueryRandomLeafVideo) implementsGraphQLInterfaceUnionNoFragmentsQueryRandomLeafLeafContent() {
 }
-
-// GetTypename is a part of, and documented with, the interface UnionNoFragmentsQueryRandomLeafLeafContent.
-func (v *UnionNoFragmentsQueryRandomLeafVideo) GetTypename() string { return v.Typename }
 
 func __unmarshalUnionNoFragmentsQueryRandomLeafLeafContent(b []byte, v *UnionNoFragmentsQueryRandomLeafLeafContent) error {
 	if string(b) == "null" {
@@ -102,9 +98,17 @@ type UnionNoFragmentsQueryRandomLeafVideo struct {
 	Typename string `json:"__typename"`
 }
 
+// GetTypename returns UnionNoFragmentsQueryRandomLeafVideo.Typename, and is useful for accessing the field via an interface.
+func (v *UnionNoFragmentsQueryRandomLeafVideo) GetTypename() string { return v.Typename }
+
 // UnionNoFragmentsQueryResponse is returned by UnionNoFragmentsQuery on success.
 type UnionNoFragmentsQueryResponse struct {
 	RandomLeaf UnionNoFragmentsQueryRandomLeafLeafContent `json:"-"`
+}
+
+// GetRandomLeaf returns UnionNoFragmentsQueryResponse.RandomLeaf, and is useful for accessing the field via an interface.
+func (v *UnionNoFragmentsQueryResponse) GetRandomLeaf() UnionNoFragmentsQueryRandomLeafLeafContent {
+	return v.RandomLeaf
 }
 
 func (v *UnionNoFragmentsQueryResponse) UnmarshalJSON(b []byte) error {

--- a/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
@@ -28,6 +28,9 @@ type UsesEnumTwiceQueryMeUser struct {
 	Roles []Role `json:"roles"`
 }
 
+// GetRoles returns UsesEnumTwiceQueryMeUser.Roles, and is useful for accessing the field via an interface.
+func (v *UsesEnumTwiceQueryMeUser) GetRoles() []Role { return v.Roles }
+
 // UsesEnumTwiceQueryOtherUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -35,6 +38,9 @@ type UsesEnumTwiceQueryMeUser struct {
 type UsesEnumTwiceQueryOtherUser struct {
 	Roles []Role `json:"roles"`
 }
+
+// GetRoles returns UsesEnumTwiceQueryOtherUser.Roles, and is useful for accessing the field via an interface.
+func (v *UsesEnumTwiceQueryOtherUser) GetRoles() []Role { return v.Roles }
 
 // UsesEnumTwiceQueryResponse is returned by UsesEnumTwiceQuery on success.
 type UsesEnumTwiceQueryResponse struct {
@@ -49,6 +55,12 @@ type UsesEnumTwiceQueryResponse struct {
 	// If query is null, returns the current user.
 	OtherUser UsesEnumTwiceQueryOtherUser `json:"OtherUser"`
 }
+
+// GetMe returns UsesEnumTwiceQueryResponse.Me, and is useful for accessing the field via an interface.
+func (v *UsesEnumTwiceQueryResponse) GetMe() UsesEnumTwiceQueryMeUser { return v.Me }
+
+// GetOtherUser returns UsesEnumTwiceQueryResponse.OtherUser, and is useful for accessing the field via an interface.
+func (v *UsesEnumTwiceQueryResponse) GetOtherUser() UsesEnumTwiceQueryOtherUser { return v.OtherUser }
 
 func UsesEnumTwiceQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -41,6 +41,27 @@ type UserQueryInput struct {
 	Birthdate  time.Time        `json:"-"`
 }
 
+// GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetEmail() string { return v.Email }
+
+// GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetName() string { return v.Name }
+
+// GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+
+// GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetRole() Role { return v.Role }
+
+// GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetNames() []string { return v.Names }
+
+// GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+
+// GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
+func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
+
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -127,6 +148,9 @@ type __unexportedInput struct {
 	Query UserQueryInput `json:"query"`
 }
 
+// GetQuery returns __unexportedInput.Query, and is useful for accessing the field via an interface.
+func (v *__unexportedInput) GetQuery() UserQueryInput { return v.Query }
+
 // unexportedResponse is returned by unexported on success.
 type unexportedResponse struct {
 	// user looks up a user by some stuff.
@@ -135,6 +159,9 @@ type unexportedResponse struct {
 	// If query is null, returns the current user.
 	User unexportedUser `json:"user"`
 }
+
+// GetUser returns unexportedResponse.User, and is useful for accessing the field via an interface.
+func (v *unexportedResponse) GetUser() unexportedUser { return v.User }
 
 // unexportedUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -146,6 +173,9 @@ type unexportedUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id testutil.ID `json:"id"`
 }
+
+// GetId returns unexportedUser.Id, and is useful for accessing the field via an interface.
+func (v *unexportedUser) GetId() testutil.ID { return v.Id }
 
 func unexported(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
@@ -17,6 +17,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx context.Context,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
@@ -20,6 +20,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -30,6 +33,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx testutil.MyContext,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
@@ -15,6 +15,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -25,6 +28,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery() (*SimpleQueryResponse, error) {
 	var err error

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
@@ -21,6 +21,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -31,6 +34,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx testutil.MyContext,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
@@ -17,6 +17,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx context.Context,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
@@ -17,6 +17,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx context.Context,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
@@ -15,6 +15,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -25,6 +28,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	client graphql.Client,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
@@ -17,6 +17,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx context.Context,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
@@ -17,6 +17,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx context.Context,

--- a/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
@@ -17,6 +17,9 @@ type SimpleQueryResponse struct {
 	User SimpleQueryUser `json:"user"`
 }
 
+// GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
+func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //
@@ -27,6 +30,9 @@ type SimpleQueryUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id string `json:"id"`
 }
+
+// GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
+func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 func SimpleQuery(
 	ctx context.Context,

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -19,6 +19,15 @@ type AnimalFields struct {
 	Owner AnimalFieldsOwnerBeing     `json:"-"`
 }
 
+// GetId returns AnimalFields.Id, and is useful for accessing the field via an interface.
+func (v *AnimalFields) GetId() string { return v.Id }
+
+// GetHair returns AnimalFields.Hair, and is useful for accessing the field via an interface.
+func (v *AnimalFields) GetHair() AnimalFieldsHairBeingsHair { return v.Hair }
+
+// GetOwner returns AnimalFields.Owner, and is useful for accessing the field via an interface.
+func (v *AnimalFields) GetOwner() AnimalFieldsOwnerBeing { return v.Owner }
+
 func (v *AnimalFields) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -93,11 +102,20 @@ type AnimalFieldsHairBeingsHair struct {
 	HasHair bool `json:"hasHair"`
 }
 
+// GetHasHair returns AnimalFieldsHairBeingsHair.HasHair, and is useful for accessing the field via an interface.
+func (v *AnimalFieldsHairBeingsHair) GetHasHair() bool { return v.HasHair }
+
 // AnimalFieldsOwnerAnimal includes the requested fields of the GraphQL type Animal.
 type AnimalFieldsOwnerAnimal struct {
 	Typename string `json:"__typename"`
 	Id       string `json:"id"`
 }
+
+// GetTypename returns AnimalFieldsOwnerAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *AnimalFieldsOwnerAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns AnimalFieldsOwnerAnimal.Id, and is useful for accessing the field via an interface.
+func (v *AnimalFieldsOwnerAnimal) GetId() string { return v.Id }
 
 // AnimalFieldsOwnerBeing includes the requested fields of the GraphQL interface Being.
 //
@@ -112,21 +130,8 @@ type AnimalFieldsOwnerBeing interface {
 	GetId() string
 }
 
-func (v *AnimalFieldsOwnerUser) implementsGraphQLInterfaceAnimalFieldsOwnerBeing() {}
-
-// GetTypename is a part of, and documented with, the interface AnimalFieldsOwnerBeing.
-func (v *AnimalFieldsOwnerUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface AnimalFieldsOwnerBeing.
-func (v *AnimalFieldsOwnerUser) GetId() string { return v.Id }
-
+func (v *AnimalFieldsOwnerUser) implementsGraphQLInterfaceAnimalFieldsOwnerBeing()   {}
 func (v *AnimalFieldsOwnerAnimal) implementsGraphQLInterfaceAnimalFieldsOwnerBeing() {}
-
-// GetTypename is a part of, and documented with, the interface AnimalFieldsOwnerBeing.
-func (v *AnimalFieldsOwnerAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface AnimalFieldsOwnerBeing.
-func (v *AnimalFieldsOwnerAnimal) GetId() string { return v.Id }
 
 func __unmarshalAnimalFieldsOwnerBeing(b []byte, v *AnimalFieldsOwnerBeing) error {
 	if string(b) == "null" {
@@ -197,6 +202,18 @@ type AnimalFieldsOwnerUser struct {
 	LuckyFieldsUser `json:"-"`
 }
 
+// GetTypename returns AnimalFieldsOwnerUser.Typename, and is useful for accessing the field via an interface.
+func (v *AnimalFieldsOwnerUser) GetTypename() string { return v.Typename }
+
+// GetId returns AnimalFieldsOwnerUser.Id, and is useful for accessing the field via an interface.
+func (v *AnimalFieldsOwnerUser) GetId() string { return v.Id }
+
+// GetLuckyNumber returns AnimalFieldsOwnerUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *AnimalFieldsOwnerUser) GetLuckyNumber() int { return v.LuckyFieldsUser.LuckyNumber }
+
+// GetHair returns AnimalFieldsOwnerUser.Hair, and is useful for accessing the field via an interface.
+func (v *AnimalFieldsOwnerUser) GetHair() MoreUserFieldsHair { return v.UserFields.MoreUserFields.Hair }
+
 func (v *AnimalFieldsOwnerUser) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -261,6 +278,12 @@ type FriendsFields struct {
 	Name string `json:"name"`
 }
 
+// GetId returns FriendsFields.Id, and is useful for accessing the field via an interface.
+func (v *FriendsFields) GetId() string { return v.Id }
+
+// GetName returns FriendsFields.Name, and is useful for accessing the field via an interface.
+func (v *FriendsFields) GetName() string { return v.Name }
+
 // InnerBeingFields includes the GraphQL fields of Being requested by the fragment InnerBeingFields.
 //
 // InnerBeingFields is implemented by the following types:
@@ -274,21 +297,8 @@ type InnerBeingFields interface {
 	GetName() string
 }
 
-func (v *InnerBeingFieldsUser) implementsGraphQLInterfaceInnerBeingFields() {}
-
-// GetId is a part of, and documented with, the interface InnerBeingFields.
-func (v *InnerBeingFieldsUser) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface InnerBeingFields.
-func (v *InnerBeingFieldsUser) GetName() string { return v.Name }
-
+func (v *InnerBeingFieldsUser) implementsGraphQLInterfaceInnerBeingFields()   {}
 func (v *InnerBeingFieldsAnimal) implementsGraphQLInterfaceInnerBeingFields() {}
-
-// GetId is a part of, and documented with, the interface InnerBeingFields.
-func (v *InnerBeingFieldsAnimal) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface InnerBeingFields.
-func (v *InnerBeingFieldsAnimal) GetName() string { return v.Name }
 
 func __unmarshalInnerBeingFields(b []byte, v *InnerBeingFields) error {
 	if string(b) == "null" {
@@ -353,12 +363,27 @@ type InnerBeingFieldsAnimal struct {
 	Name string `json:"name"`
 }
 
+// GetId returns InnerBeingFieldsAnimal.Id, and is useful for accessing the field via an interface.
+func (v *InnerBeingFieldsAnimal) GetId() string { return v.Id }
+
+// GetName returns InnerBeingFieldsAnimal.Name, and is useful for accessing the field via an interface.
+func (v *InnerBeingFieldsAnimal) GetName() string { return v.Name }
+
 // InnerBeingFields includes the GraphQL fields of User requested by the fragment InnerBeingFields.
 type InnerBeingFieldsUser struct {
 	Id      string          `json:"id"`
 	Name    string          `json:"name"`
 	Friends []FriendsFields `json:"friends"`
 }
+
+// GetId returns InnerBeingFieldsUser.Id, and is useful for accessing the field via an interface.
+func (v *InnerBeingFieldsUser) GetId() string { return v.Id }
+
+// GetName returns InnerBeingFieldsUser.Name, and is useful for accessing the field via an interface.
+func (v *InnerBeingFieldsUser) GetName() string { return v.Name }
+
+// GetFriends returns InnerBeingFieldsUser.Friends, and is useful for accessing the field via an interface.
+func (v *InnerBeingFieldsUser) GetFriends() []FriendsFields { return v.Friends }
 
 // InnerLuckyFields includes the GraphQL fields of Lucky requested by the fragment InnerLuckyFields.
 //
@@ -371,9 +396,6 @@ type InnerLuckyFields interface {
 }
 
 func (v *InnerLuckyFieldsUser) implementsGraphQLInterfaceInnerLuckyFields() {}
-
-// GetLuckyNumber is a part of, and documented with, the interface InnerLuckyFields.
-func (v *InnerLuckyFieldsUser) GetLuckyNumber() int { return v.LuckyNumber }
 
 func __unmarshalInnerLuckyFields(b []byte, v *InnerLuckyFields) error {
 	if string(b) == "null" {
@@ -426,6 +448,9 @@ type InnerLuckyFieldsUser struct {
 	LuckyNumber int `json:"luckyNumber"`
 }
 
+// GetLuckyNumber returns InnerLuckyFieldsUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *InnerLuckyFieldsUser) GetLuckyNumber() int { return v.LuckyNumber }
+
 // LuckyFields includes the GraphQL fields of Lucky requested by the fragment LuckyFields.
 //
 // LuckyFields is implemented by the following types:
@@ -437,9 +462,6 @@ type LuckyFields interface {
 }
 
 func (v *LuckyFieldsUser) implementsGraphQLInterfaceLuckyFields() {}
-
-// GetLuckyNumber is a part of, and documented with, the interface LuckyFields.
-func (v *LuckyFieldsUser) GetLuckyNumber() int { return v.LuckyNumber }
 
 func __unmarshalLuckyFields(b []byte, v *LuckyFields) error {
 	if string(b) == "null" {
@@ -497,6 +519,15 @@ type LuckyFieldsUser struct {
 	LuckyNumber    int `json:"luckyNumber"`
 }
 
+// GetLuckyNumber returns LuckyFieldsUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *LuckyFieldsUser) GetLuckyNumber() int { return v.LuckyNumber }
+
+// GetId returns LuckyFieldsUser.Id, and is useful for accessing the field via an interface.
+func (v *LuckyFieldsUser) GetId() string { return v.MoreUserFields.Id }
+
+// GetHair returns LuckyFieldsUser.Hair, and is useful for accessing the field via an interface.
+func (v *LuckyFieldsUser) GetHair() MoreUserFieldsHair { return v.MoreUserFields.Hair }
+
 func (v *LuckyFieldsUser) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -553,15 +584,27 @@ type MoreUserFields struct {
 	Hair MoreUserFieldsHair `json:"hair"`
 }
 
+// GetId returns MoreUserFields.Id, and is useful for accessing the field via an interface.
+func (v *MoreUserFields) GetId() string { return v.Id }
+
+// GetHair returns MoreUserFields.Hair, and is useful for accessing the field via an interface.
+func (v *MoreUserFields) GetHair() MoreUserFieldsHair { return v.Hair }
+
 // MoreUserFieldsHair includes the requested fields of the GraphQL type Hair.
 type MoreUserFieldsHair struct {
 	Color string `json:"color"`
 }
 
+// GetColor returns MoreUserFieldsHair.Color, and is useful for accessing the field via an interface.
+func (v *MoreUserFieldsHair) GetColor() string { return v.Color }
+
 // QueryFragment includes the GraphQL fields of Query requested by the fragment QueryFragment.
 type QueryFragment struct {
 	Beings []QueryFragmentBeingsBeing `json:"-"`
 }
+
+// GetBeings returns QueryFragment.Beings, and is useful for accessing the field via an interface.
+func (v *QueryFragment) GetBeings() []QueryFragmentBeingsBeing { return v.Beings }
 
 func (v *QueryFragment) UnmarshalJSON(b []byte) error {
 
@@ -645,6 +688,15 @@ type QueryFragmentBeingsAnimal struct {
 	Owner    InnerBeingFields `json:"-"`
 }
 
+// GetTypename returns QueryFragmentBeingsAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *QueryFragmentBeingsAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns QueryFragmentBeingsAnimal.Id, and is useful for accessing the field via an interface.
+func (v *QueryFragmentBeingsAnimal) GetId() string { return v.Id }
+
+// GetOwner returns QueryFragmentBeingsAnimal.Owner, and is useful for accessing the field via an interface.
+func (v *QueryFragmentBeingsAnimal) GetOwner() InnerBeingFields { return v.Owner }
+
 func (v *QueryFragmentBeingsAnimal) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -727,21 +779,8 @@ type QueryFragmentBeingsBeing interface {
 	GetId() string
 }
 
-func (v *QueryFragmentBeingsUser) implementsGraphQLInterfaceQueryFragmentBeingsBeing() {}
-
-// GetTypename is a part of, and documented with, the interface QueryFragmentBeingsBeing.
-func (v *QueryFragmentBeingsUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface QueryFragmentBeingsBeing.
-func (v *QueryFragmentBeingsUser) GetId() string { return v.Id }
-
+func (v *QueryFragmentBeingsUser) implementsGraphQLInterfaceQueryFragmentBeingsBeing()   {}
 func (v *QueryFragmentBeingsAnimal) implementsGraphQLInterfaceQueryFragmentBeingsBeing() {}
-
-// GetTypename is a part of, and documented with, the interface QueryFragmentBeingsBeing.
-func (v *QueryFragmentBeingsAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface QueryFragmentBeingsBeing.
-func (v *QueryFragmentBeingsAnimal) GetId() string { return v.Id }
 
 func __unmarshalQueryFragmentBeingsBeing(b []byte, v *QueryFragmentBeingsBeing) error {
 	if string(b) == "null" {
@@ -815,6 +854,15 @@ type QueryFragmentBeingsUser struct {
 	InnerLuckyFieldsUser `json:"-"`
 }
 
+// GetTypename returns QueryFragmentBeingsUser.Typename, and is useful for accessing the field via an interface.
+func (v *QueryFragmentBeingsUser) GetTypename() string { return v.Typename }
+
+// GetId returns QueryFragmentBeingsUser.Id, and is useful for accessing the field via an interface.
+func (v *QueryFragmentBeingsUser) GetId() string { return v.Id }
+
+// GetLuckyNumber returns QueryFragmentBeingsUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *QueryFragmentBeingsUser) GetLuckyNumber() int { return v.InnerLuckyFieldsUser.LuckyNumber }
+
 func (v *QueryFragmentBeingsUser) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -879,6 +927,15 @@ type UserFields struct {
 	MoreUserFields  `json:"-"`
 }
 
+// GetId returns UserFields.Id, and is useful for accessing the field via an interface.
+func (v *UserFields) GetId() string { return v.Id }
+
+// GetLuckyNumber returns UserFields.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *UserFields) GetLuckyNumber() int { return v.LuckyFieldsUser.LuckyNumber }
+
+// GetHair returns UserFields.Hair, and is useful for accessing the field via an interface.
+func (v *UserFields) GetHair() MoreUserFieldsHair { return v.MoreUserFields.Hair }
+
 func (v *UserFields) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -938,6 +995,9 @@ func (v *UserFields) __premarshalJSON() (*__premarshalUserFields, error) {
 type __queryWithCustomMarshalInput struct {
 	Date time.Time `json:"-"`
 }
+
+// GetDate returns __queryWithCustomMarshalInput.Date, and is useful for accessing the field via an interface.
+func (v *__queryWithCustomMarshalInput) GetDate() time.Time { return v.Date }
 
 func (v *__queryWithCustomMarshalInput) UnmarshalJSON(b []byte) error {
 
@@ -1007,6 +1067,12 @@ type __queryWithCustomMarshalOptionalInput struct {
 	Date *time.Time `json:"-"`
 	Id   *string    `json:"id"`
 }
+
+// GetDate returns __queryWithCustomMarshalOptionalInput.Date, and is useful for accessing the field via an interface.
+func (v *__queryWithCustomMarshalOptionalInput) GetDate() *time.Time { return v.Date }
+
+// GetId returns __queryWithCustomMarshalOptionalInput.Id, and is useful for accessing the field via an interface.
+func (v *__queryWithCustomMarshalOptionalInput) GetId() *string { return v.Id }
 
 func (v *__queryWithCustomMarshalOptionalInput) UnmarshalJSON(b []byte) error {
 
@@ -1081,6 +1147,9 @@ func (v *__queryWithCustomMarshalOptionalInput) __premarshalJSON() (*__premarsha
 type __queryWithCustomMarshalSliceInput struct {
 	Dates []time.Time `json:"-"`
 }
+
+// GetDates returns __queryWithCustomMarshalSliceInput.Dates, and is useful for accessing the field via an interface.
+func (v *__queryWithCustomMarshalSliceInput) GetDates() []time.Time { return v.Dates }
 
 func (v *__queryWithCustomMarshalSliceInput) UnmarshalJSON(b []byte) error {
 
@@ -1162,45 +1231,72 @@ type __queryWithFlattenInput struct {
 	Ids []string `json:"ids"`
 }
 
+// GetIds returns __queryWithFlattenInput.Ids, and is useful for accessing the field via an interface.
+func (v *__queryWithFlattenInput) GetIds() []string { return v.Ids }
+
 // __queryWithFragmentsInput is used internally by genqlient
 type __queryWithFragmentsInput struct {
 	Ids []string `json:"ids"`
 }
+
+// GetIds returns __queryWithFragmentsInput.Ids, and is useful for accessing the field via an interface.
+func (v *__queryWithFragmentsInput) GetIds() []string { return v.Ids }
 
 // __queryWithInterfaceListFieldInput is used internally by genqlient
 type __queryWithInterfaceListFieldInput struct {
 	Ids []string `json:"ids"`
 }
 
+// GetIds returns __queryWithInterfaceListFieldInput.Ids, and is useful for accessing the field via an interface.
+func (v *__queryWithInterfaceListFieldInput) GetIds() []string { return v.Ids }
+
 // __queryWithInterfaceListPointerFieldInput is used internally by genqlient
 type __queryWithInterfaceListPointerFieldInput struct {
 	Ids []string `json:"ids"`
 }
+
+// GetIds returns __queryWithInterfaceListPointerFieldInput.Ids, and is useful for accessing the field via an interface.
+func (v *__queryWithInterfaceListPointerFieldInput) GetIds() []string { return v.Ids }
 
 // __queryWithInterfaceNoFragmentsInput is used internally by genqlient
 type __queryWithInterfaceNoFragmentsInput struct {
 	Id string `json:"id"`
 }
 
+// GetId returns __queryWithInterfaceNoFragmentsInput.Id, and is useful for accessing the field via an interface.
+func (v *__queryWithInterfaceNoFragmentsInput) GetId() string { return v.Id }
+
 // __queryWithNamedFragmentsInput is used internally by genqlient
 type __queryWithNamedFragmentsInput struct {
 	Ids []string `json:"ids"`
 }
+
+// GetIds returns __queryWithNamedFragmentsInput.Ids, and is useful for accessing the field via an interface.
+func (v *__queryWithNamedFragmentsInput) GetIds() []string { return v.Ids }
 
 // __queryWithOmitemptyInput is used internally by genqlient
 type __queryWithOmitemptyInput struct {
 	Id string `json:"id,omitempty"`
 }
 
+// GetId returns __queryWithOmitemptyInput.Id, and is useful for accessing the field via an interface.
+func (v *__queryWithOmitemptyInput) GetId() string { return v.Id }
+
 // __queryWithVariablesInput is used internally by genqlient
 type __queryWithVariablesInput struct {
 	Id string `json:"id"`
 }
 
+// GetId returns __queryWithVariablesInput.Id, and is useful for accessing the field via an interface.
+func (v *__queryWithVariablesInput) GetId() string { return v.Id }
+
 // failingQueryMeUser includes the requested fields of the GraphQL type User.
 type failingQueryMeUser struct {
 	Id string `json:"id"`
 }
+
+// GetId returns failingQueryMeUser.Id, and is useful for accessing the field via an interface.
+func (v *failingQueryMeUser) GetId() string { return v.Id }
 
 // failingQueryResponse is returned by failingQuery on success.
 type failingQueryResponse struct {
@@ -1208,9 +1304,20 @@ type failingQueryResponse struct {
 	Me   failingQueryMeUser `json:"me"`
 }
 
+// GetFail returns failingQueryResponse.Fail, and is useful for accessing the field via an interface.
+func (v *failingQueryResponse) GetFail() bool { return v.Fail }
+
+// GetMe returns failingQueryResponse.Me, and is useful for accessing the field via an interface.
+func (v *failingQueryResponse) GetMe() failingQueryMeUser { return v.Me }
+
 // queryWithCustomMarshalOptionalResponse is returned by queryWithCustomMarshalOptional on success.
 type queryWithCustomMarshalOptionalResponse struct {
 	UserSearch []queryWithCustomMarshalOptionalUserSearchUser `json:"userSearch"`
+}
+
+// GetUserSearch returns queryWithCustomMarshalOptionalResponse.UserSearch, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalOptionalResponse) GetUserSearch() []queryWithCustomMarshalOptionalUserSearchUser {
+	return v.UserSearch
 }
 
 // queryWithCustomMarshalOptionalUserSearchUser includes the requested fields of the GraphQL type User.
@@ -1219,6 +1326,15 @@ type queryWithCustomMarshalOptionalUserSearchUser struct {
 	Name      string    `json:"name"`
 	Birthdate time.Time `json:"-"`
 }
+
+// GetId returns queryWithCustomMarshalOptionalUserSearchUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalOptionalUserSearchUser) GetId() string { return v.Id }
+
+// GetName returns queryWithCustomMarshalOptionalUserSearchUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalOptionalUserSearchUser) GetName() string { return v.Name }
+
+// GetBirthdate returns queryWithCustomMarshalOptionalUserSearchUser.Birthdate, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalOptionalUserSearchUser) GetBirthdate() time.Time { return v.Birthdate }
 
 func (v *queryWithCustomMarshalOptionalUserSearchUser) UnmarshalJSON(b []byte) error {
 
@@ -1294,9 +1410,19 @@ type queryWithCustomMarshalResponse struct {
 	UsersBornOn []queryWithCustomMarshalUsersBornOnUser `json:"usersBornOn"`
 }
 
+// GetUsersBornOn returns queryWithCustomMarshalResponse.UsersBornOn, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalResponse) GetUsersBornOn() []queryWithCustomMarshalUsersBornOnUser {
+	return v.UsersBornOn
+}
+
 // queryWithCustomMarshalSliceResponse is returned by queryWithCustomMarshalSlice on success.
 type queryWithCustomMarshalSliceResponse struct {
 	UsersBornOnDates []queryWithCustomMarshalSliceUsersBornOnDatesUser `json:"usersBornOnDates"`
+}
+
+// GetUsersBornOnDates returns queryWithCustomMarshalSliceResponse.UsersBornOnDates, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalSliceResponse) GetUsersBornOnDates() []queryWithCustomMarshalSliceUsersBornOnDatesUser {
+	return v.UsersBornOnDates
 }
 
 // queryWithCustomMarshalSliceUsersBornOnDatesUser includes the requested fields of the GraphQL type User.
@@ -1304,6 +1430,17 @@ type queryWithCustomMarshalSliceUsersBornOnDatesUser struct {
 	Id        string    `json:"id"`
 	Name      string    `json:"name"`
 	Birthdate time.Time `json:"-"`
+}
+
+// GetId returns queryWithCustomMarshalSliceUsersBornOnDatesUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetId() string { return v.Id }
+
+// GetName returns queryWithCustomMarshalSliceUsersBornOnDatesUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetName() string { return v.Name }
+
+// GetBirthdate returns queryWithCustomMarshalSliceUsersBornOnDatesUser.Birthdate, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetBirthdate() time.Time {
+	return v.Birthdate
 }
 
 func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) UnmarshalJSON(b []byte) error {
@@ -1382,6 +1519,15 @@ type queryWithCustomMarshalUsersBornOnUser struct {
 	Birthdate time.Time `json:"-"`
 }
 
+// GetId returns queryWithCustomMarshalUsersBornOnUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalUsersBornOnUser) GetId() string { return v.Id }
+
+// GetName returns queryWithCustomMarshalUsersBornOnUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalUsersBornOnUser) GetName() string { return v.Name }
+
+// GetBirthdate returns queryWithCustomMarshalUsersBornOnUser.Birthdate, and is useful for accessing the field via an interface.
+func (v *queryWithCustomMarshalUsersBornOnUser) GetBirthdate() time.Time { return v.Birthdate }
+
 func (v *queryWithCustomMarshalUsersBornOnUser) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -1459,6 +1605,28 @@ type queryWithFragmentsBeingsAnimal struct {
 	Hair     queryWithFragmentsBeingsAnimalHairBeingsHair `json:"hair"`
 	Species  Species                                      `json:"species"`
 	Owner    queryWithFragmentsBeingsAnimalOwnerBeing     `json:"-"`
+}
+
+// GetTypename returns queryWithFragmentsBeingsAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithFragmentsBeingsAnimal.Id, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimal) GetId() string { return v.Id }
+
+// GetName returns queryWithFragmentsBeingsAnimal.Name, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimal) GetName() string { return v.Name }
+
+// GetHair returns queryWithFragmentsBeingsAnimal.Hair, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimal) GetHair() queryWithFragmentsBeingsAnimalHairBeingsHair {
+	return v.Hair
+}
+
+// GetSpecies returns queryWithFragmentsBeingsAnimal.Species, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimal) GetSpecies() Species { return v.Species }
+
+// GetOwner returns queryWithFragmentsBeingsAnimal.Owner, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimal) GetOwner() queryWithFragmentsBeingsAnimalOwnerBeing {
+	return v.Owner
 }
 
 func (v *queryWithFragmentsBeingsAnimal) UnmarshalJSON(b []byte) error {
@@ -1544,12 +1712,24 @@ type queryWithFragmentsBeingsAnimalHairBeingsHair struct {
 	HasHair bool `json:"hasHair"`
 }
 
+// GetHasHair returns queryWithFragmentsBeingsAnimalHairBeingsHair.HasHair, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalHairBeingsHair) GetHasHair() bool { return v.HasHair }
+
 // queryWithFragmentsBeingsAnimalOwnerAnimal includes the requested fields of the GraphQL type Animal.
 type queryWithFragmentsBeingsAnimalOwnerAnimal struct {
 	Typename string `json:"__typename"`
 	Id       string `json:"id"`
 	Name     string `json:"name"`
 }
+
+// GetTypename returns queryWithFragmentsBeingsAnimalOwnerAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithFragmentsBeingsAnimalOwnerAnimal.Id, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetId() string { return v.Id }
+
+// GetName returns queryWithFragmentsBeingsAnimalOwnerAnimal.Name, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetName() string { return v.Name }
 
 // queryWithFragmentsBeingsAnimalOwnerBeing includes the requested fields of the GraphQL interface Being.
 //
@@ -1568,27 +1748,8 @@ type queryWithFragmentsBeingsAnimalOwnerBeing interface {
 
 func (v *queryWithFragmentsBeingsAnimalOwnerUser) implementsGraphQLInterfacequeryWithFragmentsBeingsAnimalOwnerBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithFragmentsBeingsAnimalOwnerBeing.
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithFragmentsBeingsAnimalOwnerBeing.
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithFragmentsBeingsAnimalOwnerBeing.
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetName() string { return v.Name }
-
 func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) implementsGraphQLInterfacequeryWithFragmentsBeingsAnimalOwnerBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithFragmentsBeingsAnimalOwnerBeing.
-func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithFragmentsBeingsAnimalOwnerBeing.
-func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithFragmentsBeingsAnimalOwnerBeing.
-func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetName() string { return v.Name }
 
 func __unmarshalqueryWithFragmentsBeingsAnimalOwnerBeing(b []byte, v *queryWithFragmentsBeingsAnimalOwnerBeing) error {
 	if string(b) == "null" {
@@ -1655,6 +1816,18 @@ type queryWithFragmentsBeingsAnimalOwnerUser struct {
 	LuckyNumber int    `json:"luckyNumber"`
 }
 
+// GetTypename returns queryWithFragmentsBeingsAnimalOwnerUser.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithFragmentsBeingsAnimalOwnerUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetId() string { return v.Id }
+
+// GetName returns queryWithFragmentsBeingsAnimalOwnerUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetName() string { return v.Name }
+
+// GetLuckyNumber returns queryWithFragmentsBeingsAnimalOwnerUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetLuckyNumber() int { return v.LuckyNumber }
+
 // queryWithFragmentsBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithFragmentsBeingsBeing is implemented by the following types:
@@ -1670,27 +1843,8 @@ type queryWithFragmentsBeingsBeing interface {
 	GetName() string
 }
 
-func (v *queryWithFragmentsBeingsUser) implementsGraphQLInterfacequeryWithFragmentsBeingsBeing() {}
-
-// GetTypename is a part of, and documented with, the interface queryWithFragmentsBeingsBeing.
-func (v *queryWithFragmentsBeingsUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithFragmentsBeingsBeing.
-func (v *queryWithFragmentsBeingsUser) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithFragmentsBeingsBeing.
-func (v *queryWithFragmentsBeingsUser) GetName() string { return v.Name }
-
+func (v *queryWithFragmentsBeingsUser) implementsGraphQLInterfacequeryWithFragmentsBeingsBeing()   {}
 func (v *queryWithFragmentsBeingsAnimal) implementsGraphQLInterfacequeryWithFragmentsBeingsBeing() {}
-
-// GetTypename is a part of, and documented with, the interface queryWithFragmentsBeingsBeing.
-func (v *queryWithFragmentsBeingsAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithFragmentsBeingsBeing.
-func (v *queryWithFragmentsBeingsAnimal) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithFragmentsBeingsBeing.
-func (v *queryWithFragmentsBeingsAnimal) GetName() string { return v.Name }
 
 func __unmarshalqueryWithFragmentsBeingsBeing(b []byte, v *queryWithFragmentsBeingsBeing) error {
 	if string(b) == "null" {
@@ -1762,15 +1916,36 @@ type queryWithFragmentsBeingsUser struct {
 	Hair        queryWithFragmentsBeingsUserHair `json:"hair"`
 }
 
+// GetTypename returns queryWithFragmentsBeingsUser.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsUser) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithFragmentsBeingsUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsUser) GetId() string { return v.Id }
+
+// GetName returns queryWithFragmentsBeingsUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsUser) GetName() string { return v.Name }
+
+// GetLuckyNumber returns queryWithFragmentsBeingsUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsUser) GetLuckyNumber() int { return v.LuckyNumber }
+
+// GetHair returns queryWithFragmentsBeingsUser.Hair, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsUser) GetHair() queryWithFragmentsBeingsUserHair { return v.Hair }
+
 // queryWithFragmentsBeingsUserHair includes the requested fields of the GraphQL type Hair.
 type queryWithFragmentsBeingsUserHair struct {
 	Color string `json:"color"`
 }
 
+// GetColor returns queryWithFragmentsBeingsUserHair.Color, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsBeingsUserHair) GetColor() string { return v.Color }
+
 // queryWithFragmentsResponse is returned by queryWithFragments on success.
 type queryWithFragmentsResponse struct {
 	Beings []queryWithFragmentsBeingsBeing `json:"-"`
 }
+
+// GetBeings returns queryWithFragmentsResponse.Beings, and is useful for accessing the field via an interface.
+func (v *queryWithFragmentsResponse) GetBeings() []queryWithFragmentsBeingsBeing { return v.Beings }
 
 func (v *queryWithFragmentsResponse) UnmarshalJSON(b []byte) error {
 
@@ -1854,6 +2029,15 @@ type queryWithInterfaceListFieldBeingsAnimal struct {
 	Name     string `json:"name"`
 }
 
+// GetTypename returns queryWithInterfaceListFieldBeingsAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListFieldBeingsAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithInterfaceListFieldBeingsAnimal.Id, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListFieldBeingsAnimal) GetId() string { return v.Id }
+
+// GetName returns queryWithInterfaceListFieldBeingsAnimal.Name, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListFieldBeingsAnimal) GetName() string { return v.Name }
+
 // queryWithInterfaceListFieldBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithInterfaceListFieldBeingsBeing is implemented by the following types:
@@ -1871,27 +2055,8 @@ type queryWithInterfaceListFieldBeingsBeing interface {
 
 func (v *queryWithInterfaceListFieldBeingsUser) implementsGraphQLInterfacequeryWithInterfaceListFieldBeingsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithInterfaceListFieldBeingsBeing.
-func (v *queryWithInterfaceListFieldBeingsUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithInterfaceListFieldBeingsBeing.
-func (v *queryWithInterfaceListFieldBeingsUser) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithInterfaceListFieldBeingsBeing.
-func (v *queryWithInterfaceListFieldBeingsUser) GetName() string { return v.Name }
-
 func (v *queryWithInterfaceListFieldBeingsAnimal) implementsGraphQLInterfacequeryWithInterfaceListFieldBeingsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithInterfaceListFieldBeingsBeing.
-func (v *queryWithInterfaceListFieldBeingsAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithInterfaceListFieldBeingsBeing.
-func (v *queryWithInterfaceListFieldBeingsAnimal) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithInterfaceListFieldBeingsBeing.
-func (v *queryWithInterfaceListFieldBeingsAnimal) GetName() string { return v.Name }
 
 func __unmarshalqueryWithInterfaceListFieldBeingsBeing(b []byte, v *queryWithInterfaceListFieldBeingsBeing) error {
 	if string(b) == "null" {
@@ -1957,9 +2122,23 @@ type queryWithInterfaceListFieldBeingsUser struct {
 	Name     string `json:"name"`
 }
 
+// GetTypename returns queryWithInterfaceListFieldBeingsUser.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListFieldBeingsUser) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithInterfaceListFieldBeingsUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListFieldBeingsUser) GetId() string { return v.Id }
+
+// GetName returns queryWithInterfaceListFieldBeingsUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListFieldBeingsUser) GetName() string { return v.Name }
+
 // queryWithInterfaceListFieldResponse is returned by queryWithInterfaceListField on success.
 type queryWithInterfaceListFieldResponse struct {
 	Beings []queryWithInterfaceListFieldBeingsBeing `json:"-"`
+}
+
+// GetBeings returns queryWithInterfaceListFieldResponse.Beings, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListFieldResponse) GetBeings() []queryWithInterfaceListFieldBeingsBeing {
+	return v.Beings
 }
 
 func (v *queryWithInterfaceListFieldResponse) UnmarshalJSON(b []byte) error {
@@ -2044,6 +2223,15 @@ type queryWithInterfaceListPointerFieldBeingsAnimal struct {
 	Name     string `json:"name"`
 }
 
+// GetTypename returns queryWithInterfaceListPointerFieldBeingsAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithInterfaceListPointerFieldBeingsAnimal.Id, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetId() string { return v.Id }
+
+// GetName returns queryWithInterfaceListPointerFieldBeingsAnimal.Name, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetName() string { return v.Name }
+
 // queryWithInterfaceListPointerFieldBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithInterfaceListPointerFieldBeingsBeing is implemented by the following types:
@@ -2061,27 +2249,8 @@ type queryWithInterfaceListPointerFieldBeingsBeing interface {
 
 func (v *queryWithInterfaceListPointerFieldBeingsUser) implementsGraphQLInterfacequeryWithInterfaceListPointerFieldBeingsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithInterfaceListPointerFieldBeingsBeing.
-func (v *queryWithInterfaceListPointerFieldBeingsUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithInterfaceListPointerFieldBeingsBeing.
-func (v *queryWithInterfaceListPointerFieldBeingsUser) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithInterfaceListPointerFieldBeingsBeing.
-func (v *queryWithInterfaceListPointerFieldBeingsUser) GetName() string { return v.Name }
-
 func (v *queryWithInterfaceListPointerFieldBeingsAnimal) implementsGraphQLInterfacequeryWithInterfaceListPointerFieldBeingsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithInterfaceListPointerFieldBeingsBeing.
-func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithInterfaceListPointerFieldBeingsBeing.
-func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithInterfaceListPointerFieldBeingsBeing.
-func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetName() string { return v.Name }
 
 func __unmarshalqueryWithInterfaceListPointerFieldBeingsBeing(b []byte, v *queryWithInterfaceListPointerFieldBeingsBeing) error {
 	if string(b) == "null" {
@@ -2147,9 +2316,23 @@ type queryWithInterfaceListPointerFieldBeingsUser struct {
 	Name     string `json:"name"`
 }
 
+// GetTypename returns queryWithInterfaceListPointerFieldBeingsUser.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListPointerFieldBeingsUser) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithInterfaceListPointerFieldBeingsUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListPointerFieldBeingsUser) GetId() string { return v.Id }
+
+// GetName returns queryWithInterfaceListPointerFieldBeingsUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListPointerFieldBeingsUser) GetName() string { return v.Name }
+
 // queryWithInterfaceListPointerFieldResponse is returned by queryWithInterfaceListPointerField on success.
 type queryWithInterfaceListPointerFieldResponse struct {
 	Beings []*queryWithInterfaceListPointerFieldBeingsBeing `json:"-"`
+}
+
+// GetBeings returns queryWithInterfaceListPointerFieldResponse.Beings, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceListPointerFieldResponse) GetBeings() []*queryWithInterfaceListPointerFieldBeingsBeing {
+	return v.Beings
 }
 
 func (v *queryWithInterfaceListPointerFieldResponse) UnmarshalJSON(b []byte) error {
@@ -2247,27 +2430,8 @@ type queryWithInterfaceNoFragmentsBeing interface {
 
 func (v *queryWithInterfaceNoFragmentsBeingUser) implementsGraphQLInterfacequeryWithInterfaceNoFragmentsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithInterfaceNoFragmentsBeing.
-func (v *queryWithInterfaceNoFragmentsBeingUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithInterfaceNoFragmentsBeing.
-func (v *queryWithInterfaceNoFragmentsBeingUser) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithInterfaceNoFragmentsBeing.
-func (v *queryWithInterfaceNoFragmentsBeingUser) GetName() string { return v.Name }
-
 func (v *queryWithInterfaceNoFragmentsBeingAnimal) implementsGraphQLInterfacequeryWithInterfaceNoFragmentsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithInterfaceNoFragmentsBeing.
-func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithInterfaceNoFragmentsBeing.
-func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetId() string { return v.Id }
-
-// GetName is a part of, and documented with, the interface queryWithInterfaceNoFragmentsBeing.
-func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetName() string { return v.Name }
 
 func __unmarshalqueryWithInterfaceNoFragmentsBeing(b []byte, v *queryWithInterfaceNoFragmentsBeing) error {
 	if string(b) == "null" {
@@ -2333,6 +2497,15 @@ type queryWithInterfaceNoFragmentsBeingAnimal struct {
 	Name     string `json:"name"`
 }
 
+// GetTypename returns queryWithInterfaceNoFragmentsBeingAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithInterfaceNoFragmentsBeingAnimal.Id, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetId() string { return v.Id }
+
+// GetName returns queryWithInterfaceNoFragmentsBeingAnimal.Name, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetName() string { return v.Name }
+
 // queryWithInterfaceNoFragmentsBeingUser includes the requested fields of the GraphQL type User.
 type queryWithInterfaceNoFragmentsBeingUser struct {
 	Typename string `json:"__typename"`
@@ -2340,16 +2513,41 @@ type queryWithInterfaceNoFragmentsBeingUser struct {
 	Name     string `json:"name"`
 }
 
+// GetTypename returns queryWithInterfaceNoFragmentsBeingUser.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsBeingUser) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithInterfaceNoFragmentsBeingUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsBeingUser) GetId() string { return v.Id }
+
+// GetName returns queryWithInterfaceNoFragmentsBeingUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsBeingUser) GetName() string { return v.Name }
+
 // queryWithInterfaceNoFragmentsMeUser includes the requested fields of the GraphQL type User.
 type queryWithInterfaceNoFragmentsMeUser struct {
 	Id   string `json:"id"`
 	Name string `json:"name"`
 }
 
+// GetId returns queryWithInterfaceNoFragmentsMeUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsMeUser) GetId() string { return v.Id }
+
+// GetName returns queryWithInterfaceNoFragmentsMeUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsMeUser) GetName() string { return v.Name }
+
 // queryWithInterfaceNoFragmentsResponse is returned by queryWithInterfaceNoFragments on success.
 type queryWithInterfaceNoFragmentsResponse struct {
 	Being queryWithInterfaceNoFragmentsBeing  `json:"-"`
 	Me    queryWithInterfaceNoFragmentsMeUser `json:"me"`
+}
+
+// GetBeing returns queryWithInterfaceNoFragmentsResponse.Being, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsResponse) GetBeing() queryWithInterfaceNoFragmentsBeing {
+	return v.Being
+}
+
+// GetMe returns queryWithInterfaceNoFragmentsResponse.Me, and is useful for accessing the field via an interface.
+func (v *queryWithInterfaceNoFragmentsResponse) GetMe() queryWithInterfaceNoFragmentsMeUser {
+	return v.Me
 }
 
 func (v *queryWithInterfaceNoFragmentsResponse) UnmarshalJSON(b []byte) error {
@@ -2423,6 +2621,22 @@ type queryWithNamedFragmentsBeingsAnimal struct {
 	Typename     string `json:"__typename"`
 	Id           string `json:"id"`
 	AnimalFields `json:"-"`
+}
+
+// GetTypename returns queryWithNamedFragmentsBeingsAnimal.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsAnimal) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithNamedFragmentsBeingsAnimal.Id, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsAnimal) GetId() string { return v.Id }
+
+// GetHair returns queryWithNamedFragmentsBeingsAnimal.Hair, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsAnimal) GetHair() AnimalFieldsHairBeingsHair {
+	return v.AnimalFields.Hair
+}
+
+// GetOwner returns queryWithNamedFragmentsBeingsAnimal.Owner, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsAnimal) GetOwner() AnimalFieldsOwnerBeing {
+	return v.AnimalFields.Owner
 }
 
 func (v *queryWithNamedFragmentsBeingsAnimal) UnmarshalJSON(b []byte) error {
@@ -2504,21 +2718,8 @@ type queryWithNamedFragmentsBeingsBeing interface {
 
 func (v *queryWithNamedFragmentsBeingsUser) implementsGraphQLInterfacequeryWithNamedFragmentsBeingsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithNamedFragmentsBeingsBeing.
-func (v *queryWithNamedFragmentsBeingsUser) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithNamedFragmentsBeingsBeing.
-func (v *queryWithNamedFragmentsBeingsUser) GetId() string { return v.Id }
-
 func (v *queryWithNamedFragmentsBeingsAnimal) implementsGraphQLInterfacequeryWithNamedFragmentsBeingsBeing() {
 }
-
-// GetTypename is a part of, and documented with, the interface queryWithNamedFragmentsBeingsBeing.
-func (v *queryWithNamedFragmentsBeingsAnimal) GetTypename() string { return v.Typename }
-
-// GetId is a part of, and documented with, the interface queryWithNamedFragmentsBeingsBeing.
-func (v *queryWithNamedFragmentsBeingsAnimal) GetId() string { return v.Id }
 
 func __unmarshalqueryWithNamedFragmentsBeingsBeing(b []byte, v *queryWithNamedFragmentsBeingsBeing) error {
 	if string(b) == "null" {
@@ -2592,6 +2793,22 @@ type queryWithNamedFragmentsBeingsUser struct {
 	UserFields `json:"-"`
 }
 
+// GetTypename returns queryWithNamedFragmentsBeingsUser.Typename, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsUser) GetTypename() string { return v.Typename }
+
+// GetId returns queryWithNamedFragmentsBeingsUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsUser) GetId() string { return v.Id }
+
+// GetLuckyNumber returns queryWithNamedFragmentsBeingsUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsUser) GetLuckyNumber() int {
+	return v.UserFields.LuckyFieldsUser.LuckyNumber
+}
+
+// GetHair returns queryWithNamedFragmentsBeingsUser.Hair, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsBeingsUser) GetHair() MoreUserFieldsHair {
+	return v.UserFields.MoreUserFields.Hair
+}
+
 func (v *queryWithNamedFragmentsBeingsUser) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -2648,6 +2865,11 @@ func (v *queryWithNamedFragmentsBeingsUser) __premarshalJSON() (*__premarshalque
 // queryWithNamedFragmentsResponse is returned by queryWithNamedFragments on success.
 type queryWithNamedFragmentsResponse struct {
 	Beings []queryWithNamedFragmentsBeingsBeing `json:"-"`
+}
+
+// GetBeings returns queryWithNamedFragmentsResponse.Beings, and is useful for accessing the field via an interface.
+func (v *queryWithNamedFragmentsResponse) GetBeings() []queryWithNamedFragmentsBeingsBeing {
+	return v.Beings
 }
 
 func (v *queryWithNamedFragmentsResponse) UnmarshalJSON(b []byte) error {
@@ -2730,6 +2952,9 @@ type queryWithOmitemptyResponse struct {
 	User queryWithOmitemptyUser `json:"user"`
 }
 
+// GetUser returns queryWithOmitemptyResponse.User, and is useful for accessing the field via an interface.
+func (v *queryWithOmitemptyResponse) GetUser() queryWithOmitemptyUser { return v.User }
+
 // queryWithOmitemptyUser includes the requested fields of the GraphQL type User.
 type queryWithOmitemptyUser struct {
 	Id          string `json:"id"`
@@ -2737,10 +2962,22 @@ type queryWithOmitemptyUser struct {
 	LuckyNumber int    `json:"luckyNumber"`
 }
 
+// GetId returns queryWithOmitemptyUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithOmitemptyUser) GetId() string { return v.Id }
+
+// GetName returns queryWithOmitemptyUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithOmitemptyUser) GetName() string { return v.Name }
+
+// GetLuckyNumber returns queryWithOmitemptyUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *queryWithOmitemptyUser) GetLuckyNumber() int { return v.LuckyNumber }
+
 // queryWithVariablesResponse is returned by queryWithVariables on success.
 type queryWithVariablesResponse struct {
 	User queryWithVariablesUser `json:"user"`
 }
+
+// GetUser returns queryWithVariablesResponse.User, and is useful for accessing the field via an interface.
+func (v *queryWithVariablesResponse) GetUser() queryWithVariablesUser { return v.User }
 
 // queryWithVariablesUser includes the requested fields of the GraphQL type User.
 type queryWithVariablesUser struct {
@@ -2749,6 +2986,15 @@ type queryWithVariablesUser struct {
 	LuckyNumber int    `json:"luckyNumber"`
 }
 
+// GetId returns queryWithVariablesUser.Id, and is useful for accessing the field via an interface.
+func (v *queryWithVariablesUser) GetId() string { return v.Id }
+
+// GetName returns queryWithVariablesUser.Name, and is useful for accessing the field via an interface.
+func (v *queryWithVariablesUser) GetName() string { return v.Name }
+
+// GetLuckyNumber returns queryWithVariablesUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *queryWithVariablesUser) GetLuckyNumber() int { return v.LuckyNumber }
+
 // simpleQueryMeUser includes the requested fields of the GraphQL type User.
 type simpleQueryMeUser struct {
 	Id          string `json:"id"`
@@ -2756,10 +3002,22 @@ type simpleQueryMeUser struct {
 	LuckyNumber int    `json:"luckyNumber"`
 }
 
+// GetId returns simpleQueryMeUser.Id, and is useful for accessing the field via an interface.
+func (v *simpleQueryMeUser) GetId() string { return v.Id }
+
+// GetName returns simpleQueryMeUser.Name, and is useful for accessing the field via an interface.
+func (v *simpleQueryMeUser) GetName() string { return v.Name }
+
+// GetLuckyNumber returns simpleQueryMeUser.LuckyNumber, and is useful for accessing the field via an interface.
+func (v *simpleQueryMeUser) GetLuckyNumber() int { return v.LuckyNumber }
+
 // simpleQueryResponse is returned by simpleQuery on success.
 type simpleQueryResponse struct {
 	Me simpleQueryMeUser `json:"me"`
 }
+
+// GetMe returns simpleQueryResponse.Me, and is useful for accessing the field via an interface.
+func (v *simpleQueryResponse) GetMe() simpleQueryMeUser { return v.Me }
 
 func simpleQuery(
 	ctx context.Context,


### PR DESCRIPTION
## Summary:
If your type implements an interface, we add getter methods for the
shared fields, so that those may be accessed via the interface.  But it
turns out occasionally it's useful to have these getter methods when
they don't implement a GraphQL interface, so you can use two
genqlient-generated types in the same function if they have the same
fields.  (This comes up most often when you have a GraphQL union that
maybe should really be an interface, or if you don't yet support
interfaces implementing other interfaces (indeed our parser doesn't
either).  But one can imagine other use cases.)

We can't predict how you want to do that, so we can't generate the
interface, but we can generate the methods, so you can define the
interface and do a type assertion from there.  Since these methods are
pretty simple to generate, we just do it always.  (As with #120, if
binary size becomes an issue we could later add an option to only
generate methods that are truly needed but including them seems like the
better default.)

This also fixes a subtle and rare bug, which would have become much more
common (indeed existing tests caught it).  Specifically, if you have a
query like
```graphql
fragment FragmentOne on T { id }
fragment FragmentTwo on T { id }
query Q {
    f {   # interface type T
        ...FragmentOne
        ...FragmentTwo
    }
}
```
since both `FragmentOne` and `FragmentTwo` request some common field,
say `id`, we generate a method `GetId` on each one.  But since
`FragmentOne` and `FragmentTwo` are both on `T`, we also include their
interfaces in the interface we generate for the type of `f`, `QFT`.  So
`QFT` includes a method `GetId`.  But on the implementations, the two
methods conflict, and neither gets promoted; this causes various code to
fail to compile.  With this change, this would have happened much more
frequently -- even if only one of the two fragments is on `T`, as long
as both request the field.  Anyway, we now generate explicit methods on
each struct for all of its recursively emebedded fields -- using the
logic from #120 to compute them -- so that we don't need to rely on
method-promotion.

## Test plan:
make tesc
