### PR TITLE
Reject a glob that matches no files

### DIFF
--- a/generate/parse.go
+++ b/generate/parse.go
@@ -72,6 +72,9 @@ func expandFilenames(globs []string) ([]string, error) {
 		if err != nil {
 			return nil, errorf(nil, "can't expand file-glob %v: %v", glob, err)
 		}
+		if len(matches) == 0 {
+			return nil, errorf(nil, "%v did not match any files", glob)
+		}
 		for _, match := range matches {
 			uniqFilenames[match] = true
 		}


### PR DESCRIPTION
The most important case here is if your glob isn't even a glob, it's
just a filename.  But even if it was a glob, it's probably a mistake;
you'll probably end up with a confusing error due to an empty schema, or
a slightly less confusing error due to not having any operations.
Instead, let's just say outright that your glob didn't match any files.

Fixes #146.

Test plan:
This was a bit annoying to test via snapshot, so I just tested it
manually by modifying the example to use a glob that didn't match any
files, first for the schema then for the operations, and got errors like
```
bogus*.graphql did not match any files
exit status 1
example/main.go:68: running "go": exit status 1
```


I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable (see above)
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features (n/a)
- [x] Added an entry to the changelog (n/a, fixing a bug not in a release)
