### PR TITLE
fix: premarshal structs get generated with omitempty tag

### DIFF
--- a/generate/marshal.go.tmpl
+++ b/generate/marshal.go.tmpl
@@ -31,9 +31,9 @@
 type __premarshal{{.GoName}} struct{
     {{range .FlattenedFields -}}
     {{if .NeedsMarshaling -}}
-    {{.GoName}} {{repeat .GoType.SliceDepth "[]"}}{{ref "encoding/json.RawMessage"}} `json:"{{.JSONName}}"`
+    {{.GoName}} {{repeat .GoType.SliceDepth "[]"}}{{ref "encoding/json.RawMessage"}} `json:"{{.JSONName}}{{if .Omitempty -}},omitempty{{end}}"`
     {{else}}
-    {{.GoName}} {{.GoType.Reference}} `json:"{{.JSONName}}"`
+    {{.GoName}} {{.GoType.Reference}} `json:"{{.JSONName}}{{if .Omitempty -}},omitempty{{end}}"`
     {{end}}
     {{end}}
 }

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -83,19 +83,19 @@ func (v *MyInput) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalMyInput struct {
-	Email *string `json:"email"`
+	Email *string `json:"email,omitempty"`
 
-	Name *string `json:"name"`
+	Name *string `json:"name,omitempty"`
 
-	Id *testutil.ID `json:"id"`
+	Id *testutil.ID `json:"id,omitempty"`
 
-	Role *Role `json:"role"`
+	Role *Role `json:"role,omitempty"`
 
-	Names []*string `json:"names"`
+	Names []*string `json:"names,omitempty"`
 
-	HasPokemon *testutil.Pokemon `json:"hasPokemon"`
+	HasPokemon *testutil.Pokemon `json:"hasPokemon,omitempty"`
 
-	Birthdate json.RawMessage `json:"birthdate"`
+	Birthdate json.RawMessage `json:"birthdate,omitempty"`
 }
 
 func (v *MyInput) MarshalJSON() ([]byte, error) {
@@ -264,19 +264,19 @@ func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalUserQueryInput struct {
-	Email *string `json:"email"`
+	Email *string `json:"email,omitempty"`
 
-	Name *string `json:"name"`
+	Name *string `json:"name,omitempty"`
 
-	Id *testutil.ID `json:"id"`
+	Id *testutil.ID `json:"id,omitempty"`
 
-	Role *Role `json:"role"`
+	Role *Role `json:"role,omitempty"`
 
-	Names []*string `json:"names"`
+	Names []*string `json:"names,omitempty"`
 
-	HasPokemon *testutil.Pokemon `json:"hasPokemon"`
+	HasPokemon *testutil.Pokemon `json:"hasPokemon,omitempty"`
 
-	Birthdate json.RawMessage `json:"birthdate"`
+	Birthdate json.RawMessage `json:"birthdate,omitempty"`
 }
 
 func (v *UserQueryInput) MarshalJSON() ([]byte, error) {

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -148,19 +148,19 @@ func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalUserQueryInput struct {
-	Email string `json:"email"`
+	Email string `json:"email,omitempty"`
 
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	Id testutil.ID `json:"id"`
 
-	Role Role `json:"role"`
+	Role Role `json:"role,omitempty"`
 
-	Names []string `json:"names"`
+	Names []string `json:"names,omitempty"`
 
-	HasPokemon testutil.Pokemon `json:"hasPokemon"`
+	HasPokemon testutil.Pokemon `json:"hasPokemon,omitempty"`
 
-	Birthdate json.RawMessage `json:"birthdate"`
+	Birthdate json.RawMessage `json:"birthdate,omitempty"`
 }
 
 func (v *UserQueryInput) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->

This PR addresses a bug described in https://github.com/Khan/genqlient/issues/263

Basically, whenever a struct involves a custom genqlient binding, a secondary "premarshal" struct gets generated.

The bug was that this "premarshal" struct was not propagating the `omitempty` JSON tags, which was resulting in unexpected behavior.

The fix involved a few changed lines in the Go template, and a few changes in the unit tests.

I have:
- [x] Written a clear PR title and description (above)
- [ ] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [ ] Added tests covering my changes, if applicable
- [ ] Included a link to the issue fixed, if applicable
- [ ] Included documentation, for new features
- [ ] Added an entry to the changelog
