### PR TITLE
allow omitempty even if arguments are required

### DIFF
--- a/generate/genqlient_directive.go
+++ b/generate/genqlient_directive.go
@@ -239,10 +239,6 @@ func (dir *genqlientDirective) validate(node interface{}, schema *ast.Schema) er
 		// fragment.
 		return nil
 	case *ast.VariableDefinition:
-		if dir.Omitempty != nil && node.Type.NonNull {
-			return errorf(dir.pos, "omitempty may only be used on optional arguments")
-		}
-
 		if dir.Struct != nil {
 			return errorf(dir.pos, "struct is only applicable to fields, not variable-definitions")
 		}


### PR DESCRIPTION
Sometimes the argument is a struct that has optional fields, such as this example:

```GraphQL
input message_insert_input {
  subject: String!
  body: String!
  created_by_id: bigint
  created_at: bigint
}

mutation insertComment($comment: message_insert_input!) {
  insert_task_comment_one(
    object: $comment
  ) {
    id
  }
}
```

The `created_at` and `created_by` field should usually be omitted because the server will default it to `now()` and `current_user`.  What we need is to have them be optional with `omitonly`, but that fails because `message_insert_input` is required.

For instance this would error:

```
# @genqlient(omitempty: true)
mutation insertComment($comment: message_insert_input!) {
  insert_task_comment_one(
    object: $comment
  ) {
    id
  }
}
```

I did not see a test case for this, but am happy to add one if you can point to the suitable file to add it to