### PR TITLE
feat: allow imports from same generated package

### DIFF
--- a/generate/imports.go
+++ b/generate/imports.go
@@ -100,6 +100,11 @@ func (g *generator) ref(fullyQualifiedName string) (qualifiedName string, err er
 	pkgPath := nameToImport[:i]
 	localName := nameToImport[i+1:]
 	alias, ok := g.imports[pkgPath]
+
+	if pkgPath == g.Config.Package {
+		return localName, nil
+	}
+
 	if !ok {
 		if g.importsLocked {
 			return "", errorf(nil,


### PR DESCRIPTION
This is a small change, but it lets you import marshaler and unmarshalers from the same generated package. 

Why?
   I'd like to keep all the graphql related code into one. Following the conventions of the `genqlient/example`, I would like to keep a custom marshaler in the same directory as `example`. For e.g., `example/helper.go` could contain:

```go
// helper.go
func UnMarshalDateTime(b []byte, v *time.Time) error {
	...
	return nil
}
```

 But following won't work:

```yaml
...
generated: generated.go
package: main
bindings:
  DateTime:
    type: time.Time
    unmarshaler: "https://github.com/Khan/genqlient/main.UnMarshalDateTime" // since package name is main
    # unmarshaler: "https://github.com/Khan/genqlient/example.UnMarshalDateTime" // nor this, if one is using a custom package
```

So, instead I would like to add a new feature where one can import from the same package:

```yaml
...
generated: generated.go
package: main
bindings:
  DateTime:
    type: time.Time
    unmarshaler: "main.UnMarshalDateTime"
```

What do you think? If you think this is good, then I will add tests and update the documentation

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [ ] Added tests covering my changes, if applicable
- [ ] Included a link to the issue fixed, if applicable
- [ ] Included documentation, for new features
- [ ] Added an entry to the changelog
