### PR TITLE
feat: always set omitempty on pointer fields

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ When releasing a new version:
 
 ### Bug fixes:
 
+- Using `pointer: true` will generate `omitempty` tags to all pointer input types.
+
 -->
 
 ## next

--- a/generate/convert.go
+++ b/generate/convert.go
@@ -453,7 +453,7 @@ func (g *generator) convertDefinition(
 			// We always want to set omitempty if the field is a pointer, unless
 			// the user explicitly wants the value to be sent as null.
 			omitEmpty := fieldOptions.GetOmitempty()
-			if options.GetPointer() && (!field.Type.NonNull && g.Config.Optional == "pointer") && fieldOptions.Omitempty == nil {
+			if options.GetPointer() || (!field.Type.NonNull && g.Config.Optional == "pointer") && fieldOptions.Omitempty == nil {
 				omitEmpty = true
 			}
 

--- a/generate/convert.go
+++ b/generate/convert.go
@@ -450,13 +450,20 @@ func (g *generator) convertDefinition(
 				return nil, err
 			}
 
+			// We always want to set omitempty if the field is a pointer, unless
+			// the user explicitly wants the value to be sent as null.
+			omitEmpty := fieldOptions.GetOmitempty()
+			if options.GetPointer() && (!field.Type.NonNull && g.Config.Optional == "pointer") && fieldOptions.Omitempty == nil {
+				omitEmpty = true
+			}
+
 			goType.Fields[i] = &goStructField{
 				GoName:      goName,
 				GoType:      fieldGoType,
 				JSONName:    field.Name,
 				GraphQLName: field.Name,
 				Description: field.Description,
-				Omitempty:   fieldOptions.GetOmitempty(),
+				Omitempty:   omitEmpty,
 			}
 		}
 		return goType, nil


### PR DESCRIPTION
<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->

When optional: "pointer" is configured, omitempty is needed for input fields for the generated code to be semantically correct. Without omitempty an empty pointer would generate an "empty value" which is incorrect.

Consider the following graphql schema generated by Hasura:

```
input task_insert_input {
  id: Int
}
```

Without this fix, the following golang struct will be generated:

```
type Task_insert_input struct {
  Id: *int `json:"id"`
}
```

* Ref: https://github.com/Khan/genqlient/issues/260
* Ref: https://github.com/Khan/genqlient/pull/264

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [ ] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
