### PR TITLE
Reject the use of both typename and bind

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ When releasing a new version:
 ### Breaking changes:
 
 - The `Config` fields `Schema` and `Operations` are now both of type `StringList`.  This does not affect configuration via `genqlient.yaml`, only via the Go API.
+- The `typename` and `bind` options may no longer be combined; doing so will now result in an error.  In practice, any such use was likely in error (and the rules for which would win were confusing and undocumented).
 
 ### New features:
 

--- a/docs/genqlient_directive.graphql
+++ b/docs/genqlient_directive.graphql
@@ -226,6 +226,10 @@ directive genqlient(
   # Note that unlike most directives, if applied to the entire operation,
   # typename affects the overall response type, rather than being propagated
   # down to all child fields (which would cause conflicts).
+  #
+  # To avoid confusion, typename may not be combined with local or global
+  # bindings; to use typename instead of a global binding do
+  # `typename: "MyTypeName", bind: "-"`.
   typename: String
 
 # Multiple genqlient directives are allowed in the same location, as long as

--- a/generate/convert.go
+++ b/generate/convert.go
@@ -289,6 +289,11 @@ func (g *generator) convertDefinition(
 	// unless the binding is "-" which means "ignore the global binding".
 	globalBinding, ok := g.Config.Bindings[def.Name]
 	if ok && options.Bind != "-" {
+		if options.TypeName != "" {
+			return nil, errorf(pos,
+				"typename option conflicts with global binding for %s; "+
+					"use `bind: \"-\"` to override it", def.Name)
+		}
 		if def.Kind == ast.Object || def.Kind == ast.Interface || def.Kind == ast.Union {
 			err := g.validateBindingSelection(
 				def.Name, globalBinding, pos, selectionSet)

--- a/generate/testdata/errors/ConflictingTypeNameAndForFieldBind.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndForFieldBind.graphql
@@ -1,0 +1,7 @@
+# @genqlient(for: "User.name", bind: "[]byte")
+query ConflictingTypeNameAndGlobalBind {
+  user {
+    # @genqlient(typename: "MyID")
+    name
+  }
+}

--- a/generate/testdata/errors/ConflictingTypeNameAndForFieldBind.schema.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndForFieldBind.schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  user: User
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/generate/testdata/errors/ConflictingTypeNameAndGlobalBind.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndGlobalBind.graphql
@@ -1,0 +1,8 @@
+query ConflictingTypeNameAndGlobalBind {
+  user {
+    # @genqlient(typename: "OtherScalar")
+    name
+  }
+}
+
+

--- a/generate/testdata/errors/ConflictingTypeNameAndGlobalBind.schema.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndGlobalBind.schema.graphql
@@ -1,0 +1,10 @@
+type Query {
+  user: User
+}
+
+type User {
+  id: ID!
+  name: ValidScalar!
+}
+
+scalar ValidScalar

--- a/generate/testdata/errors/ConflictingTypeNameAndLocalBind.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndLocalBind.graphql
@@ -1,0 +1,6 @@
+query ConflictingTypeNameAndGlobalBind {
+  user {
+    # @genqlient(bind: "[]byte", typename: "MyID")
+    name
+  }
+}

--- a/generate/testdata/errors/ConflictingTypeNameAndLocalBind.schema.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndLocalBind.schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  user: User
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndForFieldBind-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndForFieldBind-graphql
@@ -1,0 +1,1 @@
+testdata/errors/ConflictingTypeNameAndForFieldBind.graphql:5: typename and bind may not be used together

--- a/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndGlobalBind-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndGlobalBind-graphql
@@ -1,0 +1,1 @@
+testdata/errors/ConflictingTypeNameAndGlobalBind.schema.graphql:8: typename option conflicts with global binding for ValidScalar; use `bind: "-"` to override it

--- a/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndLocalBind-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndLocalBind-graphql
@@ -1,0 +1,1 @@
+testdata/errors/ConflictingTypeNameAndLocalBind.graphql:4: typename and bind may not be used together


### PR DESCRIPTION
In #133, Craig added support for a new use of typename, where it applies
to a scalar and means that genqlient should generate a named type, e.g.
`# @genqlient(typename: "MyString")` on a node of type string will
generate and use `type MyString string`.  But this gets a bit confusing
if you mix it with `bind`; should
`typename: "MyString", bind: "int32"` generate `type MyString int32`, or
should one override the other, or what?  Of course in practice you're
not likely to write that all in one place, but you could via a global
binding, or a `for` directive, and in that case probably it was a
mistake.  In #138, we looked at making them work together correctly, but
it added complexity and got even more confusing.

So instead, here, we just ban it; we can always add it back if it proves
useful.  (Or, you can make the `typename` win over a global binding by
locally unbinding it via `bind: "-"`.)  This required changes in
surprisingly many places; I already knew the directive-validation code
was due for a refactor but that will happen some other day.  The tests
show that it works, in any case.

Interestingly, this problem actually could have arisen for a struct
binding already, before #133.  But all the same reasons it's confusing
seem to apply, so I just banned it there too.  This is technically a
breaking change although I doubt anyone will hit it.

Test plan: make check

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla) (hehe I realized I actually should go and sign this now!)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable (n/a)
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
