### PR TITLE
Allow the use of `typename` to be combined with `bind`.

### DIFF
--- a/generate/convert.go
+++ b/generate/convert.go
@@ -229,6 +229,21 @@ func (g *generator) convertType(
 		goRef, err := g.ref(localBinding)
 		// TODO(benkraft): Add syntax to specify a custom (un)marshaler, if
 		// it proves useful.
+		if options.TypeName != "" {
+			// You can combine bind and typename; we make (and use) a
+			// type-alias to the bound type instead of the bound type
+			// directly.
+			goType := &goTypenameForBuiltinType{
+				GoTypeName:    options.TypeName,
+				GoBuiltinName: goRef,
+				GraphQLName:   typ.Name(),
+			}
+			_, err = g.addType(goType, goType.GoTypeName, typ.Position)
+			if err != nil {
+				return nil, err
+			}
+			goRef = options.TypeName
+		}
 		return &goOpaqueType{GoRef: goRef, GraphQLName: typ.Name()}, err
 	}
 
@@ -281,6 +296,21 @@ func (g *generator) convertDefinition(
 			}
 		}
 		goRef, err := g.ref(globalBinding.Type)
+		if options.TypeName != "" {
+			// You can combine bind and typename; we make (and use) a
+			// type-alias to the bound type instead of the bound type
+			// directly.
+			goType := &goTypenameForBuiltinType{
+				GoTypeName:    options.TypeName,
+				GoBuiltinName: goRef,
+				GraphQLName:   def.Name,
+			}
+			_, err = g.addType(goType, goType.GoTypeName, pos)
+			if err != nil {
+				return nil, err
+			}
+			goRef = options.TypeName
+		}
 		return &goOpaqueType{
 			GoRef:       goRef,
 			GraphQLName: def.Name,

--- a/generate/testdata/queries/Pokemon.graphql
+++ b/generate/testdata/queries/Pokemon.graphql
@@ -6,6 +6,10 @@ query GetPokemonSiblings($input: PokemonInput!) {
     # this is normally an enum, but here we make it a (list of) string:
     # @genqlient(bind: "[]string")
     roles
+    # and we'll fetch it a second time, again making it a list of strings
+    # but creating our own type-name for that list of strings.
+    # @genqlient(bind: "[]string", typename: "StringList")
+    rolesAgain: roles
     name
     # this is mapped globally to internal/testutil.Pokemon:
     # note field ordering matters, but whitespace shouldn't.

--- a/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
@@ -29,6 +29,7 @@ type GetPokemonSiblingsUser struct {
 	// It is stable, unique, and opaque, like all good IDs.
 	Id               string                                   `json:"id"`
 	Roles            []string                                 `json:"roles"`
+	RolesAgain       StringList                               `json:"rolesAgain"`
 	Name             string                                   `json:"name"`
 	Pokemon          []testutil.Pokemon                       `json:"pokemon"`
 	GenqlientPokemon []GetPokemonSiblingsUserGenqlientPokemon `json:"genqlientPokemon"`
@@ -39,6 +40,9 @@ func (v *GetPokemonSiblingsUser) GetId() string { return v.Id }
 
 // GetRoles returns GetPokemonSiblingsUser.Roles, and is useful for accessing the field via an interface.
 func (v *GetPokemonSiblingsUser) GetRoles() []string { return v.Roles }
+
+// GetRolesAgain returns GetPokemonSiblingsUser.RolesAgain, and is useful for accessing the field via an interface.
+func (v *GetPokemonSiblingsUser) GetRolesAgain() StringList { return v.RolesAgain }
 
 // GetName returns GetPokemonSiblingsUser.Name, and is useful for accessing the field via an interface.
 func (v *GetPokemonSiblingsUser) GetName() string { return v.Name }
@@ -62,6 +66,8 @@ func (v *GetPokemonSiblingsUserGenqlientPokemon) GetSpecies() string { return v.
 
 // GetLevel returns GetPokemonSiblingsUserGenqlientPokemon.Level, and is useful for accessing the field via an interface.
 func (v *GetPokemonSiblingsUserGenqlientPokemon) GetLevel() int { return v.Level }
+
+type StringList []string
 
 // __GetPokemonSiblingsInput is used internally by genqlient
 type __GetPokemonSiblingsInput struct {
@@ -89,6 +95,7 @@ query GetPokemonSiblings ($input: PokemonInput!) {
 	user(query: {hasPokemon:$input}) {
 		id
 		roles
+		rolesAgain: roles
 		name
 		pokemon {
 			species

--- a/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.json
+++ b/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.json
@@ -2,7 +2,7 @@
   "operations": [
     {
       "operationName": "GetPokemonSiblings",
-      "query": "\nquery GetPokemonSiblings ($input: PokemonInput!) {\n\tuser(query: {hasPokemon:$input}) {\n\t\tid\n\t\troles\n\t\tname\n\t\tpokemon {\n\t\t\tspecies\n\t\t\tlevel\n\t\t}\n\t\tgenqlientPokemon: pokemon {\n\t\t\tspecies\n\t\t\tlevel\n\t\t}\n\t}\n}\n",
+      "query": "\nquery GetPokemonSiblings ($input: PokemonInput!) {\n\tuser(query: {hasPokemon:$input}) {\n\t\tid\n\t\troles\n\t\trolesAgain: roles\n\t\tname\n\t\tpokemon {\n\t\t\tspecies\n\t\t\tlevel\n\t\t}\n\t\tgenqlientPokemon: pokemon {\n\t\t\tspecies\n\t\t\tlevel\n\t\t}\n\t}\n}\n",
       "sourceLocation": "testdata/queries/Pokemon.graphql"
     }
   ]


### PR DESCRIPTION
## Summary:
In that case, we make a type-alias that points to the `bind` type, and
use that type-alias for the type of the field.

## Test plan:
make check