### PR TITLE
Reject operation or argument names that are Go keywords

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,8 @@ When releasing a new version:
 
 ### Bug fixes:
 
+- genqlient now explicitly rejects argument, operation, and type names which are Go keywords, rather than failing with an opaque error.
+
 ## v0.4.0
 
 Version 0.4.0 adds several new configuration options, as well as additional methods to simplify the use of interfaces.

--- a/generate/convert.go
+++ b/generate/convert.go
@@ -164,6 +164,10 @@ func (g *generator) convertArguments(
 	name := "__" + operation.Name + "Input"
 	fields := make([]*goStructField, len(operation.VariableDefinitions))
 	for i, arg := range operation.VariableDefinitions {
+		if goKeywords[arg.Variable] {
+			return nil, errorf(arg.Position, "variable name must not be a go keyword")
+		}
+
 		_, options, err := g.parsePrecedingComment(arg, nil, arg.Position, queryOptions)
 		if err != nil {
 			return nil, err
@@ -317,6 +321,9 @@ func (g *generator) convertDefinition(
 	// Determine the name to use for this type.
 	var name string
 	if options.TypeName != "" {
+		if goKeywords[options.TypeName] {
+			return nil, errorf(pos, "typename option must not be a go keyword")
+		}
 		// If the user specified a name, use it!
 		name = options.TypeName
 		if namePrefix != nil && namePrefix.head == name && namePrefix.tail == nil {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -232,6 +232,8 @@ func (g *generator) preprocessQueryDocument(doc *ast.QueryDocument) {
 func (g *generator) addOperation(op *ast.OperationDefinition) error {
 	if op.Name == "" {
 		return errorf(op.Position, "operations must have operation-names")
+	} else if goKeywords[op.Name] {
+		return errorf(op.Position, "operation name must not be a go keyword")
 	}
 
 	queryDoc := &ast.QueryDocument{

--- a/generate/testdata/errors/KeywordArgumentName.graphql
+++ b/generate/testdata/errors/KeywordArgumentName.graphql
@@ -1,0 +1,3 @@
+query KeywordArgumentName($type: String) {
+  f(type: $type)
+}

--- a/generate/testdata/errors/KeywordArgumentName.schema.graphql
+++ b/generate/testdata/errors/KeywordArgumentName.schema.graphql
@@ -1,0 +1,1 @@
+type Query { f(type: String): String }

--- a/generate/testdata/errors/KeywordOperationName.graphql
+++ b/generate/testdata/errors/KeywordOperationName.graphql
@@ -1,0 +1,1 @@
+query type { f }

--- a/generate/testdata/errors/KeywordOperationName.schema.graphql
+++ b/generate/testdata/errors/KeywordOperationName.schema.graphql
@@ -1,0 +1,1 @@
+type Query { f: String }

--- a/generate/testdata/errors/KeywordTypeName.graphql
+++ b/generate/testdata/errors/KeywordTypeName.graphql
@@ -1,0 +1,6 @@
+query KeywordTypeName {
+  # @genqlient(typename: "type")
+  f {
+    g
+  }
+}

--- a/generate/testdata/errors/KeywordTypeName.schema.graphql
+++ b/generate/testdata/errors/KeywordTypeName.schema.graphql
@@ -1,0 +1,2 @@
+type Query { f: T }
+type T { g: String }

--- a/generate/testdata/snapshots/TestGenerateErrors-KeywordArgumentName-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-KeywordArgumentName-graphql
@@ -1,0 +1,1 @@
+testdata/errors/KeywordArgumentName.graphql:1: variable name must not be a go keyword

--- a/generate/testdata/snapshots/TestGenerateErrors-KeywordOperationName-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-KeywordOperationName-graphql
@@ -1,0 +1,1 @@
+testdata/errors/KeywordOperationName.graphql:1: operation name must not be a go keyword

--- a/generate/testdata/snapshots/TestGenerateErrors-KeywordTypeName-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-KeywordTypeName-graphql
@@ -1,0 +1,1 @@
+testdata/errors/KeywordTypeName.schema.graphql:1: typename option must not be a go keyword

--- a/generate/util.go
+++ b/generate/util.go
@@ -46,3 +46,32 @@ func goConstName(s string) string {
 		return ret
 	}, s)
 }
+
+// https://go.dev/ref/spec#Keywords
+var goKeywords = map[string]bool{
+	"break":       true,
+	"default":     true,
+	"func":        true,
+	"interface":   true,
+	"select":      true,
+	"case":        true,
+	"defer":       true,
+	"go":          true,
+	"map":         true,
+	"struct":      true,
+	"chan":        true,
+	"else":        true,
+	"goto":        true,
+	"package":     true,
+	"switch":      true,
+	"const":       true,
+	"fallthrough": true,
+	"if":          true,
+	"range":       true,
+	"type":        true,
+	"continue":    true,
+	"for":         true,
+	"import":      true,
+	"return":      true,
+	"var":         true,
+}


### PR DESCRIPTION
GraphQL is pretty restrictive about its identifiers, so for the most
part we can and do safely use GraphQL identifiers in the Go we generate
with attention only to conflicts with other such identifiers. But we do
need to check one thing, which is that the identifier isn't a Go
keyword. (If it is, the generated code will almost certainly fail to
compile, but often with a confusing error message.) In this commit I add
such checks.

The most likely place to run into trouble here is argument names, which
are often one word and are used as-is.  Operation names, if unexported,
can also be keywords, although in practice they're usually multiword.
Field names are always exported, thus safe.  Generated type names are
always prefixed, camel-cased, with the operation name, so they always
contain an uppercase letter (even if the operation name is lowercase),
but type-names specified by `typename` may collide, so we check those.
In theory we could check type-names specified by `bind`, but these must
be defined by the user, so their code will already fail to compile, so I
didn't bother.  I think that's all the places to consider, although it's
hard to be sure.  In summary, we check argument names, operation names,
and user-specified type names.

Fixes #194.

Test plan: make check

<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->



I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
