### PR TITLE
Add CODEOWNERS so community PR reviews are auto-assigned

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these individuals will be requested for
+# review when someone opens a pull request.
+*       @benjaminjkraft @csilvers @dnerdy @StevenACoffman


### PR DESCRIPTION
Not sure if we want to add anyone else, or make a team. but this way community PR reviews will be auto-assigned.


Signed-off-by: Steve Coffman <steve@khanacademy.org>
