### PR TITLE
Expose the graphql operation as a constant in the generated genqlient file

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ When releasing a new version:
 ### New features:
 
 - You can now bind all types from a package in `genqlient.yaml` using the new `package_bindings` option.
+- The graphql operation (query or mutation) as sent over the wire is now exposed via a constant in the generated genqlient .go file.
 
 ### Bug fixes:
 

--- a/example/generated.go
+++ b/example/generated.go
@@ -69,6 +69,15 @@ func (v *getViewerViewerUser) GetMyName() string { return v.MyName }
 // GetCreatedAt returns getViewerViewerUser.CreatedAt, and is useful for accessing the field via an interface.
 func (v *getViewerViewerUser) GetCreatedAt() time.Time { return v.CreatedAt }
 
+const getUserOperation = `
+query getUser ($Login: String!) {
+	user(login: $Login) {
+		theirName: name
+		createdAt
+	}
+}
+`
+
 // getUser gets the given user's name from their username.
 func getUser(
 	ctx context.Context,
@@ -77,14 +86,7 @@ func getUser(
 ) (*getUserResponse, error) {
 	req := &graphql.Request{
 		OpName: "getUser",
-		Query: `
-query getUser ($Login: String!) {
-	user(login: $Login) {
-		theirName: name
-		createdAt
-	}
-}
-`,
+		Query:  getUserOperation,
 		Variables: &__getUserInput{
 			Login: Login,
 		},
@@ -103,20 +105,22 @@ query getUser ($Login: String!) {
 	return &data, err
 }
 
-func getViewer(
-	ctx context.Context,
-	client graphql.Client,
-) (*getViewerResponse, error) {
-	req := &graphql.Request{
-		OpName: "getViewer",
-		Query: `
+const getViewerOperation = `
 query getViewer {
 	viewer {
 		MyName: name
 		createdAt
 	}
 }
-`,
+`
+
+func getViewer(
+	ctx context.Context,
+	client graphql.Client,
+) (*getViewerResponse, error) {
+	req := &graphql.Request{
+		OpName: "getViewer",
+		Query:  getViewerOperation,
 	}
 	var err error
 

--- a/generate/operation.go.tmpl
+++ b/generate/operation.go.tmpl
@@ -1,3 +1,5 @@
+const {{.Name}}Operation = `{{$.Body}}`
+
 {{.Doc}}
 func {{.Name}}(
     {{if ne .Config.ContextType "-" -}}
@@ -15,7 +17,7 @@ func {{.Name}}(
 ) (*{{.ResponseName}}, {{if .Config.Extensions -}}map[string]interface{},{{end}} error) {
     req := &graphql.Request{
         OpName: "{{.Name}}",
-        Query:  `{{.Body}}`,
+        Query:  {{.Name}}Operation,
     {{if .Input -}}
         Variables: &{{.Input.GoName}}{
         {{range .Input.Fields -}}

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -1340,17 +1340,7 @@ func (v *ComplexInlineFragmentsRootTopic) GetSchoolGrade() string { return v.Sch
 // GetName returns ComplexInlineFragmentsRootTopic.Name, and is useful for accessing the field via an interface.
 func (v *ComplexInlineFragmentsRootTopic) GetName() string { return v.Name }
 
-// We test all the spread cases from docs/DESIGN.md, see there for more context
-// on each, as well as various other nonsense.  But for abstract-in-abstract
-// spreads, we can't test cases (4b) and (4c), where I implements J or vice
-// versa, because gqlparser doesn't support interfaces that implement other
-// interfaces yet.
-func ComplexInlineFragments(
-	client graphql.Client,
-) (*ComplexInlineFragmentsResponse, error) {
-	req := &graphql.Request{
-		OpName: "ComplexInlineFragments",
-		Query: `
+const ComplexInlineFragmentsOperation = `
 query ComplexInlineFragments {
 	root {
 		id
@@ -1436,7 +1426,19 @@ query ComplexInlineFragments {
 		}
 	}
 }
-`,
+`
+
+// We test all the spread cases from docs/DESIGN.md, see there for more context
+// on each, as well as various other nonsense.  But for abstract-in-abstract
+// spreads, we can't test cases (4b) and (4c), where I implements J or vice
+// versa, because gqlparser doesn't support interfaces that implement other
+// interfaces yet.
+func ComplexInlineFragments(
+	client graphql.Client,
+) (*ComplexInlineFragmentsResponse, error) {
+	req := &graphql.Request{
+		OpName: "ComplexInlineFragments",
+		Query:  ComplexInlineFragmentsOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -1739,12 +1739,7 @@ type VideoFieldsThumbnail struct {
 // GetId returns VideoFieldsThumbnail.Id, and is useful for accessing the field via an interface.
 func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
-func ComplexNamedFragments(
-	client graphql.Client,
-) (*ComplexNamedFragmentsResponse, error) {
-	req := &graphql.Request{
-		OpName: "ComplexNamedFragments",
-		Query: `
+const ComplexNamedFragmentsOperation = `
 query ComplexNamedFragments {
 	... on Query {
 		... QueryFragment
@@ -1802,7 +1797,14 @@ fragment MoreVideoFields on Video {
 		}
 	}
 }
-`,
+`
+
+func ComplexNamedFragments(
+	client graphql.Client,
+) (*ComplexNamedFragmentsResponse, error) {
+	req := &graphql.Request{
+		OpName: "ComplexNamedFragments",
+		Query:  ComplexNamedFragmentsOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
@@ -2346,12 +2346,7 @@ type TopicFieldsRelatedTopic struct {
 // GetId returns TopicFieldsRelatedTopic.Id, and is useful for accessing the field via an interface.
 func (v *TopicFieldsRelatedTopic) GetId() testutil.ID { return v.Id }
 
-func CovariantInterfaceImplementation(
-	client graphql.Client,
-) (*CovariantInterfaceImplementationResponse, error) {
-	req := &graphql.Request{
-		OpName: "CovariantInterfaceImplementation",
-		Query: `
+const CovariantInterfaceImplementationOperation = `
 query CovariantInterfaceImplementation {
 	randomItem {
 		__typename
@@ -2394,7 +2389,14 @@ fragment TopicFields on Topic {
 		id
 	}
 }
-`,
+`
+
+func CovariantInterfaceImplementation(
+	client graphql.Client,
+) (*CovariantInterfaceImplementationResponse, error) {
+	req := &graphql.Request{
+		OpName: "CovariantInterfaceImplementation",
+		Query:  CovariantInterfaceImplementationOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -174,20 +174,22 @@ func (v *__CustomMarshalInput) __premarshalJSON() (*__premarshal__CustomMarshalI
 	return &retval, nil
 }
 
-func CustomMarshal(
-	client graphql.Client,
-	date time.Time,
-) (*CustomMarshalResponse, error) {
-	req := &graphql.Request{
-		OpName: "CustomMarshal",
-		Query: `
+const CustomMarshalOperation = `
 query CustomMarshal ($date: Date!) {
 	usersBornOn(date: $date) {
 		id
 		birthdate
 	}
 }
-`,
+`
+
+func CustomMarshal(
+	client graphql.Client,
+	date time.Time,
+) (*CustomMarshalResponse, error) {
+	req := &graphql.Request{
+		OpName: "CustomMarshal",
+		Query:  CustomMarshalOperation,
 		Variables: &__CustomMarshalInput{
 			Date: date,
 		},

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -203,6 +203,13 @@ func (v *__CustomMarshalSliceInput) __premarshalJSON() (*__premarshal__CustomMar
 	return &retval, nil
 }
 
+const CustomMarshalSliceOperation = `
+query CustomMarshalSlice ($datesss: [[[Date!]!]!]!, $datesssp: [[[Date!]!]!]!) {
+	acceptsListOfListOfListsOfDates(datesss: $datesss)
+	withPointer: acceptsListOfListOfListsOfDates(datesss: $datesssp)
+}
+`
+
 func CustomMarshalSlice(
 	client graphql.Client,
 	datesss [][][]time.Time,
@@ -210,12 +217,7 @@ func CustomMarshalSlice(
 ) (*CustomMarshalSliceResponse, error) {
 	req := &graphql.Request{
 		OpName: "CustomMarshalSlice",
-		Query: `
-query CustomMarshalSlice ($datesss: [[[Date!]!]!]!, $datesssp: [[[Date!]!]!]!) {
-	acceptsListOfListOfListsOfDates(datesss: $datesss)
-	withPointer: acceptsListOfListOfListsOfDates(datesss: $datesssp)
-}
-`,
+		Query:  CustomMarshalSliceOperation,
 		Variables: &__CustomMarshalSliceInput{
 			Datesss:  datesss,
 			Datesssp: datesssp,

--- a/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
@@ -28,6 +28,12 @@ type convertTimezoneResponse struct {
 // GetConvert returns convertTimezoneResponse.Convert, and is useful for accessing the field via an interface.
 func (v *convertTimezoneResponse) GetConvert() time.Time { return v.Convert }
 
+const convertTimezoneOperation = `
+query convertTimezone ($dt: DateTime!, $tz: String) {
+	convert(dt: $dt, tz: $tz)
+}
+`
+
 func convertTimezone(
 	client graphql.Client,
 	dt time.Time,
@@ -35,11 +41,7 @@ func convertTimezone(
 ) (*convertTimezoneResponse, error) {
 	req := &graphql.Request{
 		OpName: "convertTimezone",
-		Query: `
-query convertTimezone ($dt: DateTime!, $tz: String) {
-	convert(dt: $dt, tz: $tz)
-}
-`,
+		Query:  convertTimezoneOperation,
 		Variables: &__convertTimezoneInput{
 			Dt: dt,
 			Tz: tz,

--- a/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
@@ -20,17 +20,19 @@ func (v *EmptyInterfaceResponse) GetGetComplexJunk() []map[string]*[]*map[string
 	return v.GetComplexJunk
 }
 
+const EmptyInterfaceOperation = `
+query EmptyInterface {
+	getJunk
+	getComplexJunk
+}
+`
+
 func EmptyInterface(
 	client graphql.Client,
 ) (*EmptyInterfaceResponse, error) {
 	req := &graphql.Request{
 		OpName: "EmptyInterface",
-		Query: `
-query EmptyInterface {
-	getJunk
-	getComplexJunk
-}
-`,
+		Query:  EmptyInterfaceOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
@@ -266,12 +266,7 @@ type VideoFieldsParentTopic struct {
 // GetVideoChildren returns VideoFieldsParentTopic.VideoChildren, and is useful for accessing the field via an interface.
 func (v *VideoFieldsParentTopic) GetVideoChildren() []ChildVideoFields { return v.VideoChildren }
 
-func ComplexNamedFragments(
-	client graphql.Client,
-) (*InnerQueryFragment, error) {
-	req := &graphql.Request{
-		OpName: "ComplexNamedFragments",
-		Query: `
+const ComplexNamedFragmentsOperation = `
 query ComplexNamedFragments {
 	... QueryFragment
 }
@@ -306,7 +301,14 @@ fragment ChildVideoFields on Video {
 	id
 	name
 }
-`,
+`
+
+func ComplexNamedFragments(
+	client graphql.Client,
+) (*InnerQueryFragment, error) {
+	req := &graphql.Request{
+		OpName: "ComplexNamedFragments",
+		Query:  ComplexNamedFragmentsOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
@@ -54,19 +54,21 @@ type __InputEnumQueryInput struct {
 // GetRole returns __InputEnumQueryInput.Role, and is useful for accessing the field via an interface.
 func (v *__InputEnumQueryInput) GetRole() Role { return v.Role }
 
+const InputEnumQueryOperation = `
+query InputEnumQuery ($role: Role!) {
+	usersWithRole(role: $role) {
+		id
+	}
+}
+`
+
 func InputEnumQuery(
 	client graphql.Client,
 	role Role,
 ) (*InputEnumQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InputEnumQuery",
-		Query: `
-query InputEnumQuery ($role: Role!) {
-	usersWithRole(role: $role) {
-		id
-	}
-}
-`,
+		Query:  InputEnumQueryOperation,
 		Variables: &__InputEnumQueryInput{
 			Role: role,
 		},

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -177,19 +177,21 @@ type __InputObjectQueryInput struct {
 // GetQuery returns __InputObjectQueryInput.Query, and is useful for accessing the field via an interface.
 func (v *__InputObjectQueryInput) GetQuery() UserQueryInput { return v.Query }
 
+const InputObjectQueryOperation = `
+query InputObjectQuery ($query: UserQueryInput) {
+	user(query: $query) {
+		id
+	}
+}
+`
+
 func InputObjectQuery(
 	client graphql.Client,
 	query UserQueryInput,
 ) (*InputObjectQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InputObjectQuery",
-		Query: `
-query InputObjectQuery ($query: UserQueryInput) {
-	user(query: $query) {
-		id
-	}
-}
-`,
+		Query:  InputObjectQueryOperation,
 		Variables: &__InputObjectQueryInput{
 			Query: query,
 		},

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -520,12 +520,7 @@ func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetId() testutil.ID { 
 // GetName returns InterfaceListFieldWithPointerTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
 func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetName() string { return v.Name }
 
-func InterfaceListField(
-	client graphql.Client,
-) (*InterfaceListFieldResponse, error) {
-	req := &graphql.Request{
-		OpName: "InterfaceListField",
-		Query: `
+const InterfaceListFieldOperation = `
 query InterfaceListField {
 	root {
 		id
@@ -546,7 +541,14 @@ query InterfaceListField {
 		}
 	}
 }
-`,
+`
+
+func InterfaceListField(
+	client graphql.Client,
+) (*InterfaceListFieldResponse, error) {
+	req := &graphql.Request{
+		OpName: "InterfaceListField",
+		Query:  InterfaceListFieldOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -506,12 +506,7 @@ func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetId() *testutil.ID {
 // GetName returns InterfaceListOfListOfListsFieldWithPointerVideo.Name, and is useful for accessing the field via an interface.
 func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetName() *string { return v.Name }
 
-func InterfaceListOfListOfListsField(
-	client graphql.Client,
-) (*InterfaceListOfListOfListsFieldResponse, error) {
-	req := &graphql.Request{
-		OpName: "InterfaceListOfListOfListsField",
-		Query: `
+const InterfaceListOfListOfListsFieldOperation = `
 query InterfaceListOfListOfListsField {
 	listOfListsOfListsOfContent {
 		__typename
@@ -524,7 +519,14 @@ query InterfaceListOfListOfListsField {
 		name
 	}
 }
-`,
+`
+
+func InterfaceListOfListOfListsField(
+	client graphql.Client,
+) (*InterfaceListOfListOfListsFieldResponse, error) {
+	req := &graphql.Request{
+		OpName: "InterfaceListOfListOfListsField",
+		Query:  InterfaceListOfListOfListsFieldOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -504,12 +504,7 @@ func (v *InterfaceNestingRootTopicChildrenVideo) GetParent() InterfaceNestingRoo
 	return v.Parent
 }
 
-func InterfaceNesting(
-	client graphql.Client,
-) (*InterfaceNestingResponse, error) {
-	req := &graphql.Request{
-		OpName: "InterfaceNesting",
-		Query: `
+const InterfaceNestingOperation = `
 query InterfaceNesting {
 	root {
 		id
@@ -526,7 +521,14 @@ query InterfaceNesting {
 		}
 	}
 }
-`,
+`
+
+func InterfaceNesting(
+	client graphql.Client,
+) (*InterfaceNestingResponse, error) {
+	req := &graphql.Request{
+		OpName: "InterfaceNesting",
+		Query:  InterfaceNestingOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -626,12 +626,7 @@ func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetId() *testutil.ID { retur
 // GetName returns InterfaceNoFragmentsQueryWithPointerVideo.Name, and is useful for accessing the field via an interface.
 func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetName() *string { return v.Name }
 
-func InterfaceNoFragmentsQuery(
-	client graphql.Client,
-) (*InterfaceNoFragmentsQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "InterfaceNoFragmentsQuery",
-		Query: `
+const InterfaceNoFragmentsQueryOperation = `
 query InterfaceNoFragmentsQuery {
 	root {
 		id
@@ -653,7 +648,14 @@ query InterfaceNoFragmentsQuery {
 		name
 	}
 }
-`,
+`
+
+func InterfaceNoFragmentsQuery(
+	client graphql.Client,
+) (*InterfaceNoFragmentsQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "InterfaceNoFragmentsQuery",
+		Query:  InterfaceNoFragmentsQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
@@ -41,19 +41,21 @@ type __ListInputQueryInput struct {
 // GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
 func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
 
+const ListInputQueryOperation = `
+query ListInputQuery ($names: [String]) {
+	user(query: {names:$names}) {
+		id
+	}
+}
+`
+
 func ListInputQuery(
 	client graphql.Client,
 	names []string,
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
-		Query: `
-query ListInputQuery ($names: [String]) {
-	user(query: {names:$names}) {
-		id
-	}
-}
-`,
+		Query:  ListInputQueryOperation,
 		Variables: &__ListInputQueryInput{
 			Names: names,
 		},

--- a/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
@@ -16,16 +16,18 @@ func (v *ListOfListsOfListsResponse) GetListOfListsOfLists() [][][]string {
 	return v.ListOfListsOfLists
 }
 
+const ListOfListsOfListsOperation = `
+query ListOfListsOfLists {
+	listOfListsOfLists
+}
+`
+
 func ListOfListsOfLists(
 	client graphql.Client,
 ) (*ListOfListsOfListsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListOfListsOfLists",
-		Query: `
-query ListOfListsOfLists {
-	listOfListsOfLists
-}
-`,
+		Query:  ListOfListsOfListsOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -325,14 +325,7 @@ func (v *__MultipleDirectivesInput) GetQuery() MyInput { return v.Query }
 // GetQueries returns __MultipleDirectivesInput.Queries, and is useful for accessing the field via an interface.
 func (v *__MultipleDirectivesInput) GetQueries() []*UserQueryInput { return v.Queries }
 
-func MultipleDirectives(
-	client graphql.Client,
-	query MyInput,
-	queries []*UserQueryInput,
-) (*MyMultipleDirectivesResponse, error) {
-	req := &graphql.Request{
-		OpName: "MultipleDirectives",
-		Query: `
+const MultipleDirectivesOperation = `
 query MultipleDirectives ($query: UserQueryInput, $queries: [UserQueryInput]) {
 	user(query: $query) {
 		id
@@ -341,7 +334,16 @@ query MultipleDirectives ($query: UserQueryInput, $queries: [UserQueryInput]) {
 		id
 	}
 }
-`,
+`
+
+func MultipleDirectives(
+	client graphql.Client,
+	query MyInput,
+	queries []*UserQueryInput,
+) (*MyMultipleDirectivesResponse, error) {
+	req := &graphql.Request{
+		OpName: "MultipleDirectives",
+		Query:  MultipleDirectivesOperation,
 		Variables: &__MultipleDirectivesInput{
 			Query:   query,
 			Queries: queries,

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -219,17 +219,7 @@ func (v *__OmitEmptyQueryInput) GetTz() string { return v.Tz }
 // GetTzNoOmitEmpty returns __OmitEmptyQueryInput.TzNoOmitEmpty, and is useful for accessing the field via an interface.
 func (v *__OmitEmptyQueryInput) GetTzNoOmitEmpty() string { return v.TzNoOmitEmpty }
 
-func OmitEmptyQuery(
-	client graphql.Client,
-	query UserQueryInput,
-	queries []UserQueryInput,
-	dt time.Time,
-	tz string,
-	tzNoOmitEmpty string,
-) (*OmitEmptyQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "OmitEmptyQuery",
-		Query: `
+const OmitEmptyQueryOperation = `
 query OmitEmptyQuery ($query: UserQueryInput, $queries: [UserQueryInput], $dt: DateTime, $tz: String, $tzNoOmitEmpty: String) {
 	user(query: $query) {
 		id
@@ -240,7 +230,19 @@ query OmitEmptyQuery ($query: UserQueryInput, $queries: [UserQueryInput], $dt: D
 	maybeConvert(dt: $dt, tz: $tz)
 	convert2: maybeConvert(dt: $dt, tz: $tzNoOmitEmpty)
 }
-`,
+`
+
+func OmitEmptyQuery(
+	client graphql.Client,
+	query UserQueryInput,
+	queries []UserQueryInput,
+	dt time.Time,
+	tz string,
+	tzNoOmitEmpty string,
+) (*OmitEmptyQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "OmitEmptyQuery",
+		Query:  OmitEmptyQueryOperation,
 		Variables: &__OmitEmptyQueryInput{
 			Query:         query,
 			Queries:       queries,

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -230,15 +230,7 @@ func (v *__PointersQueryInput) GetDt() time.Time { return v.Dt }
 // GetTz returns __PointersQueryInput.Tz, and is useful for accessing the field via an interface.
 func (v *__PointersQueryInput) GetTz() *string { return v.Tz }
 
-func PointersQuery(
-	client graphql.Client,
-	query *UserQueryInput,
-	dt time.Time,
-	tz *string,
-) (*PointersQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "PointersQuery",
-		Query: `
+const PointersQueryOperation = `
 query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 	user(query: $query) {
 		id
@@ -252,7 +244,17 @@ query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 	}
 	maybeConvert(dt: $dt, tz: $tz)
 }
-`,
+`
+
+func PointersQuery(
+	client graphql.Client,
+	query *UserQueryInput,
+	dt time.Time,
+	tz *string,
+) (*PointersQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "PointersQuery",
+		Query:  PointersQueryOperation,
 		Variables: &__PointersQueryInput{
 			Query: query,
 			Dt:    dt,

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -227,15 +227,7 @@ func (v *__PointersQueryInput) GetDt() *time.Time { return v.Dt }
 // GetTz returns __PointersQueryInput.Tz, and is useful for accessing the field via an interface.
 func (v *__PointersQueryInput) GetTz() string { return v.Tz }
 
-func PointersQuery(
-	client graphql.Client,
-	query *UserQueryInput,
-	dt *time.Time,
-	tz string,
-) (*PointersQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "PointersQuery",
-		Query: `
+const PointersQueryOperation = `
 query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 	user(query: $query) {
 		id
@@ -249,7 +241,17 @@ query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 	}
 	maybeConvert(dt: $dt, tz: $tz)
 }
-`,
+`
+
+func PointersQuery(
+	client graphql.Client,
+	query *UserQueryInput,
+	dt *time.Time,
+	tz string,
+) (*PointersQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "PointersQuery",
+		Query:  PointersQueryOperation,
 		Variables: &__PointersQueryInput{
 			Query: query,
 			Dt:    dt,

--- a/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
@@ -71,13 +71,7 @@ type __GetPokemonSiblingsInput struct {
 // GetInput returns __GetPokemonSiblingsInput.Input, and is useful for accessing the field via an interface.
 func (v *__GetPokemonSiblingsInput) GetInput() testutil.Pokemon { return v.Input }
 
-func GetPokemonSiblings(
-	client graphql.Client,
-	input testutil.Pokemon,
-) (*GetPokemonSiblingsResponse, error) {
-	req := &graphql.Request{
-		OpName: "GetPokemonSiblings",
-		Query: `
+const GetPokemonSiblingsOperation = `
 query GetPokemonSiblings ($input: PokemonInput!) {
 	user(query: {hasPokemon:$input}) {
 		id
@@ -93,7 +87,15 @@ query GetPokemonSiblings ($input: PokemonInput!) {
 		}
 	}
 }
-`,
+`
+
+func GetPokemonSiblings(
+	client graphql.Client,
+	input testutil.Pokemon,
+) (*GetPokemonSiblingsResponse, error) {
+	req := &graphql.Request{
+		OpName: "GetPokemonSiblings",
+		Query:  GetPokemonSiblingsOperation,
 		Variables: &__GetPokemonSiblingsInput{
 			Input: input,
 		},

--- a/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
@@ -40,19 +40,21 @@ func (v *QueryWithAliasUser) GetID() testutil.ID { return v.ID }
 // GetOtherID returns QueryWithAliasUser.OtherID, and is useful for accessing the field via an interface.
 func (v *QueryWithAliasUser) GetOtherID() testutil.ID { return v.OtherID }
 
-func QueryWithAlias(
-	client graphql.Client,
-) (*QueryWithAliasResponse, error) {
-	req := &graphql.Request{
-		OpName: "QueryWithAlias",
-		Query: `
+const QueryWithAliasOperation = `
 query QueryWithAlias {
 	User: user {
 		ID: id
 		otherID: id
 	}
 }
-`,
+`
+
+func QueryWithAlias(
+	client graphql.Client,
+) (*QueryWithAliasResponse, error) {
+	req := &graphql.Request{
+		OpName: "QueryWithAlias",
+		Query:  QueryWithAliasOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
@@ -40,19 +40,21 @@ func (v *QueryWithDoubleAliasUser) GetID() testutil.ID { return v.ID }
 // GetAlsoID returns QueryWithDoubleAliasUser.AlsoID, and is useful for accessing the field via an interface.
 func (v *QueryWithDoubleAliasUser) GetAlsoID() testutil.ID { return v.AlsoID }
 
-func QueryWithDoubleAlias(
-	client graphql.Client,
-) (*QueryWithDoubleAliasResponse, error) {
-	req := &graphql.Request{
-		OpName: "QueryWithDoubleAlias",
-		Query: `
+const QueryWithDoubleAliasOperation = `
 query QueryWithDoubleAlias {
 	user {
 		ID: id
 		AlsoID: id
 	}
 }
-`,
+`
+
+func QueryWithDoubleAlias(
+	client graphql.Client,
+) (*QueryWithDoubleAliasResponse, error) {
+	req := &graphql.Request{
+		OpName: "QueryWithDoubleAlias",
+		Query:  QueryWithDoubleAliasOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
@@ -62,12 +62,7 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
-func QueryWithEnums(
-	client graphql.Client,
-) (*QueryWithEnumsResponse, error) {
-	req := &graphql.Request{
-		OpName: "QueryWithEnums",
-		Query: `
+const QueryWithEnumsOperation = `
 query QueryWithEnums {
 	user {
 		roles
@@ -76,7 +71,14 @@ query QueryWithEnums {
 		roles
 	}
 }
-`,
+`
+
+func QueryWithEnums(
+	client graphql.Client,
+) (*QueryWithEnumsResponse, error) {
+	req := &graphql.Request{
+		OpName: "QueryWithEnums",
+		Query:  QueryWithEnumsOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
@@ -41,12 +41,7 @@ func (v *QueryWithSlicesUser) GetEmailsWithNulls() []string { return v.EmailsWit
 // GetEmailsWithNullsOrNull returns QueryWithSlicesUser.EmailsWithNullsOrNull, and is useful for accessing the field via an interface.
 func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []string { return v.EmailsWithNullsOrNull }
 
-func QueryWithSlices(
-	client graphql.Client,
-) (*QueryWithSlicesResponse, error) {
-	req := &graphql.Request{
-		OpName: "QueryWithSlices",
-		Query: `
+const QueryWithSlicesOperation = `
 query QueryWithSlices {
 	user {
 		emails
@@ -55,7 +50,14 @@ query QueryWithSlices {
 		emailsWithNullsOrNull
 	}
 }
-`,
+`
+
+func QueryWithSlices(
+	client graphql.Client,
+) (*QueryWithSlicesResponse, error) {
+	req := &graphql.Request{
+		OpName: "QueryWithSlices",
+		Query:  QueryWithSlicesOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
@@ -43,12 +43,7 @@ func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() string { retur
 // GetEmail returns QueryWithStructsUserAuthMethodsAuthMethod.Email, and is useful for accessing the field via an interface.
 func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() string { return v.Email }
 
-func QueryWithStructs(
-	client graphql.Client,
-) (*QueryWithStructsResponse, error) {
-	req := &graphql.Request{
-		OpName: "QueryWithStructs",
-		Query: `
+const QueryWithStructsOperation = `
 query QueryWithStructs {
 	user {
 		authMethods {
@@ -57,7 +52,14 @@ query QueryWithStructs {
 		}
 	}
 }
-`,
+`
+
+func QueryWithStructs(
+	client graphql.Client,
+) (*QueryWithStructsResponse, error) {
+	req := &graphql.Request{
+		OpName: "QueryWithStructs",
+		Query:  QueryWithStructsOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
@@ -68,13 +68,7 @@ type __RecursionInput struct {
 // GetInput returns __RecursionInput.Input, and is useful for accessing the field via an interface.
 func (v *__RecursionInput) GetInput() RecursiveInput { return v.Input }
 
-func Recursion(
-	client graphql.Client,
-	input RecursiveInput,
-) (*RecursionResponse, error) {
-	req := &graphql.Request{
-		OpName: "Recursion",
-		Query: `
+const RecursionOperation = `
 query Recursion ($input: RecursiveInput!) {
 	recur(input: $input) {
 		rec {
@@ -86,7 +80,15 @@ query Recursion ($input: RecursiveInput!) {
 		}
 	}
 }
-`,
+`
+
+func Recursion(
+	client graphql.Client,
+	input RecursiveInput,
+) (*RecursionResponse, error) {
+	req := &graphql.Request{
+		OpName: "Recursion",
+		Query:  RecursionOperation,
 		Variables: &__RecursionInput{
 			Input: input,
 		},

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -239,12 +239,7 @@ func (v *SimpleInlineFragmentResponse) __premarshalJSON() (*__premarshalSimpleIn
 	return &retval, nil
 }
 
-func SimpleInlineFragment(
-	client graphql.Client,
-) (*SimpleInlineFragmentResponse, error) {
-	req := &graphql.Request{
-		OpName: "SimpleInlineFragment",
-		Query: `
+const SimpleInlineFragmentOperation = `
 query SimpleInlineFragment {
 	randomItem {
 		__typename
@@ -258,7 +253,14 @@ query SimpleInlineFragment {
 		}
 	}
 }
-`,
+`
+
+func SimpleInlineFragment(
+	client graphql.Client,
+) (*SimpleInlineFragmentResponse, error) {
+	req := &graphql.Request{
+		OpName: "SimpleInlineFragment",
+		Query:  SimpleInlineFragmentOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
@@ -41,19 +41,21 @@ type __SimpleInputQueryInput struct {
 // GetName returns __SimpleInputQueryInput.Name, and is useful for accessing the field via an interface.
 func (v *__SimpleInputQueryInput) GetName() string { return v.Name }
 
+const SimpleInputQueryOperation = `
+query SimpleInputQuery ($name: String!) {
+	user(query: {name:$name}) {
+		id
+	}
+}
+`
+
 func SimpleInputQuery(
 	client graphql.Client,
 	name string,
 ) (*SimpleInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleInputQuery",
-		Query: `
-query SimpleInputQuery ($name: String!) {
-	user(query: {name:$name}) {
-		id
-	}
-}
-`,
+		Query:  SimpleInputQueryOperation,
 		Variables: &__SimpleInputQueryInput{
 			Name: name,
 		},

--- a/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
@@ -41,6 +41,15 @@ type __SimpleMutationInput struct {
 // GetName returns __SimpleMutationInput.Name, and is useful for accessing the field via an interface.
 func (v *__SimpleMutationInput) GetName() string { return v.Name }
 
+const SimpleMutationOperation = `
+mutation SimpleMutation ($name: String!) {
+	createUser(name: $name) {
+		id
+		name
+	}
+}
+`
+
 // SimpleMutation creates a user.
 //
 // It has a long doc-comment, to test that we handle that correctly.
@@ -51,14 +60,7 @@ func SimpleMutation(
 ) (*SimpleMutationResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleMutation",
-		Query: `
-mutation SimpleMutation ($name: String!) {
-	createUser(name: $name) {
-		id
-		name
-	}
-}
-`,
+		Query:  SimpleMutationOperation,
 		Variables: &__SimpleMutationInput{
 			Name: name,
 		},

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -546,12 +546,7 @@ type VideoFieldsThumbnail struct {
 // GetId returns VideoFieldsThumbnail.Id, and is useful for accessing the field via an interface.
 func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
-func SimpleNamedFragment(
-	client graphql.Client,
-) (*SimpleNamedFragmentResponse, error) {
-	req := &graphql.Request{
-		OpName: "SimpleNamedFragment",
-		Query: `
+const SimpleNamedFragmentOperation = `
 query SimpleNamedFragment {
 	randomItem {
 		__typename
@@ -573,7 +568,14 @@ fragment VideoFields on Video {
 		id
 	}
 }
-`,
+`
+
+func SimpleNamedFragment(
+	client graphql.Client,
+) (*SimpleNamedFragmentResponse, error) {
+	req := &graphql.Request{
+		OpName: "SimpleNamedFragment",
+		Query:  SimpleNamedFragmentOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
@@ -33,18 +33,20 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
 
-func SimpleQuery(
-	client graphql.Client,
-) (*SimpleQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "SimpleQuery",
-		Query: `
+const SimpleQueryOperation = `
 query SimpleQuery {
 	user {
 		id
 	}
 }
-`,
+`
+
+func SimpleQuery(
+	client graphql.Client,
+) (*SimpleQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "SimpleQuery",
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -424,12 +424,7 @@ type VideoFields struct {
 // GetDuration returns VideoFields.Duration, and is useful for accessing the field via an interface.
 func (v *VideoFields) GetDuration() int { return v.Duration }
 
-func StructOption(
-	client graphql.Client,
-) (*StructOptionResponse, error) {
-	req := &graphql.Request{
-		OpName: "StructOption",
-		Query: `
+const StructOptionOperation = `
 query StructOption {
 	root {
 		id
@@ -457,7 +452,14 @@ query StructOption {
 fragment VideoFields on Video {
 	duration
 }
-`,
+`
+
+func StructOption(
+	client graphql.Client,
+) (*StructOptionResponse, error) {
+	req := &graphql.Request{
+		OpName: "StructOption",
+		Query:  StructOptionOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
@@ -37,19 +37,21 @@ func (v *TypeNameQueryUser) GetTypename() string { return v.Typename }
 // GetId returns TypeNameQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *TypeNameQueryUser) GetId() testutil.ID { return v.Id }
 
-func TypeNameQuery(
-	client graphql.Client,
-) (*TypeNameQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "TypeNameQuery",
-		Query: `
+const TypeNameQueryOperation = `
 query TypeNameQuery {
 	user {
 		__typename
 		id
 	}
 }
-`,
+`
+
+func TypeNameQuery(
+	client graphql.Client,
+) (*TypeNameQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "TypeNameQuery",
+		Query:  TypeNameQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -264,12 +264,7 @@ func (v *User) GetId() testutil.ID { return v.Id }
 // GetName returns User.Name, and is useful for accessing the field via an interface.
 func (v *User) GetName() string { return v.Name }
 
-func TypeNames(
-	client graphql.Client,
-) (*Resp, error) {
-	req := &graphql.Request{
-		OpName: "TypeNames",
-		Query: `
+const TypeNamesOperation = `
 query TypeNames {
 	user {
 		id
@@ -285,7 +280,14 @@ query TypeNames {
 		name
 	}
 }
-`,
+`
+
+func TypeNames(
+	client graphql.Client,
+) (*Resp, error) {
+	req := &graphql.Request{
+		OpName: "TypeNames",
+		Query:  TypeNamesOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -174,18 +174,20 @@ func (v *UnionNoFragmentsQueryResponse) __premarshalJSON() (*__premarshalUnionNo
 	return &retval, nil
 }
 
-func UnionNoFragmentsQuery(
-	client graphql.Client,
-) (*UnionNoFragmentsQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "UnionNoFragmentsQuery",
-		Query: `
+const UnionNoFragmentsQueryOperation = `
 query UnionNoFragmentsQuery {
 	randomLeaf {
 		__typename
 	}
 }
-`,
+`
+
+func UnionNoFragmentsQuery(
+	client graphql.Client,
+) (*UnionNoFragmentsQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "UnionNoFragmentsQuery",
+		Query:  UnionNoFragmentsQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
@@ -62,12 +62,7 @@ func (v *UsesEnumTwiceQueryResponse) GetMe() UsesEnumTwiceQueryMeUser { return v
 // GetOtherUser returns UsesEnumTwiceQueryResponse.OtherUser, and is useful for accessing the field via an interface.
 func (v *UsesEnumTwiceQueryResponse) GetOtherUser() UsesEnumTwiceQueryOtherUser { return v.OtherUser }
 
-func UsesEnumTwiceQuery(
-	client graphql.Client,
-) (*UsesEnumTwiceQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "UsesEnumTwiceQuery",
-		Query: `
+const UsesEnumTwiceQueryOperation = `
 query UsesEnumTwiceQuery {
 	Me: user {
 		roles
@@ -76,7 +71,14 @@ query UsesEnumTwiceQuery {
 		roles
 	}
 }
-`,
+`
+
+func UsesEnumTwiceQuery(
+	client graphql.Client,
+) (*UsesEnumTwiceQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "UsesEnumTwiceQuery",
+		Query:  UsesEnumTwiceQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -177,19 +177,21 @@ type unexportedUser struct {
 // GetId returns unexportedUser.Id, and is useful for accessing the field via an interface.
 func (v *unexportedUser) GetId() testutil.ID { return v.Id }
 
+const unexportedOperation = `
+query unexported ($query: UserQueryInput) {
+	user(query: $query) {
+		id
+	}
+}
+`
+
 func unexported(
 	client graphql.Client,
 	query UserQueryInput,
 ) (*unexportedResponse, error) {
 	req := &graphql.Request{
 		OpName: "unexported",
-		Query: `
-query unexported ($query: UserQueryInput) {
-	user(query: $query) {
-		id
-	}
-}
-`,
+		Query:  unexportedOperation,
 		Variables: &__unexportedInput{
 			Query: query,
 		},

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
@@ -35,18 +35,20 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
-func SimpleQuery(
-	ctx context.Context,
-) (*SimpleQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "SimpleQuery",
-		Query: `
+const SimpleQueryOperation = `
 query SimpleQuery {
 	user {
 		id
 	}
 }
-`,
+`
+
+func SimpleQuery(
+	ctx context.Context,
+) (*SimpleQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "SimpleQuery",
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 	var client graphql.Client

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
@@ -38,18 +38,20 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
-func SimpleQuery(
-	ctx testutil.MyContext,
-) (*SimpleQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "SimpleQuery",
-		Query: `
+const SimpleQueryOperation = `
 query SimpleQuery {
 	user {
 		id
 	}
 }
-`,
+`
+
+func SimpleQuery(
+	ctx testutil.MyContext,
+) (*SimpleQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "SimpleQuery",
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 	var client graphql.Client

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
@@ -33,16 +33,18 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
-func SimpleQuery() (*SimpleQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "SimpleQuery",
-		Query: `
+const SimpleQueryOperation = `
 query SimpleQuery {
 	user {
 		id
 	}
 }
-`,
+`
+
+func SimpleQuery() (*SimpleQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "SimpleQuery",
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 	var client graphql.Client

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
@@ -38,19 +38,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx testutil.MyContext,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContextWithAlias-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContextWithAlias-testdata-queries-generated.go
@@ -38,19 +38,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx junkfunname.MyContext,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
@@ -34,19 +34,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
@@ -34,19 +34,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
@@ -34,19 +34,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
@@ -32,18 +32,20 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
-func SimpleQuery(
-	client graphql.Client,
-) (*SimpleQueryResponse, error) {
-	req := &graphql.Request{
-		OpName: "SimpleQuery",
-		Query: `
+const SimpleQueryOperation = `
 query SimpleQuery {
 	user {
 		id
 	}
 }
-`,
+`
+
+func SimpleQuery(
+	client graphql.Client,
+) (*SimpleQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "SimpleQuery",
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
@@ -77,6 +77,14 @@ type __ListInputQueryInput struct {
 // GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
 func (v *__ListInputQueryInput) GetNames() []*string { return v.Names }
 
+const ListInputQueryOperation = `
+query ListInputQuery ($names: [String]) {
+	user(query: {names:$names}) {
+		id
+	}
+}
+`
+
 func ListInputQuery(
 	ctx context.Context,
 	client graphql.Client,
@@ -84,13 +92,7 @@ func ListInputQuery(
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
-		Query: `
-query ListInputQuery ($names: [String]) {
-	user(query: {names:$names}) {
-		id
-	}
-}
-`,
+		Query:  ListInputQueryOperation,
 		Variables: &__ListInputQueryInput{
 			Names: names,
 		},
@@ -109,13 +111,7 @@ query ListInputQuery ($names: [String]) {
 	return &data, err
 }
 
-func QueryWithSlices(
-	ctx context.Context,
-	client graphql.Client,
-) (*QueryWithSlicesResponse, error) {
-	req := &graphql.Request{
-		OpName: "QueryWithSlices",
-		Query: `
+const QueryWithSlicesOperation = `
 query QueryWithSlices {
 	user {
 		emails
@@ -124,7 +120,15 @@ query QueryWithSlices {
 		emailsWithNullsOrNull
 	}
 }
-`,
+`
+
+func QueryWithSlices(
+	ctx context.Context,
+	client graphql.Client,
+) (*QueryWithSlicesResponse, error) {
+	req := &graphql.Request{
+		OpName: "QueryWithSlices",
+		Query:  QueryWithSlicesOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
@@ -77,6 +77,14 @@ type __ListInputQueryInput struct {
 // GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
 func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
 
+const ListInputQueryOperation = `
+query ListInputQuery ($names: [String]) {
+	user(query: {names:$names}) {
+		id
+	}
+}
+`
+
 func ListInputQuery(
 	ctx context.Context,
 	client graphql.Client,
@@ -84,13 +92,7 @@ func ListInputQuery(
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
-		Query: `
-query ListInputQuery ($names: [String]) {
-	user(query: {names:$names}) {
-		id
-	}
-}
-`,
+		Query:  ListInputQueryOperation,
 		Variables: &__ListInputQueryInput{
 			Names: names,
 		},
@@ -109,13 +111,7 @@ query ListInputQuery ($names: [String]) {
 	return &data, err
 }
 
-func QueryWithSlices(
-	ctx context.Context,
-	client graphql.Client,
-) (*QueryWithSlicesResponse, error) {
-	req := &graphql.Request{
-		OpName: "QueryWithSlices",
-		Query: `
+const QueryWithSlicesOperation = `
 query QueryWithSlices {
 	user {
 		emails
@@ -124,7 +120,15 @@ query QueryWithSlices {
 		emailsWithNullsOrNull
 	}
 }
-`,
+`
+
+func QueryWithSlices(
+	ctx context.Context,
+	client graphql.Client,
+) (*QueryWithSlicesResponse, error) {
+	req := &graphql.Request{
+		OpName: "QueryWithSlices",
+		Query:  QueryWithSlicesOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageBindings-testdata-queries
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageBindings-testdata-queries
@@ -35,19 +35,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
@@ -34,19 +34,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated-structrefs.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated-structrefs.go
@@ -34,19 +34,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
@@ -34,19 +34,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
@@ -34,19 +34,21 @@ type SimpleQueryUser struct {
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
+const SimpleQueryOperation = `
+query SimpleQuery {
+	user {
+		id
+	}
+}
+`
+
 func SimpleQuery(
 	ctx context.Context,
 	client graphql.Client,
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query: `
-query SimpleQuery {
-	user {
-		id
-	}
-}
-`,
+		Query:  SimpleQueryOperation,
 	}
 	var err error
 

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -3078,6 +3078,15 @@ type simpleQueryResponse struct {
 // GetMe returns simpleQueryResponse.Me, and is useful for accessing the field via an interface.
 func (v *simpleQueryResponse) GetMe() simpleQueryMeUser { return v.Me }
 
+const createUserOperation = `
+mutation createUser ($user: NewUser!) {
+	createUser(input: $user) {
+		id
+		name
+	}
+}
+`
+
 func createUser(
 	ctx context.Context,
 	client graphql.Client,
@@ -3085,14 +3094,7 @@ func createUser(
 ) (*createUserResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "createUser",
-		Query: `
-mutation createUser ($user: NewUser!) {
-	createUser(input: $user) {
-		id
-		name
-	}
-}
-`,
+		Query:  createUserOperation,
 		Variables: &__createUserInput{
 			User: user,
 		},
@@ -3111,20 +3113,22 @@ mutation createUser ($user: NewUser!) {
 	return &data, resp.Extensions, err
 }
 
-func failingQuery(
-	ctx context.Context,
-	client graphql.Client,
-) (*failingQueryResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "failingQuery",
-		Query: `
+const failingQueryOperation = `
 query failingQuery {
 	fail
 	me {
 		id
 	}
 }
-`,
+`
+
+func failingQuery(
+	ctx context.Context,
+	client graphql.Client,
+) (*failingQueryResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "failingQuery",
+		Query:  failingQueryOperation,
 	}
 	var err error
 
@@ -3140,14 +3144,7 @@ query failingQuery {
 	return &data, resp.Extensions, err
 }
 
-func queryWithCustomMarshal(
-	ctx context.Context,
-	client graphql.Client,
-	date time.Time,
-) (*queryWithCustomMarshalResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithCustomMarshal",
-		Query: `
+const queryWithCustomMarshalOperation = `
 query queryWithCustomMarshal ($date: Date!) {
 	usersBornOn(date: $date) {
 		id
@@ -3155,7 +3152,16 @@ query queryWithCustomMarshal ($date: Date!) {
 		birthdate
 	}
 }
-`,
+`
+
+func queryWithCustomMarshal(
+	ctx context.Context,
+	client graphql.Client,
+	date time.Time,
+) (*queryWithCustomMarshalResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithCustomMarshal",
+		Query:  queryWithCustomMarshalOperation,
 		Variables: &__queryWithCustomMarshalInput{
 			Date: date,
 		},
@@ -3174,6 +3180,16 @@ query queryWithCustomMarshal ($date: Date!) {
 	return &data, resp.Extensions, err
 }
 
+const queryWithCustomMarshalOptionalOperation = `
+query queryWithCustomMarshalOptional ($date: Date, $id: ID) {
+	userSearch(birthdate: $date, id: $id) {
+		id
+		name
+		birthdate
+	}
+}
+`
+
 func queryWithCustomMarshalOptional(
 	ctx context.Context,
 	client graphql.Client,
@@ -3182,15 +3198,7 @@ func queryWithCustomMarshalOptional(
 ) (*queryWithCustomMarshalOptionalResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithCustomMarshalOptional",
-		Query: `
-query queryWithCustomMarshalOptional ($date: Date, $id: ID) {
-	userSearch(birthdate: $date, id: $id) {
-		id
-		name
-		birthdate
-	}
-}
-`,
+		Query:  queryWithCustomMarshalOptionalOperation,
 		Variables: &__queryWithCustomMarshalOptionalInput{
 			Date: date,
 			Id:   id,
@@ -3210,14 +3218,7 @@ query queryWithCustomMarshalOptional ($date: Date, $id: ID) {
 	return &data, resp.Extensions, err
 }
 
-func queryWithCustomMarshalSlice(
-	ctx context.Context,
-	client graphql.Client,
-	dates []time.Time,
-) (*queryWithCustomMarshalSliceResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithCustomMarshalSlice",
-		Query: `
+const queryWithCustomMarshalSliceOperation = `
 query queryWithCustomMarshalSlice ($dates: [Date!]!) {
 	usersBornOnDates(dates: $dates) {
 		id
@@ -3225,7 +3226,16 @@ query queryWithCustomMarshalSlice ($dates: [Date!]!) {
 		birthdate
 	}
 }
-`,
+`
+
+func queryWithCustomMarshalSlice(
+	ctx context.Context,
+	client graphql.Client,
+	dates []time.Time,
+) (*queryWithCustomMarshalSliceResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithCustomMarshalSlice",
+		Query:  queryWithCustomMarshalSliceOperation,
 		Variables: &__queryWithCustomMarshalSliceInput{
 			Dates: dates,
 		},
@@ -3244,14 +3254,7 @@ query queryWithCustomMarshalSlice ($dates: [Date!]!) {
 	return &data, resp.Extensions, err
 }
 
-func queryWithFlatten(
-	ctx context.Context,
-	client graphql.Client,
-	ids []string,
-) (*QueryFragment, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithFlatten",
-		Query: `
+const queryWithFlattenOperation = `
 query queryWithFlatten ($ids: [ID!]!) {
 	... QueryFragment
 }
@@ -3293,7 +3296,16 @@ fragment FriendsFields on User {
 	id
 	name
 }
-`,
+`
+
+func queryWithFlatten(
+	ctx context.Context,
+	client graphql.Client,
+	ids []string,
+) (*QueryFragment, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithFlatten",
+		Query:  queryWithFlattenOperation,
 		Variables: &__queryWithFlattenInput{
 			Ids: ids,
 		},
@@ -3312,14 +3324,7 @@ fragment FriendsFields on User {
 	return &data, resp.Extensions, err
 }
 
-func queryWithFragments(
-	ctx context.Context,
-	client graphql.Client,
-	ids []string,
-) (*queryWithFragmentsResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithFragments",
-		Query: `
+const queryWithFragmentsOperation = `
 query queryWithFragments ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3355,7 +3360,16 @@ query queryWithFragments ($ids: [ID!]!) {
 		}
 	}
 }
-`,
+`
+
+func queryWithFragments(
+	ctx context.Context,
+	client graphql.Client,
+	ids []string,
+) (*queryWithFragmentsResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithFragments",
+		Query:  queryWithFragmentsOperation,
 		Variables: &__queryWithFragmentsInput{
 			Ids: ids,
 		},
@@ -3374,14 +3388,7 @@ query queryWithFragments ($ids: [ID!]!) {
 	return &data, resp.Extensions, err
 }
 
-func queryWithInterfaceListField(
-	ctx context.Context,
-	client graphql.Client,
-	ids []string,
-) (*queryWithInterfaceListFieldResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithInterfaceListField",
-		Query: `
+const queryWithInterfaceListFieldOperation = `
 query queryWithInterfaceListField ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3389,7 +3396,16 @@ query queryWithInterfaceListField ($ids: [ID!]!) {
 		name
 	}
 }
-`,
+`
+
+func queryWithInterfaceListField(
+	ctx context.Context,
+	client graphql.Client,
+	ids []string,
+) (*queryWithInterfaceListFieldResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithInterfaceListField",
+		Query:  queryWithInterfaceListFieldOperation,
 		Variables: &__queryWithInterfaceListFieldInput{
 			Ids: ids,
 		},
@@ -3408,14 +3424,7 @@ query queryWithInterfaceListField ($ids: [ID!]!) {
 	return &data, resp.Extensions, err
 }
 
-func queryWithInterfaceListPointerField(
-	ctx context.Context,
-	client graphql.Client,
-	ids []string,
-) (*queryWithInterfaceListPointerFieldResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithInterfaceListPointerField",
-		Query: `
+const queryWithInterfaceListPointerFieldOperation = `
 query queryWithInterfaceListPointerField ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3423,7 +3432,16 @@ query queryWithInterfaceListPointerField ($ids: [ID!]!) {
 		name
 	}
 }
-`,
+`
+
+func queryWithInterfaceListPointerField(
+	ctx context.Context,
+	client graphql.Client,
+	ids []string,
+) (*queryWithInterfaceListPointerFieldResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithInterfaceListPointerField",
+		Query:  queryWithInterfaceListPointerFieldOperation,
 		Variables: &__queryWithInterfaceListPointerFieldInput{
 			Ids: ids,
 		},
@@ -3442,14 +3460,7 @@ query queryWithInterfaceListPointerField ($ids: [ID!]!) {
 	return &data, resp.Extensions, err
 }
 
-func queryWithInterfaceNoFragments(
-	ctx context.Context,
-	client graphql.Client,
-	id string,
-) (*queryWithInterfaceNoFragmentsResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithInterfaceNoFragments",
-		Query: `
+const queryWithInterfaceNoFragmentsOperation = `
 query queryWithInterfaceNoFragments ($id: ID!) {
 	being(id: $id) {
 		__typename
@@ -3461,7 +3472,16 @@ query queryWithInterfaceNoFragments ($id: ID!) {
 		name
 	}
 }
-`,
+`
+
+func queryWithInterfaceNoFragments(
+	ctx context.Context,
+	client graphql.Client,
+	id string,
+) (*queryWithInterfaceNoFragmentsResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithInterfaceNoFragments",
+		Query:  queryWithInterfaceNoFragmentsOperation,
 		Variables: &__queryWithInterfaceNoFragmentsInput{
 			Id: id,
 		},
@@ -3480,14 +3500,7 @@ query queryWithInterfaceNoFragments ($id: ID!) {
 	return &data, resp.Extensions, err
 }
 
-func queryWithNamedFragments(
-	ctx context.Context,
-	client graphql.Client,
-	ids []string,
-) (*queryWithNamedFragmentsResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithNamedFragments",
-		Query: `
+const queryWithNamedFragmentsOperation = `
 query queryWithNamedFragments ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3523,7 +3536,16 @@ fragment MoreUserFields on User {
 		color
 	}
 }
-`,
+`
+
+func queryWithNamedFragments(
+	ctx context.Context,
+	client graphql.Client,
+	ids []string,
+) (*queryWithNamedFragmentsResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithNamedFragments",
+		Query:  queryWithNamedFragmentsOperation,
 		Variables: &__queryWithNamedFragmentsInput{
 			Ids: ids,
 		},
@@ -3542,14 +3564,7 @@ fragment MoreUserFields on User {
 	return &data, resp.Extensions, err
 }
 
-func queryWithOmitempty(
-	ctx context.Context,
-	client graphql.Client,
-	id string,
-) (*queryWithOmitemptyResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithOmitempty",
-		Query: `
+const queryWithOmitemptyOperation = `
 query queryWithOmitempty ($id: ID) {
 	user(id: $id) {
 		id
@@ -3557,7 +3572,16 @@ query queryWithOmitempty ($id: ID) {
 		luckyNumber
 	}
 }
-`,
+`
+
+func queryWithOmitempty(
+	ctx context.Context,
+	client graphql.Client,
+	id string,
+) (*queryWithOmitemptyResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithOmitempty",
+		Query:  queryWithOmitemptyOperation,
 		Variables: &__queryWithOmitemptyInput{
 			Id: id,
 		},
@@ -3576,14 +3600,7 @@ query queryWithOmitempty ($id: ID) {
 	return &data, resp.Extensions, err
 }
 
-func queryWithVariables(
-	ctx context.Context,
-	client graphql.Client,
-	id string,
-) (*queryWithVariablesResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "queryWithVariables",
-		Query: `
+const queryWithVariablesOperation = `
 query queryWithVariables ($id: ID!) {
 	user(id: $id) {
 		id
@@ -3591,7 +3608,16 @@ query queryWithVariables ($id: ID!) {
 		luckyNumber
 	}
 }
-`,
+`
+
+func queryWithVariables(
+	ctx context.Context,
+	client graphql.Client,
+	id string,
+) (*queryWithVariablesResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "queryWithVariables",
+		Query:  queryWithVariablesOperation,
 		Variables: &__queryWithVariablesInput{
 			Id: id,
 		},
@@ -3610,13 +3636,7 @@ query queryWithVariables ($id: ID!) {
 	return &data, resp.Extensions, err
 }
 
-func simpleQuery(
-	ctx context.Context,
-	client graphql.Client,
-) (*simpleQueryResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "simpleQuery",
-		Query: `
+const simpleQueryOperation = `
 query simpleQuery {
 	me {
 		id
@@ -3624,7 +3644,15 @@ query simpleQuery {
 		luckyNumber
 	}
 }
-`,
+`
+
+func simpleQuery(
+	ctx context.Context,
+	client graphql.Client,
+) (*simpleQueryResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "simpleQuery",
+		Query:  simpleQueryOperation,
 	}
 	var err error
 
@@ -3640,13 +3668,7 @@ query simpleQuery {
 	return &data, resp.Extensions, err
 }
 
-func simpleQueryExt(
-	ctx context.Context,
-	client graphql.Client,
-) (*simpleQueryExtResponse, map[string]interface{}, error) {
-	req := &graphql.Request{
-		OpName: "simpleQueryExt",
-		Query: `
+const simpleQueryExtOperation = `
 query simpleQueryExt {
 	me {
 		id
@@ -3654,7 +3676,15 @@ query simpleQueryExt {
 		luckyNumber
 	}
 }
-`,
+`
+
+func simpleQueryExt(
+	ctx context.Context,
+	client graphql.Client,
+) (*simpleQueryExtResponse, map[string]interface{}, error) {
+	req := &graphql.Request{
+		OpName: "simpleQueryExt",
+		Query:  simpleQueryExtOperation,
 	}
 	var err error
 


### PR DESCRIPTION
This allows client code to see the operation (query or mutation) exactly as genqlient sends it over the wire.  This data was already available in the generated safelist.json file, but now it's easily available from Go code as well.
    
Fixes #236

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
