### PR TITLE
⚡️ Accept array of string as valid input schema path.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ When releasing a new version:
 ### New features:
 
 - genqlient now generates getter methods for all fields, even those which do not implement a genqlient-generated interface; this can be useful for callers who wish to define their own interface and have several unrelated genqlient types which have the same fields implement it.
-
+- genqlient config now accepts either a single or multiple schema files for the `schema` field.
 ### Bug fixes:
 
 - In certain very rare cases involving duplicate fields in fragment spreads, genqlient would generate code that failed to compile due to duplicate methods not getting promoted; genqlient now generates correct types.  (See #126 for a more complete description.)

--- a/docs/genqlient.yaml
+++ b/docs/genqlient.yaml
@@ -4,6 +4,11 @@
 
 # The filename with the GraphQL schema (in SDL format), relative to
 # genqlient.yaml.
+# This can also be a list of filenames, such as:
+#  schema:
+#  - user.graphql
+#  - ./schema/*.graphql
+#  - ./another_directory/**/*.graphqls
 schema: schema.graphql
 
 # Filenames or globs with the operations for which to generate code, relative

--- a/generate/config.go
+++ b/generate/config.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"fmt"
 	"go/token"
 	"io"
 	"io/ioutil"
@@ -166,13 +165,13 @@ func loadSchemaSources(schemas StringList) ([]*ast.Source, error) {
 
 				return nil
 			}); err != nil {
-				return nil, fmt.Errorf("failed to walk schema at root %s: %w", pathParts[0], err)
+				return nil, errorf(nil, "failed to walk schema at root %s: %w", pathParts[0], err)
 			}
 		} else {
 			var err error
 			matches, err = filepath.Glob(f)
 			if err != nil {
-				return nil, fmt.Errorf("failed to glob schema filename %s: %w", f, err)
+				return nil, errorf(nil, "failed to glob schema filename %s: %w", f, err)
 			}
 		}
 
@@ -189,7 +188,7 @@ func loadSchemaSources(schemas StringList) ([]*ast.Source, error) {
 		var schemaRaw []byte
 		schemaRaw, err = ioutil.ReadFile(filename)
 		if err != nil {
-			return nil, fmt.Errorf("unable to open schema: %w", err)
+			return nil, errorf(nil, "unable to open schema: %w", err)
 		}
 
 		source = append(source, &ast.Source{Name: filename, Input: string(schemaRaw)})

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -76,7 +76,7 @@ func TestGenerate(t *testing.T) {
 
 		t.Run(sourceFilename, func(t *testing.T) {
 			generated, err := Generate(&Config{
-				Schema:           filepath.Join(dataDir, "schema.graphql"),
+				Schema:           []string{filepath.Join(dataDir, "schema.graphql")},
 				Operations:       []string{filepath.Join(dataDir, sourceFilename)},
 				Package:          "test",
 				Generated:        goFilename,
@@ -197,7 +197,7 @@ func TestGenerateWithConfig(t *testing.T) {
 		baseDir := filepath.Join(dataDir, test.baseDir)
 		t.Run(test.name, func(t *testing.T) {
 			err := config.ValidateAndFillDefaults(baseDir)
-			config.Schema = filepath.Join(dataDir, "schema.graphql")
+			config.Schema = []string{filepath.Join(dataDir, "schema.graphql")}
 			config.Operations = []string{filepath.Join(dataDir, sourceFilename)}
 			if err != nil {
 				t.Fatal(err)
@@ -256,7 +256,7 @@ func TestGenerateErrors(t *testing.T) {
 
 		t.Run(testFilename, func(t *testing.T) {
 			_, err := Generate(&Config{
-				Schema:      filepath.Join(errorsDir, schemaFilename),
+				Schema:      []string{filepath.Join(errorsDir, schemaFilename)},
 				Operations:  []string{filepath.Join(errorsDir, sourceFilename)},
 				Package:     "test",
 				Generated:   os.DevNull,

--- a/generate/parse.go
+++ b/generate/parse.go
@@ -16,19 +16,16 @@ import (
 	"github.com/vektah/gqlparser/v2/validator"
 )
 
-func getSchema(filename string) (*ast.Schema, error) {
-	text, err := ioutil.ReadFile(filename)
+func getSchema(filePatterns StringList) (*ast.Schema, error) {
+	sources, err := loadSchemaSources(filePatterns)
 	if err != nil {
-		return nil, errorf(nil, "unreadable schema file %v: %v", filename, err)
+		return nil, err
 	}
-
-	schema, graphqlError := gqlparser.LoadSchema(
-		&ast.Source{Name: filename, Input: string(text)})
+	schema, graphqlError := gqlparser.LoadSchema(sources...)
 	if graphqlError != nil {
-		return nil, errorf(nil, "invalid schema file %v: %v",
-			filename, graphqlError)
+		filename, _ := graphqlError.Extensions["file"].(string)
+		return nil, errorf(nil, "invalid schema file %v: %v", filename, graphqlError)
 	}
-
 	return schema, nil
 }
 

--- a/generate/stringlist.go
+++ b/generate/stringlist.go
@@ -1,0 +1,33 @@
+package generate
+
+// StringList provides yaml unmarshaler to accept both `string` and `[]string` as a valid type.
+// Sourced from:
+//		https://github.com/99designs/gqlgen/blob/1a0b19feff6f02d2af6631c9d847bc243f8ede39/codegen/config/config.go#L302-L329
+type StringList []string
+
+func (a *StringList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var single string
+	err := unmarshal(&single)
+	if err == nil {
+		*a = []string{single}
+		return nil
+	}
+
+	var multi []string
+	err = unmarshal(&multi)
+	if err != nil {
+		return err
+	}
+
+	*a = multi
+	return nil
+}
+
+func (a StringList) Has(file string) bool {
+	for _, existing := range a {
+		if existing == file {
+			return true
+		}
+	}
+	return false
+}

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,6 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -43,17 +42,14 @@ github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047 h1:zCoDWFD5
 github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -64,7 +60,6 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/urfave/cli/v2 v2.1.1 h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
 github.com/vektah/gqlparser/v2 v2.1.0 h1:uiKJ+T5HMGGQM2kRKQ8Pxw8+Zq9qhhZhz/lieYvCMns=


### PR DESCRIPTION
This PR adds a feature that accepts both string and array of string as valid input in `schema` key in config.

This feature is completely backward compatible. It does not deprecate or break the previous config file format.

Most of the code is sourced from [https://github.com/99designs/gqlgen](https://github.com/99designs/gqlgen). 


Closes #88 