### PR TITLE
Embed data files in the binary

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,8 @@ When releasing a new version:
 
 ### New features:
 
+- genqlient can now run as a portable binary (i.e. without a local checkout of the repository or `go run`).
+
 ### Bug fixes:
 
 ## v0.4.0

--- a/generate/config.go
+++ b/generate/config.go
@@ -1,8 +1,8 @@
 package generate
 
 import (
+	_ "embed"
 	"go/token"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -123,22 +123,11 @@ func ReadAndValidateConfigFromDefaultLocations() (*Config, error) {
 	return ReadAndValidateConfig(cfgFile)
 }
 
+//go:embed default_genqlient.yaml
+var defaultConfig []byte
+
 func initConfig(filename string) error {
-	// TODO(benkraft): Embed this config file into the binary, see
-	// https://github.com/Khan/genqlient/issues/9.
-	r, err := os.Open(filepath.Join(thisDir, "default_genqlient.yaml"))
-	if err != nil {
-		return err
-	}
-	w, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
-	if err != nil {
-		return errorf(nil, "unable to write default genqlient.yaml: %v", err)
-	}
-	_, err = io.Copy(w, r)
-	if err != nil {
-		return errorf(nil, "unable to write default genqlient.yaml: %v", err)
-	}
-	return nil
+	return ioutil.WriteFile(filename, defaultConfig, 0o644)
 }
 
 // findCfg searches for the config file in this directory and all parents up the tree

--- a/generate/config.go
+++ b/generate/config.go
@@ -127,7 +127,7 @@ func ReadAndValidateConfigFromDefaultLocations() (*Config, error) {
 var defaultConfig []byte
 
 func initConfig(filename string) error {
-	return ioutil.WriteFile(filename, defaultConfig, 0o644)
+	return os.WriteFile(filename, defaultConfig, 0o644)
 }
 
 // findCfg searches for the config file in this directory and all parents up the tree

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -124,7 +124,7 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
-func defaultConfig(t *testing.T) *Config {
+func getDefaultConfig(t *testing.T) *Config {
 	// Parse the config that `genqlient --init` generates, to make sure that
 	// works.
 	var config Config
@@ -151,7 +151,7 @@ func TestGenerateWithConfig(t *testing.T) {
 		baseDir string  // relative to dataDir
 		config  *Config // omits Schema and Operations, set below.
 	}{
-		{"DefaultConfig", "", defaultConfig(t)},
+		{"DefaultConfig", "", getDefaultConfig(t)},
 		{"Subpackage", "", &Config{
 			Generated: "mypkg/myfile.go",
 		}},


### PR DESCRIPTION
Now that we're on Go 1.16+ we can do this easily! The main advantage is
it means users can build a genqlient binary and use that portably (or we
could distribute one, or whatever). Plus the code is marginally simpler;
the `embed` API is really quite nice.

Fixes #9.

Test plan:
```
make check
go build .
rm -rf generate               # pretend we have no checkout
./genqlient ./internal/integration/genqlient.yaml
./genqlient --init            # fails after generating a default config
```

<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->



I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
