### PR TITLE
Avoid capitalized error strings in generated code

### DIFF
--- a/generate/marshal_helper.go.tmpl
+++ b/generate/marshal_helper.go.tmpl
@@ -39,6 +39,6 @@ func __marshal{{.GoName}}(v *{{.GoName}}) ([]byte, error) {
         return []byte("null"), nil
     default:
         return nil, {{ref "fmt.Errorf"}}(
-            `Unexpected concrete type for {{.GoName}}: "%T"`, v)
+            `unexpected concrete type for {{.GoName}}: "%T"`, v)
     }
 }

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -87,10 +87,10 @@ func __unmarshalComplexInlineFragmentsConflictingStuffContent(b []byte, v *Compl
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsConflictingStuffContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for ComplexInlineFragmentsConflictingStuffContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -126,7 +126,7 @@ func __marshalComplexInlineFragmentsConflictingStuffContent(v *ComplexInlineFrag
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsConflictingStuffContent: "%T"`, v)
+			`unexpected concrete type for ComplexInlineFragmentsConflictingStuffContent: "%T"`, v)
 	}
 }
 
@@ -221,10 +221,10 @@ func __unmarshalComplexInlineFragmentsNestedStuffContent(b []byte, v *ComplexInl
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for ComplexInlineFragmentsNestedStuffContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -264,7 +264,7 @@ func __marshalComplexInlineFragmentsNestedStuffContent(v *ComplexInlineFragments
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffContent: "%T"`, v)
+			`unexpected concrete type for ComplexInlineFragmentsNestedStuffContent: "%T"`, v)
 	}
 }
 
@@ -547,10 +547,10 @@ func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentConte
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -586,7 +586,7 @@ func __marshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContent
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent: "%T"`, v)
+			`unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent: "%T"`, v)
 	}
 }
 
@@ -704,10 +704,10 @@ func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenContent(b []byte, 
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -743,7 +743,7 @@ func __marshalComplexInlineFragmentsNestedStuffTopicChildrenContent(v *ComplexIn
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenContent: "%T"`, v)
+			`unexpected concrete type for ComplexInlineFragmentsNestedStuffTopicChildrenContent: "%T"`, v)
 	}
 }
 
@@ -856,10 +856,10 @@ func __unmarshalComplexInlineFragmentsRandomItemContent(b []byte, v *ComplexInli
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsRandomItemContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for ComplexInlineFragmentsRandomItemContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -895,7 +895,7 @@ func __marshalComplexInlineFragmentsRandomItemContent(v *ComplexInlineFragmentsR
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsRandomItemContent: "%T"`, v)
+			`unexpected concrete type for ComplexInlineFragmentsRandomItemContent: "%T"`, v)
 	}
 }
 
@@ -1034,10 +1034,10 @@ func __unmarshalComplexInlineFragmentsRepeatedStuffContent(b []byte, v *ComplexI
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsRepeatedStuffContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for ComplexInlineFragmentsRepeatedStuffContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -1073,7 +1073,7 @@ func __marshalComplexInlineFragmentsRepeatedStuffContent(v *ComplexInlineFragmen
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ComplexInlineFragmentsRepeatedStuffContent: "%T"`, v)
+			`unexpected concrete type for ComplexInlineFragmentsRepeatedStuffContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -159,10 +159,10 @@ func __unmarshalContentFields(b []byte, v *ContentFields) error {
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ContentFields: "%v"`, tn.TypeName)
+			`unexpected concrete type for ContentFields: "%v"`, tn.TypeName)
 	}
 }
 
@@ -198,7 +198,7 @@ func __marshalContentFields(v *ContentFields) ([]byte, error) {
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ContentFields: "%T"`, v)
+			`unexpected concrete type for ContentFields: "%T"`, v)
 	}
 }
 
@@ -495,10 +495,10 @@ func __unmarshalInnerQueryFragmentOtherLeafLeafContent(b []byte, v *InnerQueryFr
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing LeafContent.__typename")
+			"response was missing LeafContent.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InnerQueryFragmentOtherLeafLeafContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InnerQueryFragmentOtherLeafLeafContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -534,7 +534,7 @@ func __marshalInnerQueryFragmentOtherLeafLeafContent(v *InnerQueryFragmentOtherL
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InnerQueryFragmentOtherLeafLeafContent: "%T"`, v)
+			`unexpected concrete type for InnerQueryFragmentOtherLeafLeafContent: "%T"`, v)
 	}
 }
 
@@ -752,10 +752,10 @@ func __unmarshalInnerQueryFragmentRandomItemContent(b []byte, v *InnerQueryFragm
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InnerQueryFragmentRandomItemContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InnerQueryFragmentRandomItemContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -803,7 +803,7 @@ func __marshalInnerQueryFragmentRandomItemContent(v *InnerQueryFragmentRandomIte
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InnerQueryFragmentRandomItemContent: "%T"`, v)
+			`unexpected concrete type for InnerQueryFragmentRandomItemContent: "%T"`, v)
 	}
 }
 
@@ -1081,10 +1081,10 @@ func __unmarshalInnerQueryFragmentRandomLeafLeafContent(b []byte, v *InnerQueryF
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing LeafContent.__typename")
+			"response was missing LeafContent.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InnerQueryFragmentRandomLeafLeafContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InnerQueryFragmentRandomLeafLeafContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -1120,7 +1120,7 @@ func __marshalInnerQueryFragmentRandomLeafLeafContent(v *InnerQueryFragmentRando
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InnerQueryFragmentRandomLeafLeafContent: "%T"`, v)
+			`unexpected concrete type for InnerQueryFragmentRandomLeafLeafContent: "%T"`, v)
 	}
 }
 
@@ -1403,10 +1403,10 @@ func __unmarshalMoreVideoFieldsParentTopicChildrenContent(b []byte, v *MoreVideo
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for MoreVideoFieldsParentTopicChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for MoreVideoFieldsParentTopicChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -1446,7 +1446,7 @@ func __marshalMoreVideoFieldsParentTopicChildrenContent(v *MoreVideoFieldsParent
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for MoreVideoFieldsParentTopicChildrenContent: "%T"`, v)
+			`unexpected concrete type for MoreVideoFieldsParentTopicChildrenContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
@@ -69,10 +69,10 @@ func __unmarshalContentFields(b []byte, v *ContentFields) error {
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for ContentFields: "%v"`, tn.TypeName)
+			`unexpected concrete type for ContentFields: "%v"`, tn.TypeName)
 	}
 }
 
@@ -108,7 +108,7 @@ func __marshalContentFields(v *ContentFields) ([]byte, error) {
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for ContentFields: "%T"`, v)
+			`unexpected concrete type for ContentFields: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -195,10 +195,10 @@ func __unmarshalInterfaceListFieldRootTopicChildrenContent(b []byte, v *Interfac
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceListFieldRootTopicChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceListFieldRootTopicChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -234,7 +234,7 @@ func __marshalInterfaceListFieldRootTopicChildrenContent(v *InterfaceListFieldRo
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceListFieldRootTopicChildrenContent: "%T"`, v)
+			`unexpected concrete type for InterfaceListFieldRootTopicChildrenContent: "%T"`, v)
 	}
 }
 
@@ -443,10 +443,10 @@ func __unmarshalInterfaceListFieldWithPointerTopicChildrenContent(b []byte, v *I
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceListFieldWithPointerTopicChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceListFieldWithPointerTopicChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -482,7 +482,7 @@ func __marshalInterfaceListFieldWithPointerTopicChildrenContent(v *InterfaceList
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceListFieldWithPointerTopicChildrenContent: "%T"`, v)
+			`unexpected concrete type for InterfaceListFieldWithPointerTopicChildrenContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -64,10 +64,10 @@ func __unmarshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(b []b
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceListOfListOfListsFieldListOfListsOfListsOfContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceListOfListOfListsFieldListOfListsOfListsOfContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -103,7 +103,7 @@ func __marshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(v *Inte
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceListOfListOfListsFieldListOfListsOfListsOfContent: "%T"`, v)
+			`unexpected concrete type for InterfaceListOfListOfListsFieldListOfListsOfListsOfContent: "%T"`, v)
 	}
 }
 
@@ -429,10 +429,10 @@ func __unmarshalInterfaceListOfListOfListsFieldWithPointerContent(b []byte, v *I
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceListOfListOfListsFieldWithPointerContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceListOfListOfListsFieldWithPointerContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -468,7 +468,7 @@ func __marshalInterfaceListOfListOfListsFieldWithPointerContent(v *InterfaceList
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceListOfListOfListsFieldWithPointerContent: "%T"`, v)
+			`unexpected concrete type for InterfaceListOfListOfListsFieldWithPointerContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -184,10 +184,10 @@ func __unmarshalInterfaceNestingRootTopicChildrenContent(b []byte, v *InterfaceN
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceNestingRootTopicChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceNestingRootTopicChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -223,7 +223,7 @@ func __marshalInterfaceNestingRootTopicChildrenContent(v *InterfaceNestingRootTo
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceNestingRootTopicChildrenContent: "%T"`, v)
+			`unexpected concrete type for InterfaceNestingRootTopicChildrenContent: "%T"`, v)
 	}
 }
 
@@ -389,10 +389,10 @@ func __unmarshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenConte
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -428,7 +428,7 @@ func __marshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent: "%T"`, v)
+			`unexpected concrete type for InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -81,10 +81,10 @@ func __unmarshalInterfaceNoFragmentsQueryRandomItemContent(b []byte, v *Interfac
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceNoFragmentsQueryRandomItemContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceNoFragmentsQueryRandomItemContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -120,7 +120,7 @@ func __marshalInterfaceNoFragmentsQueryRandomItemContent(v *InterfaceNoFragments
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceNoFragmentsQueryRandomItemContent: "%T"`, v)
+			`unexpected concrete type for InterfaceNoFragmentsQueryRandomItemContent: "%T"`, v)
 	}
 }
 
@@ -231,10 +231,10 @@ func __unmarshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(b []byte,
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceNoFragmentsQueryRandomItemWithTypeNameContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceNoFragmentsQueryRandomItemWithTypeNameContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -270,7 +270,7 @@ func __marshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(v *Interfac
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceNoFragmentsQueryRandomItemWithTypeNameContent: "%T"`, v)
+			`unexpected concrete type for InterfaceNoFragmentsQueryRandomItemWithTypeNameContent: "%T"`, v)
 	}
 }
 
@@ -549,10 +549,10 @@ func __unmarshalInterfaceNoFragmentsQueryWithPointerContent(b []byte, v *Interfa
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InterfaceNoFragmentsQueryWithPointerContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for InterfaceNoFragmentsQueryWithPointerContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -588,7 +588,7 @@ func __marshalInterfaceNoFragmentsQueryWithPointerContent(v *InterfaceNoFragment
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InterfaceNoFragmentsQueryWithPointerContent: "%T"`, v)
+			`unexpected concrete type for InterfaceNoFragmentsQueryWithPointerContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -85,10 +85,10 @@ func __unmarshalSimpleInlineFragmentRandomItemContent(b []byte, v *SimpleInlineF
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for SimpleInlineFragmentRandomItemContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for SimpleInlineFragmentRandomItemContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -124,7 +124,7 @@ func __marshalSimpleInlineFragmentRandomItemContent(v *SimpleInlineFragmentRando
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for SimpleInlineFragmentRandomItemContent: "%T"`, v)
+			`unexpected concrete type for SimpleInlineFragmentRandomItemContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -81,10 +81,10 @@ func __unmarshalSimpleNamedFragmentRandomItemContent(b []byte, v *SimpleNamedFra
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for SimpleNamedFragmentRandomItemContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for SimpleNamedFragmentRandomItemContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -124,7 +124,7 @@ func __marshalSimpleNamedFragmentRandomItemContent(v *SimpleNamedFragmentRandomI
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for SimpleNamedFragmentRandomItemContent: "%T"`, v)
+			`unexpected concrete type for SimpleNamedFragmentRandomItemContent: "%T"`, v)
 	}
 }
 
@@ -282,10 +282,10 @@ func __unmarshalSimpleNamedFragmentRandomLeafLeafContent(b []byte, v *SimpleName
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing LeafContent.__typename")
+			"response was missing LeafContent.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for SimpleNamedFragmentRandomLeafLeafContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for SimpleNamedFragmentRandomLeafLeafContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -317,7 +317,7 @@ func __marshalSimpleNamedFragmentRandomLeafLeafContent(v *SimpleNamedFragmentRan
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for SimpleNamedFragmentRandomLeafLeafContent: "%T"`, v)
+			`unexpected concrete type for SimpleNamedFragmentRandomLeafLeafContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -268,10 +268,10 @@ func __unmarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildren
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -311,7 +311,7 @@ func __marshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenCo
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent: "%T"`, v)
+			`unexpected concrete type for StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -61,10 +61,10 @@ func __unmarshalItem(b []byte, v *Item) error {
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Content.__typename")
+			"response was missing Content.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for Item: "%v"`, tn.TypeName)
+			`unexpected concrete type for Item: "%v"`, tn.TypeName)
 	}
 }
 
@@ -100,7 +100,7 @@ func __marshalItem(v *Item) ([]byte, error) {
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for Item: "%T"`, v)
+			`unexpected concrete type for Item: "%T"`, v)
 	}
 }
 

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -58,10 +58,10 @@ func __unmarshalUnionNoFragmentsQueryRandomLeafLeafContent(b []byte, v *UnionNoF
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing LeafContent.__typename")
+			"response was missing LeafContent.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for UnionNoFragmentsQueryRandomLeafLeafContent: "%v"`, tn.TypeName)
+			`unexpected concrete type for UnionNoFragmentsQueryRandomLeafLeafContent: "%v"`, tn.TypeName)
 	}
 }
 
@@ -89,7 +89,7 @@ func __marshalUnionNoFragmentsQueryRandomLeafLeafContent(v *UnionNoFragmentsQuer
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for UnionNoFragmentsQueryRandomLeafLeafContent: "%T"`, v)
+			`unexpected concrete type for UnionNoFragmentsQueryRandomLeafLeafContent: "%T"`, v)
 	}
 }
 

--- a/generate/unmarshal_helper.go.tmpl
+++ b/generate/unmarshal_helper.go.tmpl
@@ -28,9 +28,9 @@ func __unmarshal{{.GoName}}(b []byte, v *{{.GoName}}) error {
              of the mock didn't know to add __typename, so give a special
              error. */ -}}
         return {{ref "fmt.Errorf"}}(
-            "Response was missing {{.GraphQLName}}.__typename")
+            "response was missing {{.GraphQLName}}.__typename")
     default:
         return {{ref "fmt.Errorf"}}(
-            `Unexpected concrete type for {{.GoName}}: "%v"`, tn.TypeName)
+            `unexpected concrete type for {{.GoName}}: "%v"`, tn.TypeName)
     }
 }

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -155,10 +155,10 @@ func __unmarshalAnimalFieldsOwnerBeing(b []byte, v *AnimalFieldsOwnerBeing) erro
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for AnimalFieldsOwnerBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for AnimalFieldsOwnerBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -190,7 +190,7 @@ func __marshalAnimalFieldsOwnerBeing(v *AnimalFieldsOwnerBeing) ([]byte, error) 
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for AnimalFieldsOwnerBeing: "%T"`, v)
+			`unexpected concrete type for AnimalFieldsOwnerBeing: "%T"`, v)
 	}
 }
 
@@ -322,10 +322,10 @@ func __unmarshalInnerBeingFields(b []byte, v *InnerBeingFields) error {
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InnerBeingFields: "%v"`, tn.TypeName)
+			`unexpected concrete type for InnerBeingFields: "%v"`, tn.TypeName)
 	}
 }
 
@@ -353,7 +353,7 @@ func __marshalInnerBeingFields(v *InnerBeingFields) ([]byte, error) {
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InnerBeingFields: "%T"`, v)
+			`unexpected concrete type for InnerBeingFields: "%T"`, v)
 	}
 }
 
@@ -416,10 +416,10 @@ func __unmarshalInnerLuckyFields(b []byte, v *InnerLuckyFields) error {
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Lucky.__typename")
+			"response was missing Lucky.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for InnerLuckyFields: "%v"`, tn.TypeName)
+			`unexpected concrete type for InnerLuckyFields: "%v"`, tn.TypeName)
 	}
 }
 
@@ -439,7 +439,7 @@ func __marshalInnerLuckyFields(v *InnerLuckyFields) ([]byte, error) {
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for InnerLuckyFields: "%T"`, v)
+			`unexpected concrete type for InnerLuckyFields: "%T"`, v)
 	}
 }
 
@@ -482,10 +482,10 @@ func __unmarshalLuckyFields(b []byte, v *LuckyFields) error {
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Lucky.__typename")
+			"response was missing Lucky.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for LuckyFields: "%v"`, tn.TypeName)
+			`unexpected concrete type for LuckyFields: "%v"`, tn.TypeName)
 	}
 }
 
@@ -509,7 +509,7 @@ func __marshalLuckyFields(v *LuckyFields) ([]byte, error) {
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for LuckyFields: "%T"`, v)
+			`unexpected concrete type for LuckyFields: "%T"`, v)
 	}
 }
 
@@ -804,10 +804,10 @@ func __unmarshalQueryFragmentBeingsBeing(b []byte, v *QueryFragmentBeingsBeing) 
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for QueryFragmentBeingsBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for QueryFragmentBeingsBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -843,7 +843,7 @@ func __marshalQueryFragmentBeingsBeing(v *QueryFragmentBeingsBeing) ([]byte, err
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for QueryFragmentBeingsBeing: "%T"`, v)
+			`unexpected concrete type for QueryFragmentBeingsBeing: "%T"`, v)
 	}
 }
 
@@ -1773,10 +1773,10 @@ func __unmarshalqueryWithFragmentsBeingsAnimalOwnerBeing(b []byte, v *queryWithF
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for queryWithFragmentsBeingsAnimalOwnerBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for queryWithFragmentsBeingsAnimalOwnerBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -1804,7 +1804,7 @@ func __marshalqueryWithFragmentsBeingsAnimalOwnerBeing(v *queryWithFragmentsBein
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for queryWithFragmentsBeingsAnimalOwnerBeing: "%T"`, v)
+			`unexpected concrete type for queryWithFragmentsBeingsAnimalOwnerBeing: "%T"`, v)
 	}
 }
 
@@ -1868,10 +1868,10 @@ func __unmarshalqueryWithFragmentsBeingsBeing(b []byte, v *queryWithFragmentsBei
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for queryWithFragmentsBeingsBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for queryWithFragmentsBeingsBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -1903,7 +1903,7 @@ func __marshalqueryWithFragmentsBeingsBeing(v *queryWithFragmentsBeingsBeing) ([
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for queryWithFragmentsBeingsBeing: "%T"`, v)
+			`unexpected concrete type for queryWithFragmentsBeingsBeing: "%T"`, v)
 	}
 }
 
@@ -2080,10 +2080,10 @@ func __unmarshalqueryWithInterfaceListFieldBeingsBeing(b []byte, v *queryWithInt
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for queryWithInterfaceListFieldBeingsBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for queryWithInterfaceListFieldBeingsBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -2111,7 +2111,7 @@ func __marshalqueryWithInterfaceListFieldBeingsBeing(v *queryWithInterfaceListFi
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for queryWithInterfaceListFieldBeingsBeing: "%T"`, v)
+			`unexpected concrete type for queryWithInterfaceListFieldBeingsBeing: "%T"`, v)
 	}
 }
 
@@ -2274,10 +2274,10 @@ func __unmarshalqueryWithInterfaceListPointerFieldBeingsBeing(b []byte, v *query
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for queryWithInterfaceListPointerFieldBeingsBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for queryWithInterfaceListPointerFieldBeingsBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -2305,7 +2305,7 @@ func __marshalqueryWithInterfaceListPointerFieldBeingsBeing(v *queryWithInterfac
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for queryWithInterfaceListPointerFieldBeingsBeing: "%T"`, v)
+			`unexpected concrete type for queryWithInterfaceListPointerFieldBeingsBeing: "%T"`, v)
 	}
 }
 
@@ -2455,10 +2455,10 @@ func __unmarshalqueryWithInterfaceNoFragmentsBeing(b []byte, v *queryWithInterfa
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for queryWithInterfaceNoFragmentsBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for queryWithInterfaceNoFragmentsBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -2486,7 +2486,7 @@ func __marshalqueryWithInterfaceNoFragmentsBeing(v *queryWithInterfaceNoFragment
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for queryWithInterfaceNoFragmentsBeing: "%T"`, v)
+			`unexpected concrete type for queryWithInterfaceNoFragmentsBeing: "%T"`, v)
 	}
 }
 
@@ -2743,10 +2743,10 @@ func __unmarshalqueryWithNamedFragmentsBeingsBeing(b []byte, v *queryWithNamedFr
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
-			"Response was missing Being.__typename")
+			"response was missing Being.__typename")
 	default:
 		return fmt.Errorf(
-			`Unexpected concrete type for queryWithNamedFragmentsBeingsBeing: "%v"`, tn.TypeName)
+			`unexpected concrete type for queryWithNamedFragmentsBeingsBeing: "%v"`, tn.TypeName)
 	}
 }
 
@@ -2782,7 +2782,7 @@ func __marshalqueryWithNamedFragmentsBeingsBeing(v *queryWithNamedFragmentsBeing
 		return []byte("null"), nil
 	default:
 		return nil, fmt.Errorf(
-			`Unexpected concrete type for queryWithNamedFragmentsBeingsBeing: "%T"`, v)
+			`unexpected concrete type for queryWithNamedFragmentsBeingsBeing: "%T"`, v)
 	}
 }
 


### PR DESCRIPTION
Error strings should follow established guidelines to ensure good composability and uniformity. A mention of this particular guideline can be found in [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#error-strings).