### PR TITLE
Add `omitempty` for pointer input fields

### DIFF
--- a/generate/convert.go
+++ b/generate/convert.go
@@ -439,6 +439,11 @@ func (g *generator) convertDefinition(
 				return nil, err
 			}
 
+			if options.GetPointer() || (!field.Type.NonNull && g.Config.Optional == "pointer") {
+				oe := true
+				fieldOptions.Omitempty = &oe
+			}
+
 			goType.Fields[i] = &goStructField{
 				GoName:      goName,
 				GoType:      fieldGoType,


### PR DESCRIPTION
When `optional: "pointer"` is configured, `omitempty` is needed for input fields for the generated code to be semantically correct. Without `omitempty` an empty pointer would generate an "empty value" which is incorrect.

Consider the following graphql schema generated by Hasura:

```
input task_insert_input {
  id: Int
}
```

Without this fix, the following golang struct will be generated:
```
type Task_insert_input struct {
  Id: *int `json:"id"`
}
```

When we populate the struct without `Id` being set, it'd serialize to `{ id: 0 }` as oppose to `{}` (i.e. so that the id would be generated by Hasura)

<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->



I have:
- [ ] Written a clear PR title and description (above)
- [ ] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [ ] Added tests covering my changes, if applicable
- [ ] Included a link to the issue fixed, if applicable
- [ ] Included documentation, for new features
- [ ] Added an entry to the changelog
