### PR TITLE
TYPO: Fixed variable name and  position in interface definition.

### DIFF
--- a/graphql/client.go
+++ b/graphql/client.go
@@ -42,7 +42,7 @@ type Client interface {
 		ctx context.Context,
 		opName string,
 		query string,
-		input, retval interface{},
+		retval, input interface{},
 	) error
 }
 


### PR DESCRIPTION
I was also confused about the variable names (#153). But in this [commit](https://github.com/Khan/genqlient/commit/5995653583af6e8d42477652f7d51ac4201b9fe6) it is clear that the first var is output, second var is input. In this commit I have fixed the issue. Fixes #153