### PR TITLE
fixed "for" directive documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ When releasing a new version:
 
 - Fixed non-deterministic generated code when querying graphql interfaces.
 - Fixed generated code when last component of package name is not a valid identifier (e.g. `"path/to/my-package"`).
+- Fixed incorrect documentation of `for` directive.
 
 ## v0.5.0
 

--- a/docs/genqlient_directive.graphql
+++ b/docs/genqlient_directive.graphql
@@ -63,7 +63,9 @@ directive genqlient(
   #  # @genqlient(for: "MyInput.myField", omitempty: true)
   #  # @genqlient(for: "MyInput.myOtherField", pointer: true)
   #  # @genqlient(for: "MyOutput.id", bind: "path/to/pkg.MyOutputID")
-  #  query MyQuery($arg: MyInput) { ... }
+  #  query MyQuery(
+  #    $arg: MyInput
+  #  ) { ... }
   # genqlient will generate a type
   #  type MyInput struct {
   #    MyField      <type>  `json:"myField,omitempty"`


### PR DESCRIPTION
This PR is addressing the behavior described in #151.
The former version of `for` directive example usage ended in:
```
genqlient.graphql:<line>: for is only applicable to operations and arguments
```


I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
