### PR TITLE
Fix error handling during config init

### DIFF
--- a/generate/config.go
+++ b/generate/config.go
@@ -121,5 +121,8 @@ func initConfig(filename string) error {
 		return errorf(nil, "unable to write default genqlient.yaml: %v", err)
 	}
 	_, err = io.Copy(w, r)
-	return errorf(nil, "unable to write default genqlient.yaml: %v", err)
+	if err != nil {
+		return errorf(nil, "unable to write default genqlient.yaml: %v", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Previously initConfig always returned an error even if it succeeded.
This resulted in a confusing CLI error message that did not match the
executed behavior.

Now it returns an error only if it fails to init the config.

I noticed this when setting up genqlient the first time but didn't dig into it. Ran into it again while working on #141, so submitting a fix.