### PR TITLE
Update template Un/MarshalJSON to not use pointer receiver

### DIFF
--- a/generate/marshal.go.tmpl
+++ b/generate/marshal.go.tmpl
@@ -38,7 +38,7 @@ type __premarshal{{.GoName}} struct{
     {{end}}
 }
 
-func (v *{{.GoName}}) MarshalJSON() ([]byte, error) {
+func (v {{.GoName}}) MarshalJSON() ([]byte, error) {
     premarshaled, err := v.__premarshalJSON()
     if err != nil {
         return nil, err

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -327,7 +327,7 @@ type __premarshalComplexInlineFragmentsNestedStuffTopic struct {
 	Children []json.RawMessage `json:"children"`
 }
 
-func (v *ComplexInlineFragmentsNestedStuffTopic) MarshalJSON() ([]byte, error) {
+func (v ComplexInlineFragmentsNestedStuffTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -438,7 +438,7 @@ type __premarshalComplexInlineFragmentsNestedStuffTopicChildrenArticleParentCont
 	Children []json.RawMessage `json:"children"`
 }
 
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) MarshalJSON() ([]byte, error) {
+func (v ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1260,7 +1260,7 @@ type __premarshalComplexInlineFragmentsResponse struct {
 	NestedStuff json.RawMessage `json:"nestedStuff"`
 }
 
-func (v *ComplexInlineFragmentsResponse) MarshalJSON() ([]byte, error) {
+func (v ComplexInlineFragmentsResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -63,7 +63,7 @@ type __premarshalComplexNamedFragmentsResponse struct {
 	OtherLeaf json.RawMessage `json:"otherLeaf"`
 }
 
-func (v *ComplexNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
+func (v ComplexNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -339,7 +339,7 @@ type __premarshalInnerQueryFragment struct {
 	OtherLeaf json.RawMessage `json:"otherLeaf"`
 }
 
-func (v *InnerQueryFragment) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragment) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -437,7 +437,7 @@ type __premarshalInnerQueryFragmentOtherLeafArticle struct {
 	Url string `json:"url"`
 }
 
-func (v *InnerQueryFragmentOtherLeafArticle) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragmentOtherLeafArticle) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -604,7 +604,7 @@ type __premarshalInnerQueryFragmentOtherLeafVideo struct {
 	Url string `json:"url"`
 }
 
-func (v *InnerQueryFragmentOtherLeafVideo) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragmentOtherLeafVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -679,7 +679,7 @@ type __premarshalInnerQueryFragmentRandomItemArticle struct {
 	Url string `json:"url"`
 }
 
-func (v *InnerQueryFragmentRandomItemArticle) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragmentRandomItemArticle) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -863,7 +863,7 @@ type __premarshalInnerQueryFragmentRandomItemTopic struct {
 	Url string `json:"url"`
 }
 
-func (v *InnerQueryFragmentRandomItemTopic) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragmentRandomItemTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -955,7 +955,7 @@ type __premarshalInnerQueryFragmentRandomItemVideo struct {
 	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
 }
 
-func (v *InnerQueryFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1023,7 +1023,7 @@ type __premarshalInnerQueryFragmentRandomLeafArticle struct {
 	Url string `json:"url"`
 }
 
-func (v *InnerQueryFragmentRandomLeafArticle) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragmentRandomLeafArticle) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1208,7 +1208,7 @@ type __premarshalInnerQueryFragmentRandomLeafVideo struct {
 	Parent *MoreVideoFieldsParentTopic `json:"parent"`
 }
 
-func (v *InnerQueryFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1314,7 +1314,7 @@ type __premarshalMoreVideoFieldsParentTopic struct {
 	Children []json.RawMessage `json:"children"`
 }
 
-func (v *MoreVideoFieldsParentTopic) MarshalJSON() ([]byte, error) {
+func (v MoreVideoFieldsParentTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1523,7 +1523,7 @@ type __premarshalMoreVideoFieldsParentTopicChildrenVideo struct {
 	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
 }
 
-func (v *MoreVideoFieldsParentTopicChildrenVideo) MarshalJSON() ([]byte, error) {
+func (v MoreVideoFieldsParentTopicChildrenVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1599,7 +1599,7 @@ type __premarshalQueryFragment struct {
 	OtherLeaf json.RawMessage `json:"otherLeaf"`
 }
 
-func (v *QueryFragment) MarshalJSON() ([]byte, error) {
+func (v QueryFragment) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1712,7 +1712,7 @@ type __premarshalVideoFields struct {
 	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
 }
 
-func (v *VideoFields) MarshalJSON() ([]byte, error) {
+func (v VideoFields) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
@@ -185,7 +185,7 @@ type __premarshalContentFieldsArticle struct {
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *ContentFieldsArticle) MarshalJSON() ([]byte, error) {
+func (v ContentFieldsArticle) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -565,7 +565,7 @@ type __premarshalContentFieldsTopic struct {
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *ContentFieldsTopic) MarshalJSON() ([]byte, error) {
+func (v ContentFieldsTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -683,7 +683,7 @@ type __premarshalContentFieldsVideo struct {
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *ContentFieldsVideo) MarshalJSON() ([]byte, error) {
+func (v ContentFieldsVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -815,7 +815,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemArticle struct {
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemArticle) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemArticle) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1026,7 +1026,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemContentNextArticle st
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemContentNextArticle) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1228,7 +1228,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemContentNextTopic stru
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemContentNextTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1327,7 +1327,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemContentNextVideo stru
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemContentNextVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1426,7 +1426,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemContentRelatedArticle
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemContentRelatedArticle) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1628,7 +1628,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemContentRelatedTopic s
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemContentRelatedTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1727,7 +1727,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemContentRelatedVideo s
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemContentRelatedVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1860,7 +1860,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemTopic struct {
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemTopic) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1994,7 +1994,7 @@ type __premarshalCovariantInterfaceImplementationRandomItemVideo struct {
 	Related []json.RawMessage `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRandomItemVideo) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRandomItemVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2095,7 +2095,7 @@ type __premarshalCovariantInterfaceImplementationResponse struct {
 	Root CovariantInterfaceImplementationRootTopic `json:"root"`
 }
 
-func (v *CovariantInterfaceImplementationResponse) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2176,7 +2176,7 @@ type __premarshalCovariantInterfaceImplementationRootTopic struct {
 	Related []CovariantInterfaceImplementationRootTopicRelatedTopic `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRootTopic) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRootTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2238,7 +2238,7 @@ type __premarshalCovariantInterfaceImplementationRootTopicNextTopic struct {
 	Related []TopicFieldsRelatedTopic `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRootTopicNextTopic) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRootTopicNextTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2300,7 +2300,7 @@ type __premarshalCovariantInterfaceImplementationRootTopicRelatedTopic struct {
 	Related []TopicFieldsRelatedTopic `json:"related"`
 }
 
-func (v *CovariantInterfaceImplementationRootTopicRelatedTopic) MarshalJSON() ([]byte, error) {
+func (v CovariantInterfaceImplementationRootTopicRelatedTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -76,7 +76,7 @@ type __premarshalCustomMarshalUsersBornOnUser struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *CustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
+func (v CustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ type __premarshal__CustomMarshalInput struct {
 	Date json.RawMessage `json:"date"`
 }
 
-func (v *__CustomMarshalInput) MarshalJSON() ([]byte, error) {
+func (v __CustomMarshalInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -127,7 +127,7 @@ type __premarshal__CustomMarshalSliceInput struct {
 	Datesssp [][][]json.RawMessage `json:"datesssp"`
 }
 
-func (v *__CustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
+func (v __CustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
@@ -217,7 +217,7 @@ type __premarshalInnerQueryFragment struct {
 	OtherVideo ContentFieldsVideo `json:"otherVideo"`
 }
 
-func (v *InnerQueryFragment) MarshalJSON() ([]byte, error) {
+func (v InnerQueryFragment) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -137,7 +137,7 @@ type __premarshalUserQueryInput struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v UserQueryInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -90,7 +90,7 @@ type __premarshalInterfaceListFieldRootTopic struct {
 	Children []json.RawMessage `json:"children"`
 }
 
-func (v *InterfaceListFieldRootTopic) MarshalJSON() ([]byte, error) {
+func (v InterfaceListFieldRootTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -338,7 +338,7 @@ type __premarshalInterfaceListFieldWithPointerTopic struct {
 	Children []json.RawMessage `json:"children"`
 }
 
-func (v *InterfaceListFieldWithPointerTopic) MarshalJSON() ([]byte, error) {
+func (v InterfaceListFieldWithPointerTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -282,7 +282,7 @@ type __premarshalInterfaceListOfListOfListsFieldResponse struct {
 	WithPointer [][][]json.RawMessage `json:"withPointer"`
 }
 
-func (v *InterfaceListOfListOfListsFieldResponse) MarshalJSON() ([]byte, error) {
+func (v InterfaceListOfListOfListsFieldResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -78,7 +78,7 @@ type __premarshalInterfaceNestingRootTopic struct {
 	Children []json.RawMessage `json:"children"`
 }
 
-func (v *InterfaceNestingRootTopic) MarshalJSON() ([]byte, error) {
+func (v InterfaceNestingRootTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -287,7 +287,7 @@ type __premarshalInterfaceNestingRootTopicChildrenContentParentTopic struct {
 	Children []json.RawMessage `json:"children"`
 }
 
-func (v *InterfaceNestingRootTopicChildrenContentParentTopic) MarshalJSON() ([]byte, error) {
+func (v InterfaceNestingRootTopicChildrenContentParentTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -412,7 +412,7 @@ type __premarshalInterfaceNoFragmentsQueryResponse struct {
 	WithPointer json.RawMessage `json:"withPointer"`
 }
 
-func (v *InterfaceNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
+func (v InterfaceNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -98,7 +98,7 @@ type __premarshalMyInput struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *MyInput) MarshalJSON() ([]byte, error) {
+func (v MyInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ type __premarshalUserQueryInput struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v UserQueryInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -163,7 +163,7 @@ type __premarshalUserQueryInput struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v UserQueryInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -180,7 +180,7 @@ type __premarshalUserQueryInput struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v UserQueryInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -179,7 +179,7 @@ type __premarshalUserQueryInput struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v UserQueryInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -213,7 +213,7 @@ type __premarshalSimpleInlineFragmentResponse struct {
 	RandomItem json.RawMessage `json:"randomItem"`
 }
 
-func (v *SimpleInlineFragmentResponse) MarshalJSON() ([]byte, error) {
+func (v SimpleInlineFragmentResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -213,7 +213,7 @@ type __premarshalSimpleNamedFragmentRandomItemVideo struct {
 	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
 }
 
-func (v *SimpleNamedFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
+func (v SimpleNamedFragmentRandomItemVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -386,7 +386,7 @@ type __premarshalSimpleNamedFragmentRandomLeafVideo struct {
 	Thumbnail VideoFieldsThumbnail `json:"thumbnail"`
 }
 
-func (v *SimpleNamedFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
+func (v SimpleNamedFragmentRandomLeafVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -475,7 +475,7 @@ type __premarshalSimpleNamedFragmentResponse struct {
 	RandomLeaf json.RawMessage `json:"randomLeaf"`
 }
 
-func (v *SimpleNamedFragmentResponse) MarshalJSON() ([]byte, error) {
+func (v SimpleNamedFragmentResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -145,7 +145,7 @@ type __premarshalStructOptionRootTopicChildrenContentParentTopic struct {
 	InterfaceChildren []json.RawMessage `json:"interfaceChildren"`
 }
 
-func (v *StructOptionRootTopicChildrenContentParentTopic) MarshalJSON() ([]byte, error) {
+func (v StructOptionRootTopicChildrenContentParentTopic) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -388,7 +388,7 @@ type __premarshalStructOptionRootTopicChildrenContentParentTopicInterfaceChildre
 	Duration int `json:"duration"`
 }
 
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) MarshalJSON() ([]byte, error) {
+func (v StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -218,7 +218,7 @@ type __premarshalResp struct {
 	Users []User `json:"users"`
 }
 
-func (v *Resp) MarshalJSON() ([]byte, error) {
+func (v Resp) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -148,7 +148,7 @@ type __premarshalUnionNoFragmentsQueryResponse struct {
 	RandomLeaf json.RawMessage `json:"randomLeaf"`
 }
 
-func (v *UnionNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
+func (v UnionNoFragmentsQueryResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -111,7 +111,7 @@ type __premarshalUserQueryInput struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *UserQueryInput) MarshalJSON() ([]byte, error) {
+func (v UserQueryInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -69,7 +69,7 @@ type __premarshalAnimalFields struct {
 	Owner json.RawMessage `json:"owner"`
 }
 
-func (v *AnimalFields) MarshalJSON() ([]byte, error) {
+func (v AnimalFields) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -254,7 +254,7 @@ type __premarshalAnimalFieldsOwnerUser struct {
 	Hair MoreUserFieldsHair `json:"hair"`
 }
 
-func (v *AnimalFieldsOwnerUser) MarshalJSON() ([]byte, error) {
+func (v AnimalFieldsOwnerUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -561,7 +561,7 @@ type __premarshalLuckyFieldsUser struct {
 	Hair MoreUserFieldsHair `json:"hair"`
 }
 
-func (v *LuckyFieldsUser) MarshalJSON() ([]byte, error) {
+func (v LuckyFieldsUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -656,7 +656,7 @@ type __premarshalQueryFragment struct {
 	Beings []json.RawMessage `json:"beings"`
 }
 
-func (v *QueryFragment) MarshalJSON() ([]byte, error) {
+func (v QueryFragment) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -745,7 +745,7 @@ type __premarshalQueryFragmentBeingsAnimal struct {
 	Owner json.RawMessage `json:"owner"`
 }
 
-func (v *QueryFragmentBeingsAnimal) MarshalJSON() ([]byte, error) {
+func (v QueryFragmentBeingsAnimal) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -903,7 +903,7 @@ type __premarshalQueryFragmentBeingsUser struct {
 	LuckyNumber int `json:"luckyNumber"`
 }
 
-func (v *QueryFragmentBeingsUser) MarshalJSON() ([]byte, error) {
+func (v QueryFragmentBeingsUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -981,7 +981,7 @@ type __premarshalUserFields struct {
 	Hair MoreUserFieldsHair `json:"hair"`
 }
 
-func (v *UserFields) MarshalJSON() ([]byte, error) {
+func (v UserFields) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1051,7 +1051,7 @@ type __premarshal__queryWithCustomMarshalInput struct {
 	Date json.RawMessage `json:"date"`
 }
 
-func (v *__queryWithCustomMarshalInput) MarshalJSON() ([]byte, error) {
+func (v __queryWithCustomMarshalInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1129,7 +1129,7 @@ type __premarshal__queryWithCustomMarshalOptionalInput struct {
 	Id *string `json:"id"`
 }
 
-func (v *__queryWithCustomMarshalOptionalInput) MarshalJSON() ([]byte, error) {
+func (v __queryWithCustomMarshalOptionalInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1209,7 +1209,7 @@ type __premarshal__queryWithCustomMarshalSliceInput struct {
 	Dates []json.RawMessage `json:"dates"`
 }
 
-func (v *__queryWithCustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
+func (v __queryWithCustomMarshalSliceInput) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1412,7 +1412,7 @@ type __premarshalqueryWithCustomMarshalOptionalUserSearchUser struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *queryWithCustomMarshalOptionalUserSearchUser) MarshalJSON() ([]byte, error) {
+func (v queryWithCustomMarshalOptionalUserSearchUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1519,7 +1519,7 @@ type __premarshalqueryWithCustomMarshalSliceUsersBornOnDatesUser struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) MarshalJSON() ([]byte, error) {
+func (v queryWithCustomMarshalSliceUsersBornOnDatesUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1604,7 +1604,7 @@ type __premarshalqueryWithCustomMarshalUsersBornOnUser struct {
 	Birthdate json.RawMessage `json:"birthdate"`
 }
 
-func (v *queryWithCustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
+func (v queryWithCustomMarshalUsersBornOnUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -1711,7 +1711,7 @@ type __premarshalqueryWithFragmentsBeingsAnimal struct {
 	Owner json.RawMessage `json:"owner"`
 }
 
-func (v *queryWithFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
+func (v queryWithFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2025,7 +2025,7 @@ type __premarshalqueryWithFragmentsResponse struct {
 	Beings []json.RawMessage `json:"beings"`
 }
 
-func (v *queryWithFragmentsResponse) MarshalJSON() ([]byte, error) {
+func (v queryWithFragmentsResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2219,7 +2219,7 @@ type __premarshalqueryWithInterfaceListFieldResponse struct {
 	Beings []json.RawMessage `json:"beings"`
 }
 
-func (v *queryWithInterfaceListFieldResponse) MarshalJSON() ([]byte, error) {
+func (v queryWithInterfaceListFieldResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2414,7 +2414,7 @@ type __premarshalqueryWithInterfaceListPointerFieldResponse struct {
 	Beings []json.RawMessage `json:"beings"`
 }
 
-func (v *queryWithInterfaceListPointerFieldResponse) MarshalJSON() ([]byte, error) {
+func (v queryWithInterfaceListPointerFieldResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2624,7 +2624,7 @@ type __premarshalqueryWithInterfaceNoFragmentsResponse struct {
 	Me queryWithInterfaceNoFragmentsMeUser `json:"me"`
 }
 
-func (v *queryWithInterfaceNoFragmentsResponse) MarshalJSON() ([]byte, error) {
+func (v queryWithInterfaceNoFragmentsResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2709,7 +2709,7 @@ type __premarshalqueryWithNamedFragmentsBeingsAnimal struct {
 	Owner json.RawMessage `json:"owner"`
 }
 
-func (v *queryWithNamedFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
+func (v queryWithNamedFragmentsBeingsAnimal) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2879,7 +2879,7 @@ type __premarshalqueryWithNamedFragmentsBeingsUser struct {
 	Hair MoreUserFieldsHair `json:"hair"`
 }
 
-func (v *queryWithNamedFragmentsBeingsUser) MarshalJSON() ([]byte, error) {
+func (v queryWithNamedFragmentsBeingsUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2950,7 +2950,7 @@ type __premarshalqueryWithNamedFragmentsResponse struct {
 	Beings []json.RawMessage `json:"beings"`
 }
 
-func (v *queryWithNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
+func (v queryWithNamedFragmentsResponse) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See [this](https://github.com/golang/go/issues/22967)

W/o this, `json.Marshal` does not work as expected, though `x.MarshalJSON()` will.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [ ] Added tests covering my changes, if applicable
- [ ] Included a link to the issue fixed, if applicable
- [ ] Included documentation, for new features
- [ ] Added an entry to the changelog
