### PR TITLE
Automatically update generated files if UPDATE_SNAPSHOTS=1

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,9 +40,7 @@ Notes for contributors:
 - If `GITHUB_TOKEN` is available in the environment, it also checks that the example returns the expected output when run against the real API.  This is configured automatically in GitHub Actions, but you can also use a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with no scopes.  There's no need for this to cover anything in particular; it's just to make sure the example in fact works.
 - Tests should use `testify/assert` and `testify/require` where convenient (when making many simple assertions).
 
-If you update any code-generation logic or templates, even if no new tests are needed you'll likely need to:
-- Run `UPDATE_SNAPSHOTS=1 go test ./...` to update the [cupaloy](https://github.com/bradleyjkemp/cupaloy) snapshots.
-- Run `go generate ./...` to update the genqlient-generated files used in integration tests and documentation.
+If you update any code-generation logic or templates, even if no new tests are needed you'll likely need to run `UPDATE_SNAPSHOTS=1 go test ./...` to update the [cupaloy](https://github.com/bradleyjkemp/cupaloy) snapshots and the genqlient-generated files used in integration tests and documentation.
 
 ## Finding your way around
 

--- a/internal/integration/util.go
+++ b/internal/integration/util.go
@@ -51,6 +51,14 @@ func RunGenerateTest(t *testing.T, relConfigFilename string) {
 			if testing.Verbose() {
 				t.Errorf("got:\n%s\nwant:\n%s\n", content, expectedContent)
 			}
+			if os.Getenv("UPDATE_SNAPSHOTS") == "1" {
+				err = os.WriteFile(filename, content, 0o644)
+				if err != nil {
+					t.Errorf("unable to update generated file %s: %v", filename, err)
+				} else {
+					t.Errorf("updated generated file for %s", filename)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
If you do `UPDATE_SNAPSHOTS=1 go test ./...` that will:
1. run the snapshot tests, updating any changed snapshots
2. run the integration tests and (if you have tokens) example tests
3. check that the code for the integration tests and example tests is up-to-date

Step 3 is not strictly a snapshot test; the generated code is actually checked in and used. But, I mean, it's basically the same! So now, we also update it if you asked to update snapshots, which is hopefully a little more convenient.

Fixes #212.

Test plan:
Make a trivial change to `example/generated.go`; `go test ./...` should now fail. `UPDATE_SNAPSHOTS=1 go test ./...` should also fail, but say it updated the snapshot, and the change should be reverted. Run `go test ./...` again; it should pass again.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
