### PR TITLE
Remove ioutil

### DIFF
--- a/generate/config.go
+++ b/generate/config.go
@@ -3,7 +3,6 @@ package generate
 import (
 	_ "embed"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -93,7 +92,7 @@ func (c *Config) ValidateAndFillDefaults(baseDir string) error {
 // ReadAndValidateConfig reads the configuration from the given file, validates
 // it, and returns it.
 func ReadAndValidateConfig(filename string) (*Config, error) {
-	text, err := ioutil.ReadFile(filename)
+	text, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errorf(nil, "unreadable config file %v: %v", filename, err)
 	}

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +23,7 @@ const (
 func buildGoFile(namePrefix string, content []byte) error {
 	// We need to put this within the current module, rather than in
 	// /tmp, so that it can access internal/testutil.
-	f, err := ioutil.TempFile("./testdata/tmp", namePrefix+"_*.go")
+	f, err := os.CreateTemp("./testdata/tmp", namePrefix+"_*.go")
 	if err != nil {
 		return err
 	}
@@ -61,7 +60,7 @@ func buildGoFile(namePrefix string, content []byte) error {
 // update the snapshots.  Make sure to check that the output is sensible; the
 // snapshots don't even get compiled!
 func TestGenerate(t *testing.T) {
-	files, err := ioutil.ReadDir(dataDir)
+	files, err := os.ReadDir(dataDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +127,7 @@ func getDefaultConfig(t *testing.T) *Config {
 	// Parse the config that `genqlient --init` generates, to make sure that
 	// works.
 	var config Config
-	b, err := ioutil.ReadFile("default_genqlient.yaml")
+	b, err := os.ReadFile("default_genqlient.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +240,7 @@ func TestGenerateWithConfig(t *testing.T) {
 // line numbers, etc.  We include both .go and .graphql tests, to make sure the
 // line numbers work in both cases.
 func TestGenerateErrors(t *testing.T) {
-	files, err := ioutil.ReadDir(errorsDir)
+	files, err := os.ReadDir(errorsDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generate/main.go
+++ b/generate/main.go
@@ -5,7 +5,6 @@ package generate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +40,7 @@ func readConfigGenerateAndWrite(configFilename string) error {
 				filename, err)
 		}
 
-		err = ioutil.WriteFile(filename, content, 0o644)
+		err = os.WriteFile(filename, content, 0o644)
 		if err != nil {
 			return errorf(nil, "could not write generated file %v: %v",
 				filename, err)

--- a/generate/parse.go
+++ b/generate/parse.go
@@ -5,7 +5,7 @@ import (
 	goAst "go/ast"
 	goParser "go/parser"
 	goToken "go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -25,7 +25,7 @@ func getSchema(globs StringList) (*ast.Schema, error) {
 
 	sources := make([]*ast.Source, len(filenames))
 	for i, filename := range filenames {
-		text, err := ioutil.ReadFile(filename)
+		text, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, errorf(nil, "unreadable schema file %v: %v", filename, err)
 		}
@@ -105,7 +105,7 @@ func getQueries(basedir string, globs StringList) (*ast.QueryDocument, error) {
 	}
 
 	for _, filename := range filenames {
-		text, err := ioutil.ReadFile(filename)
+		text, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, errorf(nil, "unreadable query-spec file %v: %v", filename, err)
 		}

--- a/graphql/client.go
+++ b/graphql/client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -118,7 +118,7 @@ func (c *client) MakeRequest(ctx context.Context, opName string, query string, r
 
 	if resp.StatusCode != http.StatusOK {
 		var respBody []byte
-		respBody, err = ioutil.ReadAll(resp.Body)
+		respBody, err = io.ReadAll(resp.Body)
 		if err != nil {
 			respBody = []byte(fmt.Sprintf("<unreadable: %v>", err))
 		}

--- a/internal/integration/roundtrip.go
+++ b/internal/integration/roundtrip.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -29,13 +29,13 @@ func (t *lastResponseTransport) RoundTrip(req *http.Request) (*http.Response, er
 		return resp, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return resp, fmt.Errorf("roundtrip failed: unreadable body: %w", err)
 	}
 	t.lastResponseBody = body
 	// Restore the body for the next reader:
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	resp.Body = io.NopCloser(bytes.NewBuffer(body))
 	return resp, err
 }
 

--- a/internal/integration/util.go
+++ b/internal/integration/util.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -42,7 +41,7 @@ func RunGenerateTest(t *testing.T, relConfigFilename string) {
 	}
 
 	for filename, content := range generated {
-		expectedContent, err := ioutil.ReadFile(filename)
+		expectedContent, err := os.ReadFile(filename)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
In 1.16, it's now deprecated and replaced by `io` and `os`.  Let's
upgrade!

Test plan:
- make check
- git grep ioutil

<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->



I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
