### PR TITLE
make output deterministic for graphql interfaces

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,8 @@ When releasing a new version:
 
 ### Bug fixes:
 
+- Fixed non-deterministic generated code when querying graphql interfaces
+
 ## v0.5.0
 
 Version 0.5.0 adds several new configuration options and convenience features. Note that genqlient now requires Go 1.16 or higher, and is tested through Go 1.18.

--- a/generate/convert.go
+++ b/generate/convert.go
@@ -11,6 +11,7 @@ package generate
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -465,6 +466,8 @@ func (g *generator) convertDefinition(
 		}
 
 		implementationTypes := g.schema.GetPossibleTypes(def)
+		// Make sure we generate stable output by sorting the types by name when we get them
+		sort.Slice(implementationTypes, func(i, j int) bool { return implementationTypes[i].Name < implementationTypes[j].Name })
 		goType := &goInterfaceType{
 			GoName:          name,
 			SharedFields:    sharedFields,

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -44,8 +44,8 @@ func (v *ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) G
 //
 // ComplexInlineFragmentsConflictingStuffContent is implemented by the following types:
 // ComplexInlineFragmentsConflictingStuffArticle
-// ComplexInlineFragmentsConflictingStuffVideo
 // ComplexInlineFragmentsConflictingStuffTopic
+// ComplexInlineFragmentsConflictingStuffVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -57,9 +57,9 @@ type ComplexInlineFragmentsConflictingStuffContent interface {
 
 func (v *ComplexInlineFragmentsConflictingStuffArticle) implementsGraphQLInterfaceComplexInlineFragmentsConflictingStuffContent() {
 }
-func (v *ComplexInlineFragmentsConflictingStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsConflictingStuffContent() {
-}
 func (v *ComplexInlineFragmentsConflictingStuffTopic) implementsGraphQLInterfaceComplexInlineFragmentsConflictingStuffContent() {
+}
+func (v *ComplexInlineFragmentsConflictingStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsConflictingStuffContent() {
 }
 
 func __unmarshalComplexInlineFragmentsConflictingStuffContent(b []byte, v *ComplexInlineFragmentsConflictingStuffContent) error {
@@ -79,11 +79,11 @@ func __unmarshalComplexInlineFragmentsConflictingStuffContent(b []byte, v *Compl
 	case "Article":
 		*v = new(ComplexInlineFragmentsConflictingStuffArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ComplexInlineFragmentsConflictingStuffVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ComplexInlineFragmentsConflictingStuffTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ComplexInlineFragmentsConflictingStuffVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -106,20 +106,20 @@ func __marshalComplexInlineFragmentsConflictingStuffContent(v *ComplexInlineFrag
 			*ComplexInlineFragmentsConflictingStuffArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ComplexInlineFragmentsConflictingStuffVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ComplexInlineFragmentsConflictingStuffVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ComplexInlineFragmentsConflictingStuffTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ComplexInlineFragmentsConflictingStuffTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsConflictingStuffVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsConflictingStuffVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -178,8 +178,8 @@ func (v *ComplexInlineFragmentsNestedStuffArticle) GetTypename() string { return
 //
 // ComplexInlineFragmentsNestedStuffContent is implemented by the following types:
 // ComplexInlineFragmentsNestedStuffArticle
-// ComplexInlineFragmentsNestedStuffVideo
 // ComplexInlineFragmentsNestedStuffTopic
+// ComplexInlineFragmentsNestedStuffVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -191,9 +191,9 @@ type ComplexInlineFragmentsNestedStuffContent interface {
 
 func (v *ComplexInlineFragmentsNestedStuffArticle) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffContent() {
 }
-func (v *ComplexInlineFragmentsNestedStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffContent() {
-}
 func (v *ComplexInlineFragmentsNestedStuffTopic) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffContent() {
+}
+func (v *ComplexInlineFragmentsNestedStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffContent() {
 }
 
 func __unmarshalComplexInlineFragmentsNestedStuffContent(b []byte, v *ComplexInlineFragmentsNestedStuffContent) error {
@@ -213,11 +213,11 @@ func __unmarshalComplexInlineFragmentsNestedStuffContent(b []byte, v *ComplexInl
 	case "Article":
 		*v = new(ComplexInlineFragmentsNestedStuffArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ComplexInlineFragmentsNestedStuffVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ComplexInlineFragmentsNestedStuffTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ComplexInlineFragmentsNestedStuffVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -240,14 +240,6 @@ func __marshalComplexInlineFragmentsNestedStuffContent(v *ComplexInlineFragments
 			*ComplexInlineFragmentsNestedStuffArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ComplexInlineFragmentsNestedStuffVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ComplexInlineFragmentsNestedStuffVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ComplexInlineFragmentsNestedStuffTopic:
 		typename = "Topic"
 
@@ -259,6 +251,14 @@ func __marshalComplexInlineFragmentsNestedStuffContent(v *ComplexInlineFragments
 			TypeName string `json:"__typename"`
 			*__premarshalComplexInlineFragmentsNestedStuffTopic
 		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffVideo
+		}{typename, v}
 		return json.Marshal(result)
 	case nil:
 		return []byte("null"), nil
@@ -497,8 +497,8 @@ func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParen
 //
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent is implemented by the following types:
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle
-// ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic
+// ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -517,9 +517,9 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent() {
 }
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent() {
-}
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent() {
+}
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent() {
 }
 
 func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent(b []byte, v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent) error {
@@ -539,11 +539,11 @@ func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentConte
 	case "Article":
 		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -566,20 +566,20 @@ func __marshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContent
 			*ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -656,8 +656,8 @@ func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) GetPa
 //
 // ComplexInlineFragmentsNestedStuffTopicChildrenContent is implemented by the following types:
 // ComplexInlineFragmentsNestedStuffTopicChildrenArticle
-// ComplexInlineFragmentsNestedStuffTopicChildrenVideo
 // ComplexInlineFragmentsNestedStuffTopicChildrenTopic
+// ComplexInlineFragmentsNestedStuffTopicChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -674,9 +674,9 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenContent interface {
 
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenContent() {
 }
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenContent() {
-}
 func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenContent() {
+}
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) implementsGraphQLInterfaceComplexInlineFragmentsNestedStuffTopicChildrenContent() {
 }
 
 func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenContent(b []byte, v *ComplexInlineFragmentsNestedStuffTopicChildrenContent) error {
@@ -696,11 +696,11 @@ func __unmarshalComplexInlineFragmentsNestedStuffTopicChildrenContent(b []byte, 
 	case "Article":
 		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ComplexInlineFragmentsNestedStuffTopicChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -723,20 +723,20 @@ func __marshalComplexInlineFragmentsNestedStuffTopicChildrenContent(v *ComplexIn
 			*ComplexInlineFragmentsNestedStuffTopicChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ComplexInlineFragmentsNestedStuffTopicChildrenVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ComplexInlineFragmentsNestedStuffTopicChildrenVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ComplexInlineFragmentsNestedStuffTopicChildrenTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ComplexInlineFragmentsNestedStuffTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsNestedStuffTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsNestedStuffTopicChildrenVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -806,8 +806,8 @@ func (v *ComplexInlineFragmentsRandomItemArticle) GetName() string { return v.Na
 //
 // ComplexInlineFragmentsRandomItemContent is implemented by the following types:
 // ComplexInlineFragmentsRandomItemArticle
-// ComplexInlineFragmentsRandomItemVideo
 // ComplexInlineFragmentsRandomItemTopic
+// ComplexInlineFragmentsRandomItemVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -826,9 +826,9 @@ type ComplexInlineFragmentsRandomItemContent interface {
 
 func (v *ComplexInlineFragmentsRandomItemArticle) implementsGraphQLInterfaceComplexInlineFragmentsRandomItemContent() {
 }
-func (v *ComplexInlineFragmentsRandomItemVideo) implementsGraphQLInterfaceComplexInlineFragmentsRandomItemContent() {
-}
 func (v *ComplexInlineFragmentsRandomItemTopic) implementsGraphQLInterfaceComplexInlineFragmentsRandomItemContent() {
+}
+func (v *ComplexInlineFragmentsRandomItemVideo) implementsGraphQLInterfaceComplexInlineFragmentsRandomItemContent() {
 }
 
 func __unmarshalComplexInlineFragmentsRandomItemContent(b []byte, v *ComplexInlineFragmentsRandomItemContent) error {
@@ -848,11 +848,11 @@ func __unmarshalComplexInlineFragmentsRandomItemContent(b []byte, v *ComplexInli
 	case "Article":
 		*v = new(ComplexInlineFragmentsRandomItemArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ComplexInlineFragmentsRandomItemVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ComplexInlineFragmentsRandomItemTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ComplexInlineFragmentsRandomItemVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -875,20 +875,20 @@ func __marshalComplexInlineFragmentsRandomItemContent(v *ComplexInlineFragmentsR
 			*ComplexInlineFragmentsRandomItemArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ComplexInlineFragmentsRandomItemVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ComplexInlineFragmentsRandomItemVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ComplexInlineFragmentsRandomItemTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ComplexInlineFragmentsRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsRandomItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRandomItemVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -975,8 +975,8 @@ func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherName() string { ret
 //
 // ComplexInlineFragmentsRepeatedStuffContent is implemented by the following types:
 // ComplexInlineFragmentsRepeatedStuffArticle
-// ComplexInlineFragmentsRepeatedStuffVideo
 // ComplexInlineFragmentsRepeatedStuffTopic
+// ComplexInlineFragmentsRepeatedStuffVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -1004,9 +1004,9 @@ type ComplexInlineFragmentsRepeatedStuffContent interface {
 
 func (v *ComplexInlineFragmentsRepeatedStuffArticle) implementsGraphQLInterfaceComplexInlineFragmentsRepeatedStuffContent() {
 }
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsRepeatedStuffContent() {
-}
 func (v *ComplexInlineFragmentsRepeatedStuffTopic) implementsGraphQLInterfaceComplexInlineFragmentsRepeatedStuffContent() {
+}
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) implementsGraphQLInterfaceComplexInlineFragmentsRepeatedStuffContent() {
 }
 
 func __unmarshalComplexInlineFragmentsRepeatedStuffContent(b []byte, v *ComplexInlineFragmentsRepeatedStuffContent) error {
@@ -1026,11 +1026,11 @@ func __unmarshalComplexInlineFragmentsRepeatedStuffContent(b []byte, v *ComplexI
 	case "Article":
 		*v = new(ComplexInlineFragmentsRepeatedStuffArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ComplexInlineFragmentsRepeatedStuffVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ComplexInlineFragmentsRepeatedStuffTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ComplexInlineFragmentsRepeatedStuffVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -1053,20 +1053,20 @@ func __marshalComplexInlineFragmentsRepeatedStuffContent(v *ComplexInlineFragmen
 			*ComplexInlineFragmentsRepeatedStuffArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ComplexInlineFragmentsRepeatedStuffVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ComplexInlineFragmentsRepeatedStuffVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ComplexInlineFragmentsRepeatedStuffTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ComplexInlineFragmentsRepeatedStuffTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ComplexInlineFragmentsRepeatedStuffVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ComplexInlineFragmentsRepeatedStuffVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -701,8 +701,8 @@ func (v *InnerQueryFragmentRandomItemArticle) __premarshalJSON() (*__premarshalI
 //
 // InnerQueryFragmentRandomItemContent is implemented by the following types:
 // InnerQueryFragmentRandomItemArticle
-// InnerQueryFragmentRandomItemVideo
 // InnerQueryFragmentRandomItemTopic
+// InnerQueryFragmentRandomItemVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -722,9 +722,9 @@ type InnerQueryFragmentRandomItemContent interface {
 
 func (v *InnerQueryFragmentRandomItemArticle) implementsGraphQLInterfaceInnerQueryFragmentRandomItemContent() {
 }
-func (v *InnerQueryFragmentRandomItemVideo) implementsGraphQLInterfaceInnerQueryFragmentRandomItemContent() {
-}
 func (v *InnerQueryFragmentRandomItemTopic) implementsGraphQLInterfaceInnerQueryFragmentRandomItemContent() {
+}
+func (v *InnerQueryFragmentRandomItemVideo) implementsGraphQLInterfaceInnerQueryFragmentRandomItemContent() {
 }
 
 func __unmarshalInnerQueryFragmentRandomItemContent(b []byte, v *InnerQueryFragmentRandomItemContent) error {
@@ -744,11 +744,11 @@ func __unmarshalInnerQueryFragmentRandomItemContent(b []byte, v *InnerQueryFragm
 	case "Article":
 		*v = new(InnerQueryFragmentRandomItemArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InnerQueryFragmentRandomItemVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InnerQueryFragmentRandomItemTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InnerQueryFragmentRandomItemVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -775,18 +775,6 @@ func __marshalInnerQueryFragmentRandomItemContent(v *InnerQueryFragmentRandomIte
 			*__premarshalInnerQueryFragmentRandomItemArticle
 		}{typename, premarshaled}
 		return json.Marshal(result)
-	case *InnerQueryFragmentRandomItemVideo:
-		typename = "Video"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalInnerQueryFragmentRandomItemVideo
-		}{typename, premarshaled}
-		return json.Marshal(result)
 	case *InnerQueryFragmentRandomItemTopic:
 		typename = "Topic"
 
@@ -797,6 +785,18 @@ func __marshalInnerQueryFragmentRandomItemContent(v *InnerQueryFragmentRandomIte
 		result := struct {
 			TypeName string `json:"__typename"`
 			*__premarshalInnerQueryFragmentRandomItemTopic
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *InnerQueryFragmentRandomItemVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalInnerQueryFragmentRandomItemVideo
 		}{typename, premarshaled}
 		return json.Marshal(result)
 	case nil:
@@ -1360,8 +1360,8 @@ func (v *MoreVideoFieldsParentTopicChildrenArticle) GetTypename() *string { retu
 //
 // MoreVideoFieldsParentTopicChildrenContent is implemented by the following types:
 // MoreVideoFieldsParentTopicChildrenArticle
-// MoreVideoFieldsParentTopicChildrenVideo
 // MoreVideoFieldsParentTopicChildrenTopic
+// MoreVideoFieldsParentTopicChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -1373,9 +1373,9 @@ type MoreVideoFieldsParentTopicChildrenContent interface {
 
 func (v *MoreVideoFieldsParentTopicChildrenArticle) implementsGraphQLInterfaceMoreVideoFieldsParentTopicChildrenContent() {
 }
-func (v *MoreVideoFieldsParentTopicChildrenVideo) implementsGraphQLInterfaceMoreVideoFieldsParentTopicChildrenContent() {
-}
 func (v *MoreVideoFieldsParentTopicChildrenTopic) implementsGraphQLInterfaceMoreVideoFieldsParentTopicChildrenContent() {
+}
+func (v *MoreVideoFieldsParentTopicChildrenVideo) implementsGraphQLInterfaceMoreVideoFieldsParentTopicChildrenContent() {
 }
 
 func __unmarshalMoreVideoFieldsParentTopicChildrenContent(b []byte, v *MoreVideoFieldsParentTopicChildrenContent) error {
@@ -1395,11 +1395,11 @@ func __unmarshalMoreVideoFieldsParentTopicChildrenContent(b []byte, v *MoreVideo
 	case "Article":
 		*v = new(MoreVideoFieldsParentTopicChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(MoreVideoFieldsParentTopicChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(MoreVideoFieldsParentTopicChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(MoreVideoFieldsParentTopicChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -1422,6 +1422,14 @@ func __marshalMoreVideoFieldsParentTopicChildrenContent(v *MoreVideoFieldsParent
 			*MoreVideoFieldsParentTopicChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
+	case *MoreVideoFieldsParentTopicChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*MoreVideoFieldsParentTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
 	case *MoreVideoFieldsParentTopicChildrenVideo:
 		typename = "Video"
 
@@ -1433,14 +1441,6 @@ func __marshalMoreVideoFieldsParentTopicChildrenContent(v *MoreVideoFieldsParent
 			TypeName string `json:"__typename"`
 			*__premarshalMoreVideoFieldsParentTopicChildrenVideo
 		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *MoreVideoFieldsParentTopicChildrenTopic:
-		typename = "Topic"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*MoreVideoFieldsParentTopicChildrenTopic
-		}{typename, v}
 		return json.Marshal(result)
 	case nil:
 		return []byte("null"), nil

--- a/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
@@ -17,8 +17,8 @@ import (
 //
 // ContentFields is implemented by the following types:
 // ContentFieldsArticle
-// ContentFieldsVideo
 // ContentFieldsTopic
+// ContentFieldsVideo
 type ContentFields interface {
 	implementsGraphQLInterfaceContentFields()
 	// GetNext returns the interface-field "next" from its implementation.
@@ -28,8 +28,8 @@ type ContentFields interface {
 }
 
 func (v *ContentFieldsArticle) implementsGraphQLInterfaceContentFields() {}
-func (v *ContentFieldsVideo) implementsGraphQLInterfaceContentFields()   {}
 func (v *ContentFieldsTopic) implementsGraphQLInterfaceContentFields()   {}
+func (v *ContentFieldsVideo) implementsGraphQLInterfaceContentFields()   {}
 
 func __unmarshalContentFields(b []byte, v *ContentFields) error {
 	if string(b) == "null" {
@@ -48,11 +48,11 @@ func __unmarshalContentFields(b []byte, v *ContentFields) error {
 	case "Article":
 		*v = new(ContentFieldsArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ContentFieldsVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ContentFieldsTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ContentFieldsVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -79,18 +79,6 @@ func __marshalContentFields(v *ContentFields) ([]byte, error) {
 			*__premarshalContentFieldsArticle
 		}{typename, premarshaled}
 		return json.Marshal(result)
-	case *ContentFieldsVideo:
-		typename = "Video"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalContentFieldsVideo
-		}{typename, premarshaled}
-		return json.Marshal(result)
 	case *ContentFieldsTopic:
 		typename = "Topic"
 
@@ -101,6 +89,18 @@ func __marshalContentFields(v *ContentFields) ([]byte, error) {
 		result := struct {
 			TypeName string `json:"__typename"`
 			*__premarshalContentFieldsTopic
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *ContentFieldsVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalContentFieldsVideo
 		}{typename, premarshaled}
 		return json.Marshal(result)
 	case nil:
@@ -246,8 +246,8 @@ func (v *ContentFieldsNextArticle) GetId() testutil.ID { return v.Id }
 //
 // ContentFieldsNextContent is implemented by the following types:
 // ContentFieldsNextArticle
-// ContentFieldsNextVideo
 // ContentFieldsNextTopic
+// ContentFieldsNextVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -263,8 +263,8 @@ type ContentFieldsNextContent interface {
 }
 
 func (v *ContentFieldsNextArticle) implementsGraphQLInterfaceContentFieldsNextContent() {}
-func (v *ContentFieldsNextVideo) implementsGraphQLInterfaceContentFieldsNextContent()   {}
 func (v *ContentFieldsNextTopic) implementsGraphQLInterfaceContentFieldsNextContent()   {}
+func (v *ContentFieldsNextVideo) implementsGraphQLInterfaceContentFieldsNextContent()   {}
 
 func __unmarshalContentFieldsNextContent(b []byte, v *ContentFieldsNextContent) error {
 	if string(b) == "null" {
@@ -283,11 +283,11 @@ func __unmarshalContentFieldsNextContent(b []byte, v *ContentFieldsNextContent) 
 	case "Article":
 		*v = new(ContentFieldsNextArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ContentFieldsNextVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ContentFieldsNextTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ContentFieldsNextVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -310,20 +310,20 @@ func __marshalContentFieldsNextContent(v *ContentFieldsNextContent) ([]byte, err
 			*ContentFieldsNextArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ContentFieldsNextVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ContentFieldsNextVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ContentFieldsNextTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ContentFieldsNextTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ContentFieldsNextVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ContentFieldsNextVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -377,8 +377,8 @@ func (v *ContentFieldsRelatedArticle) GetId() testutil.ID { return v.Id }
 //
 // ContentFieldsRelatedContent is implemented by the following types:
 // ContentFieldsRelatedArticle
-// ContentFieldsRelatedVideo
 // ContentFieldsRelatedTopic
+// ContentFieldsRelatedVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -394,8 +394,8 @@ type ContentFieldsRelatedContent interface {
 }
 
 func (v *ContentFieldsRelatedArticle) implementsGraphQLInterfaceContentFieldsRelatedContent() {}
-func (v *ContentFieldsRelatedVideo) implementsGraphQLInterfaceContentFieldsRelatedContent()   {}
 func (v *ContentFieldsRelatedTopic) implementsGraphQLInterfaceContentFieldsRelatedContent()   {}
+func (v *ContentFieldsRelatedVideo) implementsGraphQLInterfaceContentFieldsRelatedContent()   {}
 
 func __unmarshalContentFieldsRelatedContent(b []byte, v *ContentFieldsRelatedContent) error {
 	if string(b) == "null" {
@@ -414,11 +414,11 @@ func __unmarshalContentFieldsRelatedContent(b []byte, v *ContentFieldsRelatedCon
 	case "Article":
 		*v = new(ContentFieldsRelatedArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ContentFieldsRelatedVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ContentFieldsRelatedTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ContentFieldsRelatedVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -441,20 +441,20 @@ func __marshalContentFieldsRelatedContent(v *ContentFieldsRelatedContent) ([]byt
 			*ContentFieldsRelatedArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ContentFieldsRelatedVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ContentFieldsRelatedVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ContentFieldsRelatedTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ContentFieldsRelatedTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ContentFieldsRelatedVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ContentFieldsRelatedVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -865,8 +865,8 @@ func (v *CovariantInterfaceImplementationRandomItemArticle) __premarshalJSON() (
 //
 // CovariantInterfaceImplementationRandomItemContent is implemented by the following types:
 // CovariantInterfaceImplementationRandomItemArticle
-// CovariantInterfaceImplementationRandomItemVideo
 // CovariantInterfaceImplementationRandomItemTopic
+// CovariantInterfaceImplementationRandomItemVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -887,9 +887,9 @@ type CovariantInterfaceImplementationRandomItemContent interface {
 
 func (v *CovariantInterfaceImplementationRandomItemArticle) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContent() {
 }
-func (v *CovariantInterfaceImplementationRandomItemVideo) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContent() {
-}
 func (v *CovariantInterfaceImplementationRandomItemTopic) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContent() {
+}
+func (v *CovariantInterfaceImplementationRandomItemVideo) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContent() {
 }
 
 func __unmarshalCovariantInterfaceImplementationRandomItemContent(b []byte, v *CovariantInterfaceImplementationRandomItemContent) error {
@@ -909,11 +909,11 @@ func __unmarshalCovariantInterfaceImplementationRandomItemContent(b []byte, v *C
 	case "Article":
 		*v = new(CovariantInterfaceImplementationRandomItemArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(CovariantInterfaceImplementationRandomItemVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(CovariantInterfaceImplementationRandomItemTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(CovariantInterfaceImplementationRandomItemVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -940,18 +940,6 @@ func __marshalCovariantInterfaceImplementationRandomItemContent(v *CovariantInte
 			*__premarshalCovariantInterfaceImplementationRandomItemArticle
 		}{typename, premarshaled}
 		return json.Marshal(result)
-	case *CovariantInterfaceImplementationRandomItemVideo:
-		typename = "Video"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalCovariantInterfaceImplementationRandomItemVideo
-		}{typename, premarshaled}
-		return json.Marshal(result)
 	case *CovariantInterfaceImplementationRandomItemTopic:
 		typename = "Topic"
 
@@ -962,6 +950,18 @@ func __marshalCovariantInterfaceImplementationRandomItemContent(v *CovariantInte
 		result := struct {
 			TypeName string `json:"__typename"`
 			*__premarshalCovariantInterfaceImplementationRandomItemTopic
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *CovariantInterfaceImplementationRandomItemVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalCovariantInterfaceImplementationRandomItemVideo
 		}{typename, premarshaled}
 		return json.Marshal(result)
 	case nil:
@@ -1075,8 +1075,8 @@ func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) __premars
 //
 // CovariantInterfaceImplementationRandomItemContentNextContent is implemented by the following types:
 // CovariantInterfaceImplementationRandomItemContentNextArticle
-// CovariantInterfaceImplementationRandomItemContentNextVideo
 // CovariantInterfaceImplementationRandomItemContentNextTopic
+// CovariantInterfaceImplementationRandomItemContentNextVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -1089,9 +1089,9 @@ type CovariantInterfaceImplementationRandomItemContentNextContent interface {
 
 func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentNextContent() {
 }
-func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentNextContent() {
-}
 func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentNextContent() {
+}
+func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentNextContent() {
 }
 
 func __unmarshalCovariantInterfaceImplementationRandomItemContentNextContent(b []byte, v *CovariantInterfaceImplementationRandomItemContentNextContent) error {
@@ -1111,11 +1111,11 @@ func __unmarshalCovariantInterfaceImplementationRandomItemContentNextContent(b [
 	case "Article":
 		*v = new(CovariantInterfaceImplementationRandomItemContentNextArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(CovariantInterfaceImplementationRandomItemContentNextVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(CovariantInterfaceImplementationRandomItemContentNextTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(CovariantInterfaceImplementationRandomItemContentNextVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -1142,18 +1142,6 @@ func __marshalCovariantInterfaceImplementationRandomItemContentNextContent(v *Co
 			*__premarshalCovariantInterfaceImplementationRandomItemContentNextArticle
 		}{typename, premarshaled}
 		return json.Marshal(result)
-	case *CovariantInterfaceImplementationRandomItemContentNextVideo:
-		typename = "Video"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalCovariantInterfaceImplementationRandomItemContentNextVideo
-		}{typename, premarshaled}
-		return json.Marshal(result)
 	case *CovariantInterfaceImplementationRandomItemContentNextTopic:
 		typename = "Topic"
 
@@ -1164,6 +1152,18 @@ func __marshalCovariantInterfaceImplementationRandomItemContentNextContent(v *Co
 		result := struct {
 			TypeName string `json:"__typename"`
 			*__premarshalCovariantInterfaceImplementationRandomItemContentNextTopic
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *CovariantInterfaceImplementationRandomItemContentNextVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalCovariantInterfaceImplementationRandomItemContentNextVideo
 		}{typename, premarshaled}
 		return json.Marshal(result)
 	case nil:
@@ -1475,8 +1475,8 @@ func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) __prem
 //
 // CovariantInterfaceImplementationRandomItemContentRelatedContent is implemented by the following types:
 // CovariantInterfaceImplementationRandomItemContentRelatedArticle
-// CovariantInterfaceImplementationRandomItemContentRelatedVideo
 // CovariantInterfaceImplementationRandomItemContentRelatedTopic
+// CovariantInterfaceImplementationRandomItemContentRelatedVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -1489,9 +1489,9 @@ type CovariantInterfaceImplementationRandomItemContentRelatedContent interface {
 
 func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentRelatedContent() {
 }
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentRelatedContent() {
-}
 func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentRelatedContent() {
+}
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) implementsGraphQLInterfaceCovariantInterfaceImplementationRandomItemContentRelatedContent() {
 }
 
 func __unmarshalCovariantInterfaceImplementationRandomItemContentRelatedContent(b []byte, v *CovariantInterfaceImplementationRandomItemContentRelatedContent) error {
@@ -1511,11 +1511,11 @@ func __unmarshalCovariantInterfaceImplementationRandomItemContentRelatedContent(
 	case "Article":
 		*v = new(CovariantInterfaceImplementationRandomItemContentRelatedArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(CovariantInterfaceImplementationRandomItemContentRelatedVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(CovariantInterfaceImplementationRandomItemContentRelatedTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(CovariantInterfaceImplementationRandomItemContentRelatedVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -1542,18 +1542,6 @@ func __marshalCovariantInterfaceImplementationRandomItemContentRelatedContent(v 
 			*__premarshalCovariantInterfaceImplementationRandomItemContentRelatedArticle
 		}{typename, premarshaled}
 		return json.Marshal(result)
-	case *CovariantInterfaceImplementationRandomItemContentRelatedVideo:
-		typename = "Video"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalCovariantInterfaceImplementationRandomItemContentRelatedVideo
-		}{typename, premarshaled}
-		return json.Marshal(result)
 	case *CovariantInterfaceImplementationRandomItemContentRelatedTopic:
 		typename = "Topic"
 
@@ -1564,6 +1552,18 @@ func __marshalCovariantInterfaceImplementationRandomItemContentRelatedContent(v 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*__premarshalCovariantInterfaceImplementationRandomItemContentRelatedTopic
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *CovariantInterfaceImplementationRandomItemContentRelatedVideo:
+		typename = "Video"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalCovariantInterfaceImplementationRandomItemContentRelatedVideo
 		}{typename, premarshaled}
 		return json.Marshal(result)
 	case nil:

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -145,8 +145,8 @@ func (v *InterfaceListFieldRootTopicChildrenArticle) GetName() string { return v
 //
 // InterfaceListFieldRootTopicChildrenContent is implemented by the following types:
 // InterfaceListFieldRootTopicChildrenArticle
-// InterfaceListFieldRootTopicChildrenVideo
 // InterfaceListFieldRootTopicChildrenTopic
+// InterfaceListFieldRootTopicChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -165,9 +165,9 @@ type InterfaceListFieldRootTopicChildrenContent interface {
 
 func (v *InterfaceListFieldRootTopicChildrenArticle) implementsGraphQLInterfaceInterfaceListFieldRootTopicChildrenContent() {
 }
-func (v *InterfaceListFieldRootTopicChildrenVideo) implementsGraphQLInterfaceInterfaceListFieldRootTopicChildrenContent() {
-}
 func (v *InterfaceListFieldRootTopicChildrenTopic) implementsGraphQLInterfaceInterfaceListFieldRootTopicChildrenContent() {
+}
+func (v *InterfaceListFieldRootTopicChildrenVideo) implementsGraphQLInterfaceInterfaceListFieldRootTopicChildrenContent() {
 }
 
 func __unmarshalInterfaceListFieldRootTopicChildrenContent(b []byte, v *InterfaceListFieldRootTopicChildrenContent) error {
@@ -187,11 +187,11 @@ func __unmarshalInterfaceListFieldRootTopicChildrenContent(b []byte, v *Interfac
 	case "Article":
 		*v = new(InterfaceListFieldRootTopicChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceListFieldRootTopicChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceListFieldRootTopicChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceListFieldRootTopicChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -214,20 +214,20 @@ func __marshalInterfaceListFieldRootTopicChildrenContent(v *InterfaceListFieldRo
 			*InterfaceListFieldRootTopicChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceListFieldRootTopicChildrenVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceListFieldRootTopicChildrenVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceListFieldRootTopicChildrenTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceListFieldRootTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListFieldRootTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldRootTopicChildrenVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -393,8 +393,8 @@ func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetName() string { r
 //
 // InterfaceListFieldWithPointerTopicChildrenContent is implemented by the following types:
 // InterfaceListFieldWithPointerTopicChildrenArticle
-// InterfaceListFieldWithPointerTopicChildrenVideo
 // InterfaceListFieldWithPointerTopicChildrenTopic
+// InterfaceListFieldWithPointerTopicChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -413,9 +413,9 @@ type InterfaceListFieldWithPointerTopicChildrenContent interface {
 
 func (v *InterfaceListFieldWithPointerTopicChildrenArticle) implementsGraphQLInterfaceInterfaceListFieldWithPointerTopicChildrenContent() {
 }
-func (v *InterfaceListFieldWithPointerTopicChildrenVideo) implementsGraphQLInterfaceInterfaceListFieldWithPointerTopicChildrenContent() {
-}
 func (v *InterfaceListFieldWithPointerTopicChildrenTopic) implementsGraphQLInterfaceInterfaceListFieldWithPointerTopicChildrenContent() {
+}
+func (v *InterfaceListFieldWithPointerTopicChildrenVideo) implementsGraphQLInterfaceInterfaceListFieldWithPointerTopicChildrenContent() {
 }
 
 func __unmarshalInterfaceListFieldWithPointerTopicChildrenContent(b []byte, v *InterfaceListFieldWithPointerTopicChildrenContent) error {
@@ -435,11 +435,11 @@ func __unmarshalInterfaceListFieldWithPointerTopicChildrenContent(b []byte, v *I
 	case "Article":
 		*v = new(InterfaceListFieldWithPointerTopicChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceListFieldWithPointerTopicChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceListFieldWithPointerTopicChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceListFieldWithPointerTopicChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -462,20 +462,20 @@ func __marshalInterfaceListFieldWithPointerTopicChildrenContent(v *InterfaceList
 			*InterfaceListFieldWithPointerTopicChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceListFieldWithPointerTopicChildrenVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceListFieldWithPointerTopicChildrenVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceListFieldWithPointerTopicChildrenTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceListFieldWithPointerTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListFieldWithPointerTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListFieldWithPointerTopicChildrenVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -14,8 +14,8 @@ import (
 //
 // InterfaceListOfListOfListsFieldListOfListsOfListsOfContent is implemented by the following types:
 // InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle
-// InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo
 // InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic
+// InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -34,9 +34,9 @@ type InterfaceListOfListOfListsFieldListOfListsOfListsOfContent interface {
 
 func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldListOfListsOfListsOfContent() {
 }
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldListOfListsOfListsOfContent() {
-}
 func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldListOfListsOfListsOfContent() {
+}
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldListOfListsOfListsOfContent() {
 }
 
 func __unmarshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(b []byte, v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContent) error {
@@ -56,11 +56,11 @@ func __unmarshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(b []b
 	case "Article":
 		*v = new(InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -83,20 +83,20 @@ func __marshalInterfaceListOfListOfListsFieldListOfListsOfListsOfContent(v *Inte
 			*InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -379,8 +379,8 @@ func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetName() *string { 
 //
 // InterfaceListOfListOfListsFieldWithPointerContent is implemented by the following types:
 // InterfaceListOfListOfListsFieldWithPointerArticle
-// InterfaceListOfListOfListsFieldWithPointerVideo
 // InterfaceListOfListOfListsFieldWithPointerTopic
+// InterfaceListOfListOfListsFieldWithPointerVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -399,9 +399,9 @@ type InterfaceListOfListOfListsFieldWithPointerContent interface {
 
 func (v *InterfaceListOfListOfListsFieldWithPointerArticle) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldWithPointerContent() {
 }
-func (v *InterfaceListOfListOfListsFieldWithPointerVideo) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldWithPointerContent() {
-}
 func (v *InterfaceListOfListOfListsFieldWithPointerTopic) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldWithPointerContent() {
+}
+func (v *InterfaceListOfListOfListsFieldWithPointerVideo) implementsGraphQLInterfaceInterfaceListOfListOfListsFieldWithPointerContent() {
 }
 
 func __unmarshalInterfaceListOfListOfListsFieldWithPointerContent(b []byte, v *InterfaceListOfListOfListsFieldWithPointerContent) error {
@@ -421,11 +421,11 @@ func __unmarshalInterfaceListOfListOfListsFieldWithPointerContent(b []byte, v *I
 	case "Article":
 		*v = new(InterfaceListOfListOfListsFieldWithPointerArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceListOfListOfListsFieldWithPointerVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceListOfListOfListsFieldWithPointerTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceListOfListOfListsFieldWithPointerVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -448,20 +448,20 @@ func __marshalInterfaceListOfListOfListsFieldWithPointerContent(v *InterfaceList
 			*InterfaceListOfListOfListsFieldWithPointerArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceListOfListOfListsFieldWithPointerVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceListOfListOfListsFieldWithPointerVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceListOfListOfListsFieldWithPointerTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceListOfListOfListsFieldWithPointerTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceListOfListOfListsFieldWithPointerVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceListOfListOfListsFieldWithPointerVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -134,8 +134,8 @@ func (v *InterfaceNestingRootTopicChildrenArticle) GetParent() InterfaceNestingR
 //
 // InterfaceNestingRootTopicChildrenContent is implemented by the following types:
 // InterfaceNestingRootTopicChildrenArticle
-// InterfaceNestingRootTopicChildrenVideo
 // InterfaceNestingRootTopicChildrenTopic
+// InterfaceNestingRootTopicChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -154,9 +154,9 @@ type InterfaceNestingRootTopicChildrenContent interface {
 
 func (v *InterfaceNestingRootTopicChildrenArticle) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContent() {
 }
-func (v *InterfaceNestingRootTopicChildrenVideo) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContent() {
-}
 func (v *InterfaceNestingRootTopicChildrenTopic) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContent() {
+}
+func (v *InterfaceNestingRootTopicChildrenVideo) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContent() {
 }
 
 func __unmarshalInterfaceNestingRootTopicChildrenContent(b []byte, v *InterfaceNestingRootTopicChildrenContent) error {
@@ -176,11 +176,11 @@ func __unmarshalInterfaceNestingRootTopicChildrenContent(b []byte, v *InterfaceN
 	case "Article":
 		*v = new(InterfaceNestingRootTopicChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceNestingRootTopicChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceNestingRootTopicChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceNestingRootTopicChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -203,20 +203,20 @@ func __marshalInterfaceNestingRootTopicChildrenContent(v *InterfaceNestingRootTo
 			*InterfaceNestingRootTopicChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceNestingRootTopicChildrenVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceNestingRootTopicChildrenVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceNestingRootTopicChildrenTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceNestingRootTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNestingRootTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -341,8 +341,8 @@ func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) Get
 //
 // InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent is implemented by the following types:
 // InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle
-// InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo
 // InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic
+// InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -359,9 +359,9 @@ type InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent interfac
 
 func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent() {
 }
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent() {
-}
 func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent() {
+}
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) implementsGraphQLInterfaceInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent() {
 }
 
 func __unmarshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent(b []byte, v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent) error {
@@ -381,11 +381,11 @@ func __unmarshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenConte
 	case "Article":
 		*v = new(InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -408,20 +408,20 @@ func __marshalInterfaceNestingRootTopicChildrenContentParentTopicChildrenContent
 			*InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -31,8 +31,8 @@ func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetName() string { return v
 //
 // InterfaceNoFragmentsQueryRandomItemContent is implemented by the following types:
 // InterfaceNoFragmentsQueryRandomItemArticle
-// InterfaceNoFragmentsQueryRandomItemVideo
 // InterfaceNoFragmentsQueryRandomItemTopic
+// InterfaceNoFragmentsQueryRandomItemVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -51,9 +51,9 @@ type InterfaceNoFragmentsQueryRandomItemContent interface {
 
 func (v *InterfaceNoFragmentsQueryRandomItemArticle) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemContent() {
 }
-func (v *InterfaceNoFragmentsQueryRandomItemVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemContent() {
-}
 func (v *InterfaceNoFragmentsQueryRandomItemTopic) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemContent() {
+}
+func (v *InterfaceNoFragmentsQueryRandomItemVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemContent() {
 }
 
 func __unmarshalInterfaceNoFragmentsQueryRandomItemContent(b []byte, v *InterfaceNoFragmentsQueryRandomItemContent) error {
@@ -73,11 +73,11 @@ func __unmarshalInterfaceNoFragmentsQueryRandomItemContent(b []byte, v *Interfac
 	case "Article":
 		*v = new(InterfaceNoFragmentsQueryRandomItemArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceNoFragmentsQueryRandomItemVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceNoFragmentsQueryRandomItemTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceNoFragmentsQueryRandomItemVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -100,20 +100,20 @@ func __marshalInterfaceNoFragmentsQueryRandomItemContent(v *InterfaceNoFragments
 			*InterfaceNoFragmentsQueryRandomItemArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceNoFragmentsQueryRandomItemVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceNoFragmentsQueryRandomItemVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceNoFragmentsQueryRandomItemTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceNoFragmentsQueryRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryRandomItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -181,8 +181,8 @@ func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetName() strin
 //
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameContent is implemented by the following types:
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle
-// InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic
+// InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -201,9 +201,9 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameContent interface {
 
 func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemWithTypeNameContent() {
 }
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemWithTypeNameContent() {
-}
 func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemWithTypeNameContent() {
+}
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryRandomItemWithTypeNameContent() {
 }
 
 func __unmarshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(b []byte, v *InterfaceNoFragmentsQueryRandomItemWithTypeNameContent) error {
@@ -223,11 +223,11 @@ func __unmarshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(b []byte,
 	case "Article":
 		*v = new(InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -250,20 +250,20 @@ func __marshalInterfaceNoFragmentsQueryRandomItemWithTypeNameContent(v *Interfac
 			*InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -499,8 +499,8 @@ func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetName() *string { return
 //
 // InterfaceNoFragmentsQueryWithPointerContent is implemented by the following types:
 // InterfaceNoFragmentsQueryWithPointerArticle
-// InterfaceNoFragmentsQueryWithPointerVideo
 // InterfaceNoFragmentsQueryWithPointerTopic
+// InterfaceNoFragmentsQueryWithPointerVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -519,9 +519,9 @@ type InterfaceNoFragmentsQueryWithPointerContent interface {
 
 func (v *InterfaceNoFragmentsQueryWithPointerArticle) implementsGraphQLInterfaceInterfaceNoFragmentsQueryWithPointerContent() {
 }
-func (v *InterfaceNoFragmentsQueryWithPointerVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryWithPointerContent() {
-}
 func (v *InterfaceNoFragmentsQueryWithPointerTopic) implementsGraphQLInterfaceInterfaceNoFragmentsQueryWithPointerContent() {
+}
+func (v *InterfaceNoFragmentsQueryWithPointerVideo) implementsGraphQLInterfaceInterfaceNoFragmentsQueryWithPointerContent() {
 }
 
 func __unmarshalInterfaceNoFragmentsQueryWithPointerContent(b []byte, v *InterfaceNoFragmentsQueryWithPointerContent) error {
@@ -541,11 +541,11 @@ func __unmarshalInterfaceNoFragmentsQueryWithPointerContent(b []byte, v *Interfa
 	case "Article":
 		*v = new(InterfaceNoFragmentsQueryWithPointerArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(InterfaceNoFragmentsQueryWithPointerVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(InterfaceNoFragmentsQueryWithPointerTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(InterfaceNoFragmentsQueryWithPointerVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -568,20 +568,20 @@ func __marshalInterfaceNoFragmentsQueryWithPointerContent(v *InterfaceNoFragment
 			*InterfaceNoFragmentsQueryWithPointerArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *InterfaceNoFragmentsQueryWithPointerVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InterfaceNoFragmentsQueryWithPointerVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *InterfaceNoFragmentsQueryWithPointerTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InterfaceNoFragmentsQueryWithPointerTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *InterfaceNoFragmentsQueryWithPointerVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InterfaceNoFragmentsQueryWithPointerVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -35,8 +35,8 @@ func (v *SimpleInlineFragmentRandomItemArticle) GetText() string { return v.Text
 //
 // SimpleInlineFragmentRandomItemContent is implemented by the following types:
 // SimpleInlineFragmentRandomItemArticle
-// SimpleInlineFragmentRandomItemVideo
 // SimpleInlineFragmentRandomItemTopic
+// SimpleInlineFragmentRandomItemVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -55,9 +55,9 @@ type SimpleInlineFragmentRandomItemContent interface {
 
 func (v *SimpleInlineFragmentRandomItemArticle) implementsGraphQLInterfaceSimpleInlineFragmentRandomItemContent() {
 }
-func (v *SimpleInlineFragmentRandomItemVideo) implementsGraphQLInterfaceSimpleInlineFragmentRandomItemContent() {
-}
 func (v *SimpleInlineFragmentRandomItemTopic) implementsGraphQLInterfaceSimpleInlineFragmentRandomItemContent() {
+}
+func (v *SimpleInlineFragmentRandomItemVideo) implementsGraphQLInterfaceSimpleInlineFragmentRandomItemContent() {
 }
 
 func __unmarshalSimpleInlineFragmentRandomItemContent(b []byte, v *SimpleInlineFragmentRandomItemContent) error {
@@ -77,11 +77,11 @@ func __unmarshalSimpleInlineFragmentRandomItemContent(b []byte, v *SimpleInlineF
 	case "Article":
 		*v = new(SimpleInlineFragmentRandomItemArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(SimpleInlineFragmentRandomItemVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(SimpleInlineFragmentRandomItemTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(SimpleInlineFragmentRandomItemVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -104,20 +104,20 @@ func __marshalSimpleInlineFragmentRandomItemContent(v *SimpleInlineFragmentRando
 			*SimpleInlineFragmentRandomItemArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *SimpleInlineFragmentRandomItemVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*SimpleInlineFragmentRandomItemVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *SimpleInlineFragmentRandomItemTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*SimpleInlineFragmentRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *SimpleInlineFragmentRandomItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleInlineFragmentRandomItemVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -31,8 +31,8 @@ func (v *SimpleNamedFragmentRandomItemArticle) GetName() string { return v.Name 
 //
 // SimpleNamedFragmentRandomItemContent is implemented by the following types:
 // SimpleNamedFragmentRandomItemArticle
-// SimpleNamedFragmentRandomItemVideo
 // SimpleNamedFragmentRandomItemTopic
+// SimpleNamedFragmentRandomItemVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -51,9 +51,9 @@ type SimpleNamedFragmentRandomItemContent interface {
 
 func (v *SimpleNamedFragmentRandomItemArticle) implementsGraphQLInterfaceSimpleNamedFragmentRandomItemContent() {
 }
-func (v *SimpleNamedFragmentRandomItemVideo) implementsGraphQLInterfaceSimpleNamedFragmentRandomItemContent() {
-}
 func (v *SimpleNamedFragmentRandomItemTopic) implementsGraphQLInterfaceSimpleNamedFragmentRandomItemContent() {
+}
+func (v *SimpleNamedFragmentRandomItemVideo) implementsGraphQLInterfaceSimpleNamedFragmentRandomItemContent() {
 }
 
 func __unmarshalSimpleNamedFragmentRandomItemContent(b []byte, v *SimpleNamedFragmentRandomItemContent) error {
@@ -73,11 +73,11 @@ func __unmarshalSimpleNamedFragmentRandomItemContent(b []byte, v *SimpleNamedFra
 	case "Article":
 		*v = new(SimpleNamedFragmentRandomItemArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(SimpleNamedFragmentRandomItemVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(SimpleNamedFragmentRandomItemTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(SimpleNamedFragmentRandomItemVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -100,6 +100,14 @@ func __marshalSimpleNamedFragmentRandomItemContent(v *SimpleNamedFragmentRandomI
 			*SimpleNamedFragmentRandomItemArticle
 		}{typename, v}
 		return json.Marshal(result)
+	case *SimpleNamedFragmentRandomItemTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*SimpleNamedFragmentRandomItemTopic
+		}{typename, v}
+		return json.Marshal(result)
 	case *SimpleNamedFragmentRandomItemVideo:
 		typename = "Video"
 
@@ -111,14 +119,6 @@ func __marshalSimpleNamedFragmentRandomItemContent(v *SimpleNamedFragmentRandomI
 			TypeName string `json:"__typename"`
 			*__premarshalSimpleNamedFragmentRandomItemVideo
 		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *SimpleNamedFragmentRandomItemTopic:
-		typename = "Topic"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*SimpleNamedFragmentRandomItemTopic
-		}{typename, v}
 		return json.Marshal(result)
 	case nil:
 		return []byte("null"), nil

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -220,8 +220,8 @@ func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle
 //
 // StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent is implemented by the following types:
 // StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle
-// StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo
 // StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic
+// StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -238,9 +238,9 @@ type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent int
 
 func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) implementsGraphQLInterfaceStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent() {
 }
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) implementsGraphQLInterfaceStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent() {
-}
 func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) implementsGraphQLInterfaceStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent() {
+}
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) implementsGraphQLInterfaceStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent() {
 }
 
 func __unmarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent(b []byte, v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent) error {
@@ -260,11 +260,11 @@ func __unmarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildren
 	case "Article":
 		*v = new(StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -287,6 +287,14 @@ func __marshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenCo
 			*StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle
 		}{typename, v}
 		return json.Marshal(result)
+	case *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic:
+		typename = "Topic"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic
+		}{typename, v}
+		return json.Marshal(result)
 	case *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo:
 		typename = "Video"
 
@@ -298,14 +306,6 @@ func __marshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenCo
 			TypeName string `json:"__typename"`
 			*__premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo
 		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic:
-		typename = "Topic"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic
-		}{typename, v}
 		return json.Marshal(result)
 	case nil:
 		return []byte("null"), nil

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -14,8 +14,8 @@ import (
 //
 // Item is implemented by the following types:
 // ItemArticle
-// ItemVideo
 // ItemTopic
+// ItemVideo
 // The GraphQL type's documentation follows.
 //
 // Content is implemented by various types like Article, Video, and Topic.
@@ -33,8 +33,8 @@ type Item interface {
 }
 
 func (v *ItemArticle) implementsGraphQLInterfaceItem() {}
-func (v *ItemVideo) implementsGraphQLInterfaceItem()   {}
 func (v *ItemTopic) implementsGraphQLInterfaceItem()   {}
+func (v *ItemVideo) implementsGraphQLInterfaceItem()   {}
 
 func __unmarshalItem(b []byte, v *Item) error {
 	if string(b) == "null" {
@@ -53,11 +53,11 @@ func __unmarshalItem(b []byte, v *Item) error {
 	case "Article":
 		*v = new(ItemArticle)
 		return json.Unmarshal(b, *v)
-	case "Video":
-		*v = new(ItemVideo)
-		return json.Unmarshal(b, *v)
 	case "Topic":
 		*v = new(ItemTopic)
+		return json.Unmarshal(b, *v)
+	case "Video":
+		*v = new(ItemVideo)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -80,20 +80,20 @@ func __marshalItem(v *Item) ([]byte, error) {
 			*ItemArticle
 		}{typename, v}
 		return json.Marshal(result)
-	case *ItemVideo:
-		typename = "Video"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*ItemVideo
-		}{typename, v}
-		return json.Marshal(result)
 	case *ItemTopic:
 		typename = "Topic"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*ItemTopic
+		}{typename, v}
+		return json.Marshal(result)
+	case *ItemVideo:
+		typename = "Video"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ItemVideo
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -120,8 +120,8 @@ func (v *AnimalFieldsOwnerAnimal) GetId() string { return v.Id }
 // AnimalFieldsOwnerBeing includes the requested fields of the GraphQL interface Being.
 //
 // AnimalFieldsOwnerBeing is implemented by the following types:
-// AnimalFieldsOwnerUser
 // AnimalFieldsOwnerAnimal
+// AnimalFieldsOwnerUser
 type AnimalFieldsOwnerBeing interface {
 	implementsGraphQLInterfaceAnimalFieldsOwnerBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -130,8 +130,8 @@ type AnimalFieldsOwnerBeing interface {
 	GetId() string
 }
 
-func (v *AnimalFieldsOwnerUser) implementsGraphQLInterfaceAnimalFieldsOwnerBeing()   {}
 func (v *AnimalFieldsOwnerAnimal) implementsGraphQLInterfaceAnimalFieldsOwnerBeing() {}
+func (v *AnimalFieldsOwnerUser) implementsGraphQLInterfaceAnimalFieldsOwnerBeing()   {}
 
 func __unmarshalAnimalFieldsOwnerBeing(b []byte, v *AnimalFieldsOwnerBeing) error {
 	if string(b) == "null" {
@@ -147,11 +147,11 @@ func __unmarshalAnimalFieldsOwnerBeing(b []byte, v *AnimalFieldsOwnerBeing) erro
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(AnimalFieldsOwnerUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(AnimalFieldsOwnerAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(AnimalFieldsOwnerUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -166,6 +166,14 @@ func __marshalAnimalFieldsOwnerBeing(v *AnimalFieldsOwnerBeing) ([]byte, error) 
 
 	var typename string
 	switch v := (*v).(type) {
+	case *AnimalFieldsOwnerAnimal:
+		typename = "Animal"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AnimalFieldsOwnerAnimal
+		}{typename, v}
+		return json.Marshal(result)
 	case *AnimalFieldsOwnerUser:
 		typename = "User"
 
@@ -177,14 +185,6 @@ func __marshalAnimalFieldsOwnerBeing(v *AnimalFieldsOwnerBeing) ([]byte, error) 
 			TypeName string `json:"__typename"`
 			*__premarshalAnimalFieldsOwnerUser
 		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *AnimalFieldsOwnerAnimal:
-		typename = "Animal"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*AnimalFieldsOwnerAnimal
-		}{typename, v}
 		return json.Marshal(result)
 	case nil:
 		return []byte("null"), nil
@@ -287,8 +287,8 @@ func (v *FriendsFields) GetName() string { return v.Name }
 // InnerBeingFields includes the GraphQL fields of Being requested by the fragment InnerBeingFields.
 //
 // InnerBeingFields is implemented by the following types:
-// InnerBeingFieldsUser
 // InnerBeingFieldsAnimal
+// InnerBeingFieldsUser
 type InnerBeingFields interface {
 	implementsGraphQLInterfaceInnerBeingFields()
 	// GetId returns the interface-field "id" from its implementation.
@@ -297,8 +297,8 @@ type InnerBeingFields interface {
 	GetName() string
 }
 
-func (v *InnerBeingFieldsUser) implementsGraphQLInterfaceInnerBeingFields()   {}
 func (v *InnerBeingFieldsAnimal) implementsGraphQLInterfaceInnerBeingFields() {}
+func (v *InnerBeingFieldsUser) implementsGraphQLInterfaceInnerBeingFields()   {}
 
 func __unmarshalInnerBeingFields(b []byte, v *InnerBeingFields) error {
 	if string(b) == "null" {
@@ -314,11 +314,11 @@ func __unmarshalInnerBeingFields(b []byte, v *InnerBeingFields) error {
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(InnerBeingFieldsUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(InnerBeingFieldsAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(InnerBeingFieldsUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -333,20 +333,20 @@ func __marshalInnerBeingFields(v *InnerBeingFields) ([]byte, error) {
 
 	var typename string
 	switch v := (*v).(type) {
-	case *InnerBeingFieldsUser:
-		typename = "User"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*InnerBeingFieldsUser
-		}{typename, v}
-		return json.Marshal(result)
 	case *InnerBeingFieldsAnimal:
 		typename = "Animal"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*InnerBeingFieldsAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case *InnerBeingFieldsUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*InnerBeingFieldsUser
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -776,8 +776,8 @@ func (v *QueryFragmentBeingsAnimal) __premarshalJSON() (*__premarshalQueryFragme
 // QueryFragmentBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // QueryFragmentBeingsBeing is implemented by the following types:
-// QueryFragmentBeingsUser
 // QueryFragmentBeingsAnimal
+// QueryFragmentBeingsUser
 type QueryFragmentBeingsBeing interface {
 	implementsGraphQLInterfaceQueryFragmentBeingsBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -786,8 +786,8 @@ type QueryFragmentBeingsBeing interface {
 	GetId() string
 }
 
-func (v *QueryFragmentBeingsUser) implementsGraphQLInterfaceQueryFragmentBeingsBeing()   {}
 func (v *QueryFragmentBeingsAnimal) implementsGraphQLInterfaceQueryFragmentBeingsBeing() {}
+func (v *QueryFragmentBeingsUser) implementsGraphQLInterfaceQueryFragmentBeingsBeing()   {}
 
 func __unmarshalQueryFragmentBeingsBeing(b []byte, v *QueryFragmentBeingsBeing) error {
 	if string(b) == "null" {
@@ -803,11 +803,11 @@ func __unmarshalQueryFragmentBeingsBeing(b []byte, v *QueryFragmentBeingsBeing) 
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(QueryFragmentBeingsUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(QueryFragmentBeingsAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(QueryFragmentBeingsUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -822,18 +822,6 @@ func __marshalQueryFragmentBeingsBeing(v *QueryFragmentBeingsBeing) ([]byte, err
 
 	var typename string
 	switch v := (*v).(type) {
-	case *QueryFragmentBeingsUser:
-		typename = "User"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalQueryFragmentBeingsUser
-		}{typename, premarshaled}
-		return json.Marshal(result)
 	case *QueryFragmentBeingsAnimal:
 		typename = "Animal"
 
@@ -844,6 +832,18 @@ func __marshalQueryFragmentBeingsBeing(v *QueryFragmentBeingsBeing) ([]byte, err
 		result := struct {
 			TypeName string `json:"__typename"`
 			*__premarshalQueryFragmentBeingsAnimal
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *QueryFragmentBeingsUser:
+		typename = "User"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalQueryFragmentBeingsUser
 		}{typename, premarshaled}
 		return json.Marshal(result)
 	case nil:
@@ -1769,8 +1769,8 @@ func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetName() string { return v.
 // queryWithFragmentsBeingsAnimalOwnerBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithFragmentsBeingsAnimalOwnerBeing is implemented by the following types:
-// queryWithFragmentsBeingsAnimalOwnerUser
 // queryWithFragmentsBeingsAnimalOwnerAnimal
+// queryWithFragmentsBeingsAnimalOwnerUser
 type queryWithFragmentsBeingsAnimalOwnerBeing interface {
 	implementsGraphQLInterfacequeryWithFragmentsBeingsAnimalOwnerBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -1781,9 +1781,9 @@ type queryWithFragmentsBeingsAnimalOwnerBeing interface {
 	GetName() string
 }
 
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) implementsGraphQLInterfacequeryWithFragmentsBeingsAnimalOwnerBeing() {
-}
 func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) implementsGraphQLInterfacequeryWithFragmentsBeingsAnimalOwnerBeing() {
+}
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) implementsGraphQLInterfacequeryWithFragmentsBeingsAnimalOwnerBeing() {
 }
 
 func __unmarshalqueryWithFragmentsBeingsAnimalOwnerBeing(b []byte, v *queryWithFragmentsBeingsAnimalOwnerBeing) error {
@@ -1800,11 +1800,11 @@ func __unmarshalqueryWithFragmentsBeingsAnimalOwnerBeing(b []byte, v *queryWithF
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(queryWithFragmentsBeingsAnimalOwnerUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(queryWithFragmentsBeingsAnimalOwnerAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(queryWithFragmentsBeingsAnimalOwnerUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -1819,20 +1819,20 @@ func __marshalqueryWithFragmentsBeingsAnimalOwnerBeing(v *queryWithFragmentsBein
 
 	var typename string
 	switch v := (*v).(type) {
-	case *queryWithFragmentsBeingsAnimalOwnerUser:
-		typename = "User"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*queryWithFragmentsBeingsAnimalOwnerUser
-		}{typename, v}
-		return json.Marshal(result)
 	case *queryWithFragmentsBeingsAnimalOwnerAnimal:
 		typename = "Animal"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*queryWithFragmentsBeingsAnimalOwnerAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithFragmentsBeingsAnimalOwnerUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithFragmentsBeingsAnimalOwnerUser
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -1866,8 +1866,8 @@ func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetLuckyNumber() int { return 
 // queryWithFragmentsBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithFragmentsBeingsBeing is implemented by the following types:
-// queryWithFragmentsBeingsUser
 // queryWithFragmentsBeingsAnimal
+// queryWithFragmentsBeingsUser
 type queryWithFragmentsBeingsBeing interface {
 	implementsGraphQLInterfacequeryWithFragmentsBeingsBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -1878,8 +1878,8 @@ type queryWithFragmentsBeingsBeing interface {
 	GetName() string
 }
 
-func (v *queryWithFragmentsBeingsUser) implementsGraphQLInterfacequeryWithFragmentsBeingsBeing()   {}
 func (v *queryWithFragmentsBeingsAnimal) implementsGraphQLInterfacequeryWithFragmentsBeingsBeing() {}
+func (v *queryWithFragmentsBeingsUser) implementsGraphQLInterfacequeryWithFragmentsBeingsBeing()   {}
 
 func __unmarshalqueryWithFragmentsBeingsBeing(b []byte, v *queryWithFragmentsBeingsBeing) error {
 	if string(b) == "null" {
@@ -1895,11 +1895,11 @@ func __unmarshalqueryWithFragmentsBeingsBeing(b []byte, v *queryWithFragmentsBei
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(queryWithFragmentsBeingsUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(queryWithFragmentsBeingsAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(queryWithFragmentsBeingsUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -1914,14 +1914,6 @@ func __marshalqueryWithFragmentsBeingsBeing(v *queryWithFragmentsBeingsBeing) ([
 
 	var typename string
 	switch v := (*v).(type) {
-	case *queryWithFragmentsBeingsUser:
-		typename = "User"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*queryWithFragmentsBeingsUser
-		}{typename, v}
-		return json.Marshal(result)
 	case *queryWithFragmentsBeingsAnimal:
 		typename = "Animal"
 
@@ -1933,6 +1925,14 @@ func __marshalqueryWithFragmentsBeingsBeing(v *queryWithFragmentsBeingsBeing) ([
 			TypeName string `json:"__typename"`
 			*__premarshalqueryWithFragmentsBeingsAnimal
 		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *queryWithFragmentsBeingsUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithFragmentsBeingsUser
+		}{typename, v}
 		return json.Marshal(result)
 	case nil:
 		return []byte("null"), nil
@@ -2076,8 +2076,8 @@ func (v *queryWithInterfaceListFieldBeingsAnimal) GetName() string { return v.Na
 // queryWithInterfaceListFieldBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithInterfaceListFieldBeingsBeing is implemented by the following types:
-// queryWithInterfaceListFieldBeingsUser
 // queryWithInterfaceListFieldBeingsAnimal
+// queryWithInterfaceListFieldBeingsUser
 type queryWithInterfaceListFieldBeingsBeing interface {
 	implementsGraphQLInterfacequeryWithInterfaceListFieldBeingsBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -2088,9 +2088,9 @@ type queryWithInterfaceListFieldBeingsBeing interface {
 	GetName() string
 }
 
-func (v *queryWithInterfaceListFieldBeingsUser) implementsGraphQLInterfacequeryWithInterfaceListFieldBeingsBeing() {
-}
 func (v *queryWithInterfaceListFieldBeingsAnimal) implementsGraphQLInterfacequeryWithInterfaceListFieldBeingsBeing() {
+}
+func (v *queryWithInterfaceListFieldBeingsUser) implementsGraphQLInterfacequeryWithInterfaceListFieldBeingsBeing() {
 }
 
 func __unmarshalqueryWithInterfaceListFieldBeingsBeing(b []byte, v *queryWithInterfaceListFieldBeingsBeing) error {
@@ -2107,11 +2107,11 @@ func __unmarshalqueryWithInterfaceListFieldBeingsBeing(b []byte, v *queryWithInt
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(queryWithInterfaceListFieldBeingsUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(queryWithInterfaceListFieldBeingsAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(queryWithInterfaceListFieldBeingsUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -2126,20 +2126,20 @@ func __marshalqueryWithInterfaceListFieldBeingsBeing(v *queryWithInterfaceListFi
 
 	var typename string
 	switch v := (*v).(type) {
-	case *queryWithInterfaceListFieldBeingsUser:
-		typename = "User"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*queryWithInterfaceListFieldBeingsUser
-		}{typename, v}
-		return json.Marshal(result)
 	case *queryWithInterfaceListFieldBeingsAnimal:
 		typename = "Animal"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*queryWithInterfaceListFieldBeingsAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithInterfaceListFieldBeingsUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceListFieldBeingsUser
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -2270,8 +2270,8 @@ func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetName() string { retu
 // queryWithInterfaceListPointerFieldBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithInterfaceListPointerFieldBeingsBeing is implemented by the following types:
-// queryWithInterfaceListPointerFieldBeingsUser
 // queryWithInterfaceListPointerFieldBeingsAnimal
+// queryWithInterfaceListPointerFieldBeingsUser
 type queryWithInterfaceListPointerFieldBeingsBeing interface {
 	implementsGraphQLInterfacequeryWithInterfaceListPointerFieldBeingsBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -2282,9 +2282,9 @@ type queryWithInterfaceListPointerFieldBeingsBeing interface {
 	GetName() string
 }
 
-func (v *queryWithInterfaceListPointerFieldBeingsUser) implementsGraphQLInterfacequeryWithInterfaceListPointerFieldBeingsBeing() {
-}
 func (v *queryWithInterfaceListPointerFieldBeingsAnimal) implementsGraphQLInterfacequeryWithInterfaceListPointerFieldBeingsBeing() {
+}
+func (v *queryWithInterfaceListPointerFieldBeingsUser) implementsGraphQLInterfacequeryWithInterfaceListPointerFieldBeingsBeing() {
 }
 
 func __unmarshalqueryWithInterfaceListPointerFieldBeingsBeing(b []byte, v *queryWithInterfaceListPointerFieldBeingsBeing) error {
@@ -2301,11 +2301,11 @@ func __unmarshalqueryWithInterfaceListPointerFieldBeingsBeing(b []byte, v *query
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(queryWithInterfaceListPointerFieldBeingsUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(queryWithInterfaceListPointerFieldBeingsAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(queryWithInterfaceListPointerFieldBeingsUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -2320,20 +2320,20 @@ func __marshalqueryWithInterfaceListPointerFieldBeingsBeing(v *queryWithInterfac
 
 	var typename string
 	switch v := (*v).(type) {
-	case *queryWithInterfaceListPointerFieldBeingsUser:
-		typename = "User"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*queryWithInterfaceListPointerFieldBeingsUser
-		}{typename, v}
-		return json.Marshal(result)
 	case *queryWithInterfaceListPointerFieldBeingsAnimal:
 		typename = "Animal"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*queryWithInterfaceListPointerFieldBeingsAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithInterfaceListPointerFieldBeingsUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceListPointerFieldBeingsUser
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -2451,8 +2451,8 @@ func (v *queryWithInterfaceListPointerFieldResponse) __premarshalJSON() (*__prem
 // queryWithInterfaceNoFragmentsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithInterfaceNoFragmentsBeing is implemented by the following types:
-// queryWithInterfaceNoFragmentsBeingUser
 // queryWithInterfaceNoFragmentsBeingAnimal
+// queryWithInterfaceNoFragmentsBeingUser
 type queryWithInterfaceNoFragmentsBeing interface {
 	implementsGraphQLInterfacequeryWithInterfaceNoFragmentsBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -2463,9 +2463,9 @@ type queryWithInterfaceNoFragmentsBeing interface {
 	GetName() string
 }
 
-func (v *queryWithInterfaceNoFragmentsBeingUser) implementsGraphQLInterfacequeryWithInterfaceNoFragmentsBeing() {
-}
 func (v *queryWithInterfaceNoFragmentsBeingAnimal) implementsGraphQLInterfacequeryWithInterfaceNoFragmentsBeing() {
+}
+func (v *queryWithInterfaceNoFragmentsBeingUser) implementsGraphQLInterfacequeryWithInterfaceNoFragmentsBeing() {
 }
 
 func __unmarshalqueryWithInterfaceNoFragmentsBeing(b []byte, v *queryWithInterfaceNoFragmentsBeing) error {
@@ -2482,11 +2482,11 @@ func __unmarshalqueryWithInterfaceNoFragmentsBeing(b []byte, v *queryWithInterfa
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(queryWithInterfaceNoFragmentsBeingUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(queryWithInterfaceNoFragmentsBeingAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(queryWithInterfaceNoFragmentsBeingUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -2501,20 +2501,20 @@ func __marshalqueryWithInterfaceNoFragmentsBeing(v *queryWithInterfaceNoFragment
 
 	var typename string
 	switch v := (*v).(type) {
-	case *queryWithInterfaceNoFragmentsBeingUser:
-		typename = "User"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*queryWithInterfaceNoFragmentsBeingUser
-		}{typename, v}
-		return json.Marshal(result)
 	case *queryWithInterfaceNoFragmentsBeingAnimal:
 		typename = "Animal"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*queryWithInterfaceNoFragmentsBeingAnimal
+		}{typename, v}
+		return json.Marshal(result)
+	case *queryWithInterfaceNoFragmentsBeingUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*queryWithInterfaceNoFragmentsBeingUser
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -2741,8 +2741,8 @@ func (v *queryWithNamedFragmentsBeingsAnimal) __premarshalJSON() (*__premarshalq
 // queryWithNamedFragmentsBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
 // queryWithNamedFragmentsBeingsBeing is implemented by the following types:
-// queryWithNamedFragmentsBeingsUser
 // queryWithNamedFragmentsBeingsAnimal
+// queryWithNamedFragmentsBeingsUser
 type queryWithNamedFragmentsBeingsBeing interface {
 	implementsGraphQLInterfacequeryWithNamedFragmentsBeingsBeing()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
@@ -2751,9 +2751,9 @@ type queryWithNamedFragmentsBeingsBeing interface {
 	GetId() string
 }
 
-func (v *queryWithNamedFragmentsBeingsUser) implementsGraphQLInterfacequeryWithNamedFragmentsBeingsBeing() {
-}
 func (v *queryWithNamedFragmentsBeingsAnimal) implementsGraphQLInterfacequeryWithNamedFragmentsBeingsBeing() {
+}
+func (v *queryWithNamedFragmentsBeingsUser) implementsGraphQLInterfacequeryWithNamedFragmentsBeingsBeing() {
 }
 
 func __unmarshalqueryWithNamedFragmentsBeingsBeing(b []byte, v *queryWithNamedFragmentsBeingsBeing) error {
@@ -2770,11 +2770,11 @@ func __unmarshalqueryWithNamedFragmentsBeingsBeing(b []byte, v *queryWithNamedFr
 	}
 
 	switch tn.TypeName {
-	case "User":
-		*v = new(queryWithNamedFragmentsBeingsUser)
-		return json.Unmarshal(b, *v)
 	case "Animal":
 		*v = new(queryWithNamedFragmentsBeingsAnimal)
+		return json.Unmarshal(b, *v)
+	case "User":
+		*v = new(queryWithNamedFragmentsBeingsUser)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -2789,18 +2789,6 @@ func __marshalqueryWithNamedFragmentsBeingsBeing(v *queryWithNamedFragmentsBeing
 
 	var typename string
 	switch v := (*v).(type) {
-	case *queryWithNamedFragmentsBeingsUser:
-		typename = "User"
-
-		premarshaled, err := v.__premarshalJSON()
-		if err != nil {
-			return nil, err
-		}
-		result := struct {
-			TypeName string `json:"__typename"`
-			*__premarshalqueryWithNamedFragmentsBeingsUser
-		}{typename, premarshaled}
-		return json.Marshal(result)
 	case *queryWithNamedFragmentsBeingsAnimal:
 		typename = "Animal"
 
@@ -2811,6 +2799,18 @@ func __marshalqueryWithNamedFragmentsBeingsBeing(v *queryWithNamedFragmentsBeing
 		result := struct {
 			TypeName string `json:"__typename"`
 			*__premarshalqueryWithNamedFragmentsBeingsAnimal
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *queryWithNamedFragmentsBeingsUser:
+		typename = "User"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalqueryWithNamedFragmentsBeingsUser
 		}{typename, premarshaled}
 		return json.Marshal(result)
 	case nil:


### PR DESCRIPTION
We noticed that the output from genqlient can be non-deterministic when a graphql query queries a field that's an interface. This PR fixes that by sorting the types as soon as we extract them from the schema.

The snapshots for the tests need to be updated, but I don't know an easy way to do that. Is there a command or a flag that I can just flip somewhere to update them?

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [ ] Added tests covering my changes, if applicable
- n/a Included a link to the issue fixed, if applicable
- n/a Included documentation, for new features
- [x] Added an entry to the changelog
