### PR TITLE
Validate against a case gqlparser doesn't catch

### DIFF
--- a/generate/testdata/errors/NoMutationType.graphql
+++ b/generate/testdata/errors/NoMutationType.graphql
@@ -1,0 +1,1 @@
+mutation M { g }

--- a/generate/testdata/errors/NoMutationType.schema.graphql
+++ b/generate/testdata/errors/NoMutationType.schema.graphql
@@ -1,0 +1,1 @@
+type Query { f: String }

--- a/generate/testdata/errors/NoQueryType.graphql
+++ b/generate/testdata/errors/NoQueryType.graphql
@@ -1,0 +1,1 @@
+query Q { f }

--- a/generate/testdata/errors/NoQueryType.schema.graphql
+++ b/generate/testdata/errors/NoQueryType.schema.graphql
@@ -1,0 +1,1 @@
+type T { f: String }

--- a/generate/testdata/snapshots/TestGenerateErrors-NoMutationType-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-NoMutationType-graphql
@@ -1,0 +1,1 @@
+testdata/errors/NoMutationType.graphql:1: schema has no mutation type

--- a/generate/testdata/snapshots/TestGenerateErrors-NoQueryType-graphql
+++ b/generate/testdata/snapshots/TestGenerateErrors-NoQueryType-graphql
@@ -1,0 +1,1 @@
+testdata/errors/NoQueryType.graphql:1: schema has no query type


### PR DESCRIPTION
While writing tests at some point I came across an invalid query that
gqlparser doesn't catch (see vektah/gqlparser#221), and which causes
a panic for us.  Now we validate for it and return a nice error instead of
panicking.

Fixes #176.

Test plan: make check

<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->



I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
