### PR TITLE
Simplify errors tests a bit so they don't all have to write a schema

### DIFF
--- a/generate/convert.go
+++ b/generate/convert.go
@@ -290,7 +290,8 @@ func (g *generator) convertDefinition(
 	globalBinding, ok := g.Config.Bindings[def.Name]
 	if ok && options.Bind != "-" {
 		if options.TypeName != "" {
-			return nil, errorf(pos,
+			// The option position (in the query) is more useful here.
+			return nil, errorf(options.pos,
 				"typename option conflicts with global binding for %s; "+
 					"use `bind: \"-\"` to override it", def.Name)
 		}

--- a/generate/testdata/errors/ConflictingDirectiveArguments.schema.graphql
+++ b/generate/testdata/errors/ConflictingDirectiveArguments.schema.graphql
@@ -1,3 +1,0 @@
-type Query {
-  f: String
-}

--- a/generate/testdata/errors/ConflictingDirectives.schema.graphql
+++ b/generate/testdata/errors/ConflictingDirectives.schema.graphql
@@ -1,3 +1,0 @@
-type Query {
-  f: String
-}

--- a/generate/testdata/errors/ConflictingTypeNameAndForFieldBind.schema.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndForFieldBind.schema.graphql
@@ -1,8 +1,0 @@
-type Query {
-  user: User
-}
-
-type User {
-  id: ID!
-  name: String!
-}

--- a/generate/testdata/errors/ConflictingTypeNameAndLocalBind.schema.graphql
+++ b/generate/testdata/errors/ConflictingTypeNameAndLocalBind.schema.graphql
@@ -1,8 +1,0 @@
-type Query {
-  user: User
-}
-
-type User {
-  id: ID!
-  name: String!
-}

--- a/generate/testdata/errors/InvalidQuery.schema.graphql
+++ b/generate/testdata/errors/InvalidQuery.schema.graphql
@@ -1,3 +1,0 @@
-type Query {
-  f: String
-}

--- a/generate/testdata/errors/NoQuery.schema.graphql
+++ b/generate/testdata/errors/NoQuery.schema.graphql
@@ -1,1 +1,0 @@
-type Query { f: String }

--- a/generate/testdata/errors/schema.graphql
+++ b/generate/testdata/errors/schema.graphql
@@ -1,4 +1,5 @@
 type Query {
+  f: String
   user: User
 }
 

--- a/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndGlobalBind-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-ConflictingTypeNameAndGlobalBind-graphql
@@ -1,1 +1,1 @@
-testdata/errors/ConflictingTypeNameAndGlobalBind.schema.graphql:8: typename option conflicts with global binding for ValidScalar; use `bind: "-"` to override it
+testdata/errors/ConflictingTypeNameAndGlobalBind.graphql:4: typename option conflicts with global binding for ValidScalar; use `bind: "-"` to override it


### PR DESCRIPTION
Some of the errors tests need to have their own schema, so the schema
can do something weird (or even be entirely invalid!).  But most can
still share a schema.  In this commit I have those indeed share a
schema, to avoid having to have a bunch of copies of mostly the same
schema.  While doing so I noticed one error whose location wasn't very
useful, and fixed it.

Test plan: make check

<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->



I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
