### PR TITLE
Rename the query constant to have an underscore in it.

### DIFF
--- a/example/generated.go
+++ b/example/generated.go
@@ -70,7 +70,7 @@ func (v *getViewerViewerUser) GetMyName() string { return v.MyName }
 func (v *getViewerViewerUser) GetCreatedAt() time.Time { return v.CreatedAt }
 
 // The query or mutation executed by getUser.
-const getUserOperation = `
+const getUser_Operation = `
 query getUser ($Login: String!) {
 	user(login: $Login) {
 		theirName: name
@@ -87,7 +87,7 @@ func getUser(
 ) (*getUserResponse, error) {
 	req := &graphql.Request{
 		OpName: "getUser",
-		Query:  getUserOperation,
+		Query:  getUser_Operation,
 		Variables: &__getUserInput{
 			Login: Login,
 		},
@@ -107,7 +107,7 @@ func getUser(
 }
 
 // The query or mutation executed by getViewer.
-const getViewerOperation = `
+const getViewer_Operation = `
 query getViewer {
 	viewer {
 		MyName: name
@@ -122,7 +122,7 @@ func getViewer(
 ) (*getViewerResponse, error) {
 	req := &graphql.Request{
 		OpName: "getViewer",
-		Query:  getViewerOperation,
+		Query:  getViewer_Operation,
 	}
 	var err error
 

--- a/generate/operation.go.tmpl
+++ b/generate/operation.go.tmpl
@@ -1,5 +1,5 @@
 // The query or mutation executed by {{.Name}}.
-const {{.Name}}Operation = `{{$.Body}}`
+const {{.Name}}_Operation = `{{$.Body}}`
 
 {{.Doc}}
 func {{.Name}}(
@@ -18,7 +18,7 @@ func {{.Name}}(
 ) (*{{.ResponseName}}, {{if .Config.Extensions -}}map[string]interface{},{{end}} error) {
     req := &graphql.Request{
         OpName: "{{.Name}}",
-        Query:  {{.Name}}Operation,
+        Query:  {{.Name}}_Operation,
     {{if .Input -}}
         Variables: &{{.Input.GoName}}{
         {{range .Input.Fields -}}

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -1341,7 +1341,7 @@ func (v *ComplexInlineFragmentsRootTopic) GetSchoolGrade() string { return v.Sch
 func (v *ComplexInlineFragmentsRootTopic) GetName() string { return v.Name }
 
 // The query or mutation executed by ComplexInlineFragments.
-const ComplexInlineFragmentsOperation = `
+const ComplexInlineFragments_Operation = `
 query ComplexInlineFragments {
 	root {
 		id
@@ -1439,7 +1439,7 @@ func ComplexInlineFragments(
 ) (*ComplexInlineFragmentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ComplexInlineFragments",
-		Query:  ComplexInlineFragmentsOperation,
+		Query:  ComplexInlineFragments_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -1740,7 +1740,7 @@ type VideoFieldsThumbnail struct {
 func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
 // The query or mutation executed by ComplexNamedFragments.
-const ComplexNamedFragmentsOperation = `
+const ComplexNamedFragments_Operation = `
 query ComplexNamedFragments {
 	... on Query {
 		... QueryFragment
@@ -1805,7 +1805,7 @@ func ComplexNamedFragments(
 ) (*ComplexNamedFragmentsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ComplexNamedFragments",
-		Query:  ComplexNamedFragmentsOperation,
+		Query:  ComplexNamedFragments_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
@@ -2347,7 +2347,7 @@ type TopicFieldsRelatedTopic struct {
 func (v *TopicFieldsRelatedTopic) GetId() testutil.ID { return v.Id }
 
 // The query or mutation executed by CovariantInterfaceImplementation.
-const CovariantInterfaceImplementationOperation = `
+const CovariantInterfaceImplementation_Operation = `
 query CovariantInterfaceImplementation {
 	randomItem {
 		__typename
@@ -2397,7 +2397,7 @@ func CovariantInterfaceImplementation(
 ) (*CovariantInterfaceImplementationResponse, error) {
 	req := &graphql.Request{
 		OpName: "CovariantInterfaceImplementation",
-		Query:  CovariantInterfaceImplementationOperation,
+		Query:  CovariantInterfaceImplementation_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -175,7 +175,7 @@ func (v *__CustomMarshalInput) __premarshalJSON() (*__premarshal__CustomMarshalI
 }
 
 // The query or mutation executed by CustomMarshal.
-const CustomMarshalOperation = `
+const CustomMarshal_Operation = `
 query CustomMarshal ($date: Date!) {
 	usersBornOn(date: $date) {
 		id
@@ -190,7 +190,7 @@ func CustomMarshal(
 ) (*CustomMarshalResponse, error) {
 	req := &graphql.Request{
 		OpName: "CustomMarshal",
-		Query:  CustomMarshalOperation,
+		Query:  CustomMarshal_Operation,
 		Variables: &__CustomMarshalInput{
 			Date: date,
 		},

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -204,7 +204,7 @@ func (v *__CustomMarshalSliceInput) __premarshalJSON() (*__premarshal__CustomMar
 }
 
 // The query or mutation executed by CustomMarshalSlice.
-const CustomMarshalSliceOperation = `
+const CustomMarshalSlice_Operation = `
 query CustomMarshalSlice ($datesss: [[[Date!]!]!]!, $datesssp: [[[Date!]!]!]!) {
 	acceptsListOfListOfListsOfDates(datesss: $datesss)
 	withPointer: acceptsListOfListOfListsOfDates(datesss: $datesssp)
@@ -218,7 +218,7 @@ func CustomMarshalSlice(
 ) (*CustomMarshalSliceResponse, error) {
 	req := &graphql.Request{
 		OpName: "CustomMarshalSlice",
-		Query:  CustomMarshalSliceOperation,
+		Query:  CustomMarshalSlice_Operation,
 		Variables: &__CustomMarshalSliceInput{
 			Datesss:  datesss,
 			Datesssp: datesssp,

--- a/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
@@ -29,7 +29,7 @@ type convertTimezoneResponse struct {
 func (v *convertTimezoneResponse) GetConvert() time.Time { return v.Convert }
 
 // The query or mutation executed by convertTimezone.
-const convertTimezoneOperation = `
+const convertTimezone_Operation = `
 query convertTimezone ($dt: DateTime!, $tz: String) {
 	convert(dt: $dt, tz: $tz)
 }
@@ -42,7 +42,7 @@ func convertTimezone(
 ) (*convertTimezoneResponse, error) {
 	req := &graphql.Request{
 		OpName: "convertTimezone",
-		Query:  convertTimezoneOperation,
+		Query:  convertTimezone_Operation,
 		Variables: &__convertTimezoneInput{
 			Dt: dt,
 			Tz: tz,

--- a/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
@@ -21,7 +21,7 @@ func (v *EmptyInterfaceResponse) GetGetComplexJunk() []map[string]*[]*map[string
 }
 
 // The query or mutation executed by EmptyInterface.
-const EmptyInterfaceOperation = `
+const EmptyInterface_Operation = `
 query EmptyInterface {
 	getJunk
 	getComplexJunk
@@ -33,7 +33,7 @@ func EmptyInterface(
 ) (*EmptyInterfaceResponse, error) {
 	req := &graphql.Request{
 		OpName: "EmptyInterface",
-		Query:  EmptyInterfaceOperation,
+		Query:  EmptyInterface_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
@@ -267,7 +267,7 @@ type VideoFieldsParentTopic struct {
 func (v *VideoFieldsParentTopic) GetVideoChildren() []ChildVideoFields { return v.VideoChildren }
 
 // The query or mutation executed by ComplexNamedFragments.
-const ComplexNamedFragmentsOperation = `
+const ComplexNamedFragments_Operation = `
 query ComplexNamedFragments {
 	... QueryFragment
 }
@@ -309,7 +309,7 @@ func ComplexNamedFragments(
 ) (*InnerQueryFragment, error) {
 	req := &graphql.Request{
 		OpName: "ComplexNamedFragments",
-		Query:  ComplexNamedFragmentsOperation,
+		Query:  ComplexNamedFragments_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
@@ -55,7 +55,7 @@ type __InputEnumQueryInput struct {
 func (v *__InputEnumQueryInput) GetRole() Role { return v.Role }
 
 // The query or mutation executed by InputEnumQuery.
-const InputEnumQueryOperation = `
+const InputEnumQuery_Operation = `
 query InputEnumQuery ($role: Role!) {
 	usersWithRole(role: $role) {
 		id
@@ -69,7 +69,7 @@ func InputEnumQuery(
 ) (*InputEnumQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InputEnumQuery",
-		Query:  InputEnumQueryOperation,
+		Query:  InputEnumQuery_Operation,
 		Variables: &__InputEnumQueryInput{
 			Role: role,
 		},

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -178,7 +178,7 @@ type __InputObjectQueryInput struct {
 func (v *__InputObjectQueryInput) GetQuery() UserQueryInput { return v.Query }
 
 // The query or mutation executed by InputObjectQuery.
-const InputObjectQueryOperation = `
+const InputObjectQuery_Operation = `
 query InputObjectQuery ($query: UserQueryInput) {
 	user(query: $query) {
 		id
@@ -192,7 +192,7 @@ func InputObjectQuery(
 ) (*InputObjectQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InputObjectQuery",
-		Query:  InputObjectQueryOperation,
+		Query:  InputObjectQuery_Operation,
 		Variables: &__InputObjectQueryInput{
 			Query: query,
 		},

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -521,7 +521,7 @@ func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetId() testutil.ID { 
 func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetName() string { return v.Name }
 
 // The query or mutation executed by InterfaceListField.
-const InterfaceListFieldOperation = `
+const InterfaceListField_Operation = `
 query InterfaceListField {
 	root {
 		id
@@ -549,7 +549,7 @@ func InterfaceListField(
 ) (*InterfaceListFieldResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceListField",
-		Query:  InterfaceListFieldOperation,
+		Query:  InterfaceListField_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -507,7 +507,7 @@ func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetId() *testutil.ID {
 func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetName() *string { return v.Name }
 
 // The query or mutation executed by InterfaceListOfListOfListsField.
-const InterfaceListOfListOfListsFieldOperation = `
+const InterfaceListOfListOfListsField_Operation = `
 query InterfaceListOfListOfListsField {
 	listOfListsOfListsOfContent {
 		__typename
@@ -527,7 +527,7 @@ func InterfaceListOfListOfListsField(
 ) (*InterfaceListOfListOfListsFieldResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceListOfListOfListsField",
-		Query:  InterfaceListOfListOfListsFieldOperation,
+		Query:  InterfaceListOfListOfListsField_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -505,7 +505,7 @@ func (v *InterfaceNestingRootTopicChildrenVideo) GetParent() InterfaceNestingRoo
 }
 
 // The query or mutation executed by InterfaceNesting.
-const InterfaceNestingOperation = `
+const InterfaceNesting_Operation = `
 query InterfaceNesting {
 	root {
 		id
@@ -529,7 +529,7 @@ func InterfaceNesting(
 ) (*InterfaceNestingResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceNesting",
-		Query:  InterfaceNestingOperation,
+		Query:  InterfaceNesting_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -627,7 +627,7 @@ func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetId() *testutil.ID { retur
 func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetName() *string { return v.Name }
 
 // The query or mutation executed by InterfaceNoFragmentsQuery.
-const InterfaceNoFragmentsQueryOperation = `
+const InterfaceNoFragmentsQuery_Operation = `
 query InterfaceNoFragmentsQuery {
 	root {
 		id
@@ -656,7 +656,7 @@ func InterfaceNoFragmentsQuery(
 ) (*InterfaceNoFragmentsQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "InterfaceNoFragmentsQuery",
-		Query:  InterfaceNoFragmentsQueryOperation,
+		Query:  InterfaceNoFragmentsQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
@@ -42,7 +42,7 @@ type __ListInputQueryInput struct {
 func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
 
 // The query or mutation executed by ListInputQuery.
-const ListInputQueryOperation = `
+const ListInputQuery_Operation = `
 query ListInputQuery ($names: [String]) {
 	user(query: {names:$names}) {
 		id
@@ -56,7 +56,7 @@ func ListInputQuery(
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
-		Query:  ListInputQueryOperation,
+		Query:  ListInputQuery_Operation,
 		Variables: &__ListInputQueryInput{
 			Names: names,
 		},

--- a/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
@@ -17,7 +17,7 @@ func (v *ListOfListsOfListsResponse) GetListOfListsOfLists() [][][]string {
 }
 
 // The query or mutation executed by ListOfListsOfLists.
-const ListOfListsOfListsOperation = `
+const ListOfListsOfLists_Operation = `
 query ListOfListsOfLists {
 	listOfListsOfLists
 }
@@ -28,7 +28,7 @@ func ListOfListsOfLists(
 ) (*ListOfListsOfListsResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListOfListsOfLists",
-		Query:  ListOfListsOfListsOperation,
+		Query:  ListOfListsOfLists_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -326,7 +326,7 @@ func (v *__MultipleDirectivesInput) GetQuery() MyInput { return v.Query }
 func (v *__MultipleDirectivesInput) GetQueries() []*UserQueryInput { return v.Queries }
 
 // The query or mutation executed by MultipleDirectives.
-const MultipleDirectivesOperation = `
+const MultipleDirectives_Operation = `
 query MultipleDirectives ($query: UserQueryInput, $queries: [UserQueryInput]) {
 	user(query: $query) {
 		id
@@ -344,7 +344,7 @@ func MultipleDirectives(
 ) (*MyMultipleDirectivesResponse, error) {
 	req := &graphql.Request{
 		OpName: "MultipleDirectives",
-		Query:  MultipleDirectivesOperation,
+		Query:  MultipleDirectives_Operation,
 		Variables: &__MultipleDirectivesInput{
 			Query:   query,
 			Queries: queries,

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -220,7 +220,7 @@ func (v *__OmitEmptyQueryInput) GetTz() string { return v.Tz }
 func (v *__OmitEmptyQueryInput) GetTzNoOmitEmpty() string { return v.TzNoOmitEmpty }
 
 // The query or mutation executed by OmitEmptyQuery.
-const OmitEmptyQueryOperation = `
+const OmitEmptyQuery_Operation = `
 query OmitEmptyQuery ($query: UserQueryInput, $queries: [UserQueryInput], $dt: DateTime, $tz: String, $tzNoOmitEmpty: String) {
 	user(query: $query) {
 		id
@@ -243,7 +243,7 @@ func OmitEmptyQuery(
 ) (*OmitEmptyQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "OmitEmptyQuery",
-		Query:  OmitEmptyQueryOperation,
+		Query:  OmitEmptyQuery_Operation,
 		Variables: &__OmitEmptyQueryInput{
 			Query:         query,
 			Queries:       queries,

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -231,7 +231,7 @@ func (v *__PointersQueryInput) GetDt() time.Time { return v.Dt }
 func (v *__PointersQueryInput) GetTz() *string { return v.Tz }
 
 // The query or mutation executed by PointersQuery.
-const PointersQueryOperation = `
+const PointersQuery_Operation = `
 query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 	user(query: $query) {
 		id
@@ -255,7 +255,7 @@ func PointersQuery(
 ) (*PointersQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "PointersQuery",
-		Query:  PointersQueryOperation,
+		Query:  PointersQuery_Operation,
 		Variables: &__PointersQueryInput{
 			Query: query,
 			Dt:    dt,

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -228,7 +228,7 @@ func (v *__PointersQueryInput) GetDt() *time.Time { return v.Dt }
 func (v *__PointersQueryInput) GetTz() string { return v.Tz }
 
 // The query or mutation executed by PointersQuery.
-const PointersQueryOperation = `
+const PointersQuery_Operation = `
 query PointersQuery ($query: UserQueryInput, $dt: DateTime, $tz: String) {
 	user(query: $query) {
 		id
@@ -252,7 +252,7 @@ func PointersQuery(
 ) (*PointersQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "PointersQuery",
-		Query:  PointersQueryOperation,
+		Query:  PointersQuery_Operation,
 		Variables: &__PointersQueryInput{
 			Query: query,
 			Dt:    dt,

--- a/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
@@ -72,7 +72,7 @@ type __GetPokemonSiblingsInput struct {
 func (v *__GetPokemonSiblingsInput) GetInput() testutil.Pokemon { return v.Input }
 
 // The query or mutation executed by GetPokemonSiblings.
-const GetPokemonSiblingsOperation = `
+const GetPokemonSiblings_Operation = `
 query GetPokemonSiblings ($input: PokemonInput!) {
 	user(query: {hasPokemon:$input}) {
 		id
@@ -96,7 +96,7 @@ func GetPokemonSiblings(
 ) (*GetPokemonSiblingsResponse, error) {
 	req := &graphql.Request{
 		OpName: "GetPokemonSiblings",
-		Query:  GetPokemonSiblingsOperation,
+		Query:  GetPokemonSiblings_Operation,
 		Variables: &__GetPokemonSiblingsInput{
 			Input: input,
 		},

--- a/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
@@ -41,7 +41,7 @@ func (v *QueryWithAliasUser) GetID() testutil.ID { return v.ID }
 func (v *QueryWithAliasUser) GetOtherID() testutil.ID { return v.OtherID }
 
 // The query or mutation executed by QueryWithAlias.
-const QueryWithAliasOperation = `
+const QueryWithAlias_Operation = `
 query QueryWithAlias {
 	User: user {
 		ID: id
@@ -55,7 +55,7 @@ func QueryWithAlias(
 ) (*QueryWithAliasResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithAlias",
-		Query:  QueryWithAliasOperation,
+		Query:  QueryWithAlias_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
@@ -41,7 +41,7 @@ func (v *QueryWithDoubleAliasUser) GetID() testutil.ID { return v.ID }
 func (v *QueryWithDoubleAliasUser) GetAlsoID() testutil.ID { return v.AlsoID }
 
 // The query or mutation executed by QueryWithDoubleAlias.
-const QueryWithDoubleAliasOperation = `
+const QueryWithDoubleAlias_Operation = `
 query QueryWithDoubleAlias {
 	user {
 		ID: id
@@ -55,7 +55,7 @@ func QueryWithDoubleAlias(
 ) (*QueryWithDoubleAliasResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithDoubleAlias",
-		Query:  QueryWithDoubleAliasOperation,
+		Query:  QueryWithDoubleAlias_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
@@ -63,7 +63,7 @@ const (
 )
 
 // The query or mutation executed by QueryWithEnums.
-const QueryWithEnumsOperation = `
+const QueryWithEnums_Operation = `
 query QueryWithEnums {
 	user {
 		roles
@@ -79,7 +79,7 @@ func QueryWithEnums(
 ) (*QueryWithEnumsResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithEnums",
-		Query:  QueryWithEnumsOperation,
+		Query:  QueryWithEnums_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
@@ -42,7 +42,7 @@ func (v *QueryWithSlicesUser) GetEmailsWithNulls() []string { return v.EmailsWit
 func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []string { return v.EmailsWithNullsOrNull }
 
 // The query or mutation executed by QueryWithSlices.
-const QueryWithSlicesOperation = `
+const QueryWithSlices_Operation = `
 query QueryWithSlices {
 	user {
 		emails
@@ -58,7 +58,7 @@ func QueryWithSlices(
 ) (*QueryWithSlicesResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithSlices",
-		Query:  QueryWithSlicesOperation,
+		Query:  QueryWithSlices_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
@@ -44,7 +44,7 @@ func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() string { retur
 func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() string { return v.Email }
 
 // The query or mutation executed by QueryWithStructs.
-const QueryWithStructsOperation = `
+const QueryWithStructs_Operation = `
 query QueryWithStructs {
 	user {
 		authMethods {
@@ -60,7 +60,7 @@ func QueryWithStructs(
 ) (*QueryWithStructsResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithStructs",
-		Query:  QueryWithStructsOperation,
+		Query:  QueryWithStructs_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
@@ -69,7 +69,7 @@ type __RecursionInput struct {
 func (v *__RecursionInput) GetInput() RecursiveInput { return v.Input }
 
 // The query or mutation executed by Recursion.
-const RecursionOperation = `
+const Recursion_Operation = `
 query Recursion ($input: RecursiveInput!) {
 	recur(input: $input) {
 		rec {
@@ -89,7 +89,7 @@ func Recursion(
 ) (*RecursionResponse, error) {
 	req := &graphql.Request{
 		OpName: "Recursion",
-		Query:  RecursionOperation,
+		Query:  Recursion_Operation,
 		Variables: &__RecursionInput{
 			Input: input,
 		},

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -240,7 +240,7 @@ func (v *SimpleInlineFragmentResponse) __premarshalJSON() (*__premarshalSimpleIn
 }
 
 // The query or mutation executed by SimpleInlineFragment.
-const SimpleInlineFragmentOperation = `
+const SimpleInlineFragment_Operation = `
 query SimpleInlineFragment {
 	randomItem {
 		__typename
@@ -261,7 +261,7 @@ func SimpleInlineFragment(
 ) (*SimpleInlineFragmentResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleInlineFragment",
-		Query:  SimpleInlineFragmentOperation,
+		Query:  SimpleInlineFragment_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
@@ -42,7 +42,7 @@ type __SimpleInputQueryInput struct {
 func (v *__SimpleInputQueryInput) GetName() string { return v.Name }
 
 // The query or mutation executed by SimpleInputQuery.
-const SimpleInputQueryOperation = `
+const SimpleInputQuery_Operation = `
 query SimpleInputQuery ($name: String!) {
 	user(query: {name:$name}) {
 		id
@@ -56,7 +56,7 @@ func SimpleInputQuery(
 ) (*SimpleInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleInputQuery",
-		Query:  SimpleInputQueryOperation,
+		Query:  SimpleInputQuery_Operation,
 		Variables: &__SimpleInputQueryInput{
 			Name: name,
 		},

--- a/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
@@ -42,7 +42,7 @@ type __SimpleMutationInput struct {
 func (v *__SimpleMutationInput) GetName() string { return v.Name }
 
 // The query or mutation executed by SimpleMutation.
-const SimpleMutationOperation = `
+const SimpleMutation_Operation = `
 mutation SimpleMutation ($name: String!) {
 	createUser(name: $name) {
 		id
@@ -61,7 +61,7 @@ func SimpleMutation(
 ) (*SimpleMutationResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleMutation",
-		Query:  SimpleMutationOperation,
+		Query:  SimpleMutation_Operation,
 		Variables: &__SimpleMutationInput{
 			Name: name,
 		},

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -547,7 +547,7 @@ type VideoFieldsThumbnail struct {
 func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
 
 // The query or mutation executed by SimpleNamedFragment.
-const SimpleNamedFragmentOperation = `
+const SimpleNamedFragment_Operation = `
 query SimpleNamedFragment {
 	randomItem {
 		__typename
@@ -576,7 +576,7 @@ func SimpleNamedFragment(
 ) (*SimpleNamedFragmentResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleNamedFragment",
-		Query:  SimpleNamedFragmentOperation,
+		Query:  SimpleNamedFragment_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
@@ -34,7 +34,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -47,7 +47,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -425,7 +425,7 @@ type VideoFields struct {
 func (v *VideoFields) GetDuration() int { return v.Duration }
 
 // The query or mutation executed by StructOption.
-const StructOptionOperation = `
+const StructOption_Operation = `
 query StructOption {
 	root {
 		id
@@ -460,7 +460,7 @@ func StructOption(
 ) (*StructOptionResponse, error) {
 	req := &graphql.Request{
 		OpName: "StructOption",
-		Query:  StructOptionOperation,
+		Query:  StructOption_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
@@ -38,7 +38,7 @@ func (v *TypeNameQueryUser) GetTypename() string { return v.Typename }
 func (v *TypeNameQueryUser) GetId() testutil.ID { return v.Id }
 
 // The query or mutation executed by TypeNameQuery.
-const TypeNameQueryOperation = `
+const TypeNameQuery_Operation = `
 query TypeNameQuery {
 	user {
 		__typename
@@ -52,7 +52,7 @@ func TypeNameQuery(
 ) (*TypeNameQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "TypeNameQuery",
-		Query:  TypeNameQueryOperation,
+		Query:  TypeNameQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -265,7 +265,7 @@ func (v *User) GetId() testutil.ID { return v.Id }
 func (v *User) GetName() string { return v.Name }
 
 // The query or mutation executed by TypeNames.
-const TypeNamesOperation = `
+const TypeNames_Operation = `
 query TypeNames {
 	user {
 		id
@@ -288,7 +288,7 @@ func TypeNames(
 ) (*Resp, error) {
 	req := &graphql.Request{
 		OpName: "TypeNames",
-		Query:  TypeNamesOperation,
+		Query:  TypeNames_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -175,7 +175,7 @@ func (v *UnionNoFragmentsQueryResponse) __premarshalJSON() (*__premarshalUnionNo
 }
 
 // The query or mutation executed by UnionNoFragmentsQuery.
-const UnionNoFragmentsQueryOperation = `
+const UnionNoFragmentsQuery_Operation = `
 query UnionNoFragmentsQuery {
 	randomLeaf {
 		__typename
@@ -188,7 +188,7 @@ func UnionNoFragmentsQuery(
 ) (*UnionNoFragmentsQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "UnionNoFragmentsQuery",
-		Query:  UnionNoFragmentsQueryOperation,
+		Query:  UnionNoFragmentsQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
@@ -63,7 +63,7 @@ func (v *UsesEnumTwiceQueryResponse) GetMe() UsesEnumTwiceQueryMeUser { return v
 func (v *UsesEnumTwiceQueryResponse) GetOtherUser() UsesEnumTwiceQueryOtherUser { return v.OtherUser }
 
 // The query or mutation executed by UsesEnumTwiceQuery.
-const UsesEnumTwiceQueryOperation = `
+const UsesEnumTwiceQuery_Operation = `
 query UsesEnumTwiceQuery {
 	Me: user {
 		roles
@@ -79,7 +79,7 @@ func UsesEnumTwiceQuery(
 ) (*UsesEnumTwiceQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "UsesEnumTwiceQuery",
-		Query:  UsesEnumTwiceQueryOperation,
+		Query:  UsesEnumTwiceQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -178,7 +178,7 @@ type unexportedUser struct {
 func (v *unexportedUser) GetId() testutil.ID { return v.Id }
 
 // The query or mutation executed by unexported.
-const unexportedOperation = `
+const unexported_Operation = `
 query unexported ($query: UserQueryInput) {
 	user(query: $query) {
 		id
@@ -192,7 +192,7 @@ func unexported(
 ) (*unexportedResponse, error) {
 	req := &graphql.Request{
 		OpName: "unexported",
-		Query:  unexportedOperation,
+		Query:  unexported_Operation,
 		Variables: &__unexportedInput{
 			Query: query,
 		},

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
@@ -36,7 +36,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 	var client graphql.Client

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
@@ -39,7 +39,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -52,7 +52,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 	var client graphql.Client

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
@@ -34,7 +34,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -45,7 +45,7 @@ query SimpleQuery {
 func SimpleQuery() (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 	var client graphql.Client

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
@@ -39,7 +39,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -53,7 +53,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContextWithAlias-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContextWithAlias-testdata-queries-generated.go
@@ -39,7 +39,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -53,7 +53,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
@@ -35,7 +35,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
@@ -35,7 +35,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
@@ -35,7 +35,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
@@ -33,7 +33,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -46,7 +46,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
@@ -78,7 +78,7 @@ type __ListInputQueryInput struct {
 func (v *__ListInputQueryInput) GetNames() []*string { return v.Names }
 
 // The query or mutation executed by ListInputQuery.
-const ListInputQueryOperation = `
+const ListInputQuery_Operation = `
 query ListInputQuery ($names: [String]) {
 	user(query: {names:$names}) {
 		id
@@ -93,7 +93,7 @@ func ListInputQuery(
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
-		Query:  ListInputQueryOperation,
+		Query:  ListInputQuery_Operation,
 		Variables: &__ListInputQueryInput{
 			Names: names,
 		},
@@ -113,7 +113,7 @@ func ListInputQuery(
 }
 
 // The query or mutation executed by QueryWithSlices.
-const QueryWithSlicesOperation = `
+const QueryWithSlices_Operation = `
 query QueryWithSlices {
 	user {
 		emails
@@ -130,7 +130,7 @@ func QueryWithSlices(
 ) (*QueryWithSlicesResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithSlices",
-		Query:  QueryWithSlicesOperation,
+		Query:  QueryWithSlices_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
@@ -78,7 +78,7 @@ type __ListInputQueryInput struct {
 func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
 
 // The query or mutation executed by ListInputQuery.
-const ListInputQueryOperation = `
+const ListInputQuery_Operation = `
 query ListInputQuery ($names: [String]) {
 	user(query: {names:$names}) {
 		id
@@ -93,7 +93,7 @@ func ListInputQuery(
 ) (*ListInputQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "ListInputQuery",
-		Query:  ListInputQueryOperation,
+		Query:  ListInputQuery_Operation,
 		Variables: &__ListInputQueryInput{
 			Names: names,
 		},
@@ -113,7 +113,7 @@ func ListInputQuery(
 }
 
 // The query or mutation executed by QueryWithSlices.
-const QueryWithSlicesOperation = `
+const QueryWithSlices_Operation = `
 query QueryWithSlices {
 	user {
 		emails
@@ -130,7 +130,7 @@ func QueryWithSlices(
 ) (*QueryWithSlicesResponse, error) {
 	req := &graphql.Request{
 		OpName: "QueryWithSlices",
-		Query:  QueryWithSlicesOperation,
+		Query:  QueryWithSlices_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageBindings-testdata-queries
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageBindings-testdata-queries
@@ -36,7 +36,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -50,7 +50,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
@@ -35,7 +35,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated-structrefs.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated-structrefs.go
@@ -35,7 +35,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
@@ -35,7 +35,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
@@ -35,7 +35,7 @@ type SimpleQueryUser struct {
 func (v *SimpleQueryUser) GetId() string { return v.Id }
 
 // The query or mutation executed by SimpleQuery.
-const SimpleQueryOperation = `
+const SimpleQuery_Operation = `
 query SimpleQuery {
 	user {
 		id
@@ -49,7 +49,7 @@ func SimpleQuery(
 ) (*SimpleQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "SimpleQuery",
-		Query:  SimpleQueryOperation,
+		Query:  SimpleQuery_Operation,
 	}
 	var err error
 

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -3079,7 +3079,7 @@ type simpleQueryResponse struct {
 func (v *simpleQueryResponse) GetMe() simpleQueryMeUser { return v.Me }
 
 // The query or mutation executed by createUser.
-const createUserOperation = `
+const createUser_Operation = `
 mutation createUser ($user: NewUser!) {
 	createUser(input: $user) {
 		id
@@ -3095,7 +3095,7 @@ func createUser(
 ) (*createUserResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "createUser",
-		Query:  createUserOperation,
+		Query:  createUser_Operation,
 		Variables: &__createUserInput{
 			User: user,
 		},
@@ -3115,7 +3115,7 @@ func createUser(
 }
 
 // The query or mutation executed by failingQuery.
-const failingQueryOperation = `
+const failingQuery_Operation = `
 query failingQuery {
 	fail
 	me {
@@ -3130,7 +3130,7 @@ func failingQuery(
 ) (*failingQueryResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "failingQuery",
-		Query:  failingQueryOperation,
+		Query:  failingQuery_Operation,
 	}
 	var err error
 
@@ -3147,7 +3147,7 @@ func failingQuery(
 }
 
 // The query or mutation executed by queryWithCustomMarshal.
-const queryWithCustomMarshalOperation = `
+const queryWithCustomMarshal_Operation = `
 query queryWithCustomMarshal ($date: Date!) {
 	usersBornOn(date: $date) {
 		id
@@ -3164,7 +3164,7 @@ func queryWithCustomMarshal(
 ) (*queryWithCustomMarshalResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithCustomMarshal",
-		Query:  queryWithCustomMarshalOperation,
+		Query:  queryWithCustomMarshal_Operation,
 		Variables: &__queryWithCustomMarshalInput{
 			Date: date,
 		},
@@ -3184,7 +3184,7 @@ func queryWithCustomMarshal(
 }
 
 // The query or mutation executed by queryWithCustomMarshalOptional.
-const queryWithCustomMarshalOptionalOperation = `
+const queryWithCustomMarshalOptional_Operation = `
 query queryWithCustomMarshalOptional ($date: Date, $id: ID) {
 	userSearch(birthdate: $date, id: $id) {
 		id
@@ -3202,7 +3202,7 @@ func queryWithCustomMarshalOptional(
 ) (*queryWithCustomMarshalOptionalResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithCustomMarshalOptional",
-		Query:  queryWithCustomMarshalOptionalOperation,
+		Query:  queryWithCustomMarshalOptional_Operation,
 		Variables: &__queryWithCustomMarshalOptionalInput{
 			Date: date,
 			Id:   id,
@@ -3223,7 +3223,7 @@ func queryWithCustomMarshalOptional(
 }
 
 // The query or mutation executed by queryWithCustomMarshalSlice.
-const queryWithCustomMarshalSliceOperation = `
+const queryWithCustomMarshalSlice_Operation = `
 query queryWithCustomMarshalSlice ($dates: [Date!]!) {
 	usersBornOnDates(dates: $dates) {
 		id
@@ -3240,7 +3240,7 @@ func queryWithCustomMarshalSlice(
 ) (*queryWithCustomMarshalSliceResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithCustomMarshalSlice",
-		Query:  queryWithCustomMarshalSliceOperation,
+		Query:  queryWithCustomMarshalSlice_Operation,
 		Variables: &__queryWithCustomMarshalSliceInput{
 			Dates: dates,
 		},
@@ -3260,7 +3260,7 @@ func queryWithCustomMarshalSlice(
 }
 
 // The query or mutation executed by queryWithFlatten.
-const queryWithFlattenOperation = `
+const queryWithFlatten_Operation = `
 query queryWithFlatten ($ids: [ID!]!) {
 	... QueryFragment
 }
@@ -3311,7 +3311,7 @@ func queryWithFlatten(
 ) (*QueryFragment, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithFlatten",
-		Query:  queryWithFlattenOperation,
+		Query:  queryWithFlatten_Operation,
 		Variables: &__queryWithFlattenInput{
 			Ids: ids,
 		},
@@ -3331,7 +3331,7 @@ func queryWithFlatten(
 }
 
 // The query or mutation executed by queryWithFragments.
-const queryWithFragmentsOperation = `
+const queryWithFragments_Operation = `
 query queryWithFragments ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3376,7 +3376,7 @@ func queryWithFragments(
 ) (*queryWithFragmentsResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithFragments",
-		Query:  queryWithFragmentsOperation,
+		Query:  queryWithFragments_Operation,
 		Variables: &__queryWithFragmentsInput{
 			Ids: ids,
 		},
@@ -3396,7 +3396,7 @@ func queryWithFragments(
 }
 
 // The query or mutation executed by queryWithInterfaceListField.
-const queryWithInterfaceListFieldOperation = `
+const queryWithInterfaceListField_Operation = `
 query queryWithInterfaceListField ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3413,7 +3413,7 @@ func queryWithInterfaceListField(
 ) (*queryWithInterfaceListFieldResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithInterfaceListField",
-		Query:  queryWithInterfaceListFieldOperation,
+		Query:  queryWithInterfaceListField_Operation,
 		Variables: &__queryWithInterfaceListFieldInput{
 			Ids: ids,
 		},
@@ -3433,7 +3433,7 @@ func queryWithInterfaceListField(
 }
 
 // The query or mutation executed by queryWithInterfaceListPointerField.
-const queryWithInterfaceListPointerFieldOperation = `
+const queryWithInterfaceListPointerField_Operation = `
 query queryWithInterfaceListPointerField ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3450,7 +3450,7 @@ func queryWithInterfaceListPointerField(
 ) (*queryWithInterfaceListPointerFieldResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithInterfaceListPointerField",
-		Query:  queryWithInterfaceListPointerFieldOperation,
+		Query:  queryWithInterfaceListPointerField_Operation,
 		Variables: &__queryWithInterfaceListPointerFieldInput{
 			Ids: ids,
 		},
@@ -3470,7 +3470,7 @@ func queryWithInterfaceListPointerField(
 }
 
 // The query or mutation executed by queryWithInterfaceNoFragments.
-const queryWithInterfaceNoFragmentsOperation = `
+const queryWithInterfaceNoFragments_Operation = `
 query queryWithInterfaceNoFragments ($id: ID!) {
 	being(id: $id) {
 		__typename
@@ -3491,7 +3491,7 @@ func queryWithInterfaceNoFragments(
 ) (*queryWithInterfaceNoFragmentsResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithInterfaceNoFragments",
-		Query:  queryWithInterfaceNoFragmentsOperation,
+		Query:  queryWithInterfaceNoFragments_Operation,
 		Variables: &__queryWithInterfaceNoFragmentsInput{
 			Id: id,
 		},
@@ -3511,7 +3511,7 @@ func queryWithInterfaceNoFragments(
 }
 
 // The query or mutation executed by queryWithNamedFragments.
-const queryWithNamedFragmentsOperation = `
+const queryWithNamedFragments_Operation = `
 query queryWithNamedFragments ($ids: [ID!]!) {
 	beings(ids: $ids) {
 		__typename
@@ -3556,7 +3556,7 @@ func queryWithNamedFragments(
 ) (*queryWithNamedFragmentsResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithNamedFragments",
-		Query:  queryWithNamedFragmentsOperation,
+		Query:  queryWithNamedFragments_Operation,
 		Variables: &__queryWithNamedFragmentsInput{
 			Ids: ids,
 		},
@@ -3576,7 +3576,7 @@ func queryWithNamedFragments(
 }
 
 // The query or mutation executed by queryWithOmitempty.
-const queryWithOmitemptyOperation = `
+const queryWithOmitempty_Operation = `
 query queryWithOmitempty ($id: ID) {
 	user(id: $id) {
 		id
@@ -3593,7 +3593,7 @@ func queryWithOmitempty(
 ) (*queryWithOmitemptyResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithOmitempty",
-		Query:  queryWithOmitemptyOperation,
+		Query:  queryWithOmitempty_Operation,
 		Variables: &__queryWithOmitemptyInput{
 			Id: id,
 		},
@@ -3613,7 +3613,7 @@ func queryWithOmitempty(
 }
 
 // The query or mutation executed by queryWithVariables.
-const queryWithVariablesOperation = `
+const queryWithVariables_Operation = `
 query queryWithVariables ($id: ID!) {
 	user(id: $id) {
 		id
@@ -3630,7 +3630,7 @@ func queryWithVariables(
 ) (*queryWithVariablesResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "queryWithVariables",
-		Query:  queryWithVariablesOperation,
+		Query:  queryWithVariables_Operation,
 		Variables: &__queryWithVariablesInput{
 			Id: id,
 		},
@@ -3650,7 +3650,7 @@ func queryWithVariables(
 }
 
 // The query or mutation executed by simpleQuery.
-const simpleQueryOperation = `
+const simpleQuery_Operation = `
 query simpleQuery {
 	me {
 		id
@@ -3666,7 +3666,7 @@ func simpleQuery(
 ) (*simpleQueryResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "simpleQuery",
-		Query:  simpleQueryOperation,
+		Query:  simpleQuery_Operation,
 	}
 	var err error
 
@@ -3683,7 +3683,7 @@ func simpleQuery(
 }
 
 // The query or mutation executed by simpleQueryExt.
-const simpleQueryExtOperation = `
+const simpleQueryExt_Operation = `
 query simpleQueryExt {
 	me {
 		id
@@ -3699,7 +3699,7 @@ func simpleQueryExt(
 ) (*simpleQueryExtResponse, map[string]interface{}, error) {
 	req := &graphql.Request{
 		OpName: "simpleQueryExt",
-		Query:  simpleQueryExtOperation,
+		Query:  simpleQueryExt_Operation,
 	}
 	var err error
 


### PR DESCRIPTION
We got reports of conflicts with the old constant-name and symbols that people were defining in their app.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
