### PR TITLE
Add option for including operationName as a query parameter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ When releasing a new version:
 
 ### New features:
 
+- The new `graphql.WithOperationNameParam` allows clients to be created that include `operationName` as a query parameter.
 - The new `optional: generic` allows using a generic type to represent optionality. See the [documentation](genqlient.yaml) for details.
 - For schemas with enum values that differ only in casing, it's now possible to disable smart-casing in genqlient.yaml; see the [documentation](genqlient.yaml) for `casing` for details.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -36,6 +36,19 @@ The URL requested will be:
 
 The client does not support mutations, and will return an error if passed a request that attempts one.
 
+###  … include operationName as a query parameter?
+
+`graphql.NewClient` support the option `graphql.WithOperationNameParam`, which will add `?operationName=...` to the request's query parameters.
+
+```go
+ctx := context.Background()
+client := graphql.NewClient("https://api.github.com/graphql", http.DefaultClient, graphql.WithOperationNameParam)
+resp, err := getUser(ctx, client, "benjaminjkraft")
+fmt.Println(resp.User.Name, err)
+```
+
+
+
 ### … use an API that requires authentication?
 
 When you call `graphql.NewClient`, pass in an HTTP client that adds whatever authentication headers you need (typically by wrapping the client's `Transport`).  For example:

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -107,6 +107,7 @@ func TestVariables(t *testing.T) {
 	// worry about it.
 	clients := []graphql.Client{
 		graphql.NewClient(server.URL, http.DefaultClient),
+		graphql.NewClient(server.URL, http.DefaultClient, graphql.WithOperationNameParam),
 		graphql.NewClientUsingGet(server.URL, http.DefaultClient),
 	}
 

--- a/internal/integration/roundtrip.go
+++ b/internal/integration/roundtrip.go
@@ -104,7 +104,11 @@ func (c *roundtripClient) MakeRequest(ctx context.Context, req *graphql.Request,
 }
 
 func newRoundtripClients(t *testing.T, endpoint string) []graphql.Client {
-	return []graphql.Client{newRoundtripClient(t, endpoint), newRoundtripGetClient(t, endpoint)}
+	return []graphql.Client{
+		newRoundtripClient(t, endpoint),
+		newRoundtripClientWithOptions(t, endpoint),
+		newRoundtripGetClient(t, endpoint),
+	}
 }
 
 func newRoundtripClient(t *testing.T, endpoint string) graphql.Client {
@@ -112,6 +116,16 @@ func newRoundtripClient(t *testing.T, endpoint string) graphql.Client {
 	httpClient := &http.Client{Transport: transport}
 	return &roundtripClient{
 		wrapped:   graphql.NewClient(endpoint, httpClient),
+		transport: transport,
+		t:         t,
+	}
+}
+
+func newRoundtripClientWithOptions(t *testing.T, endpoint string) graphql.Client {
+	transport := &lastResponseTransport{wrapped: http.DefaultTransport}
+	httpClient := &http.Client{Transport: transport}
+	return &roundtripClient{
+		wrapped:   graphql.NewClient(endpoint, httpClient, graphql.WithOperationNameParam),
 		transport: transport,
 		t:         t,
 	}


### PR DESCRIPTION
<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->

This introduces the ability to include `operationName` as a query parameter for the default client.

There are a few patterns for options that are described [here](https://golang.cafe/blog/golang-functional-options-pattern.html). The existing `NewClientUsingGet` follows the "Declare a new constructor for each configuration option" pattern. As additional options get added, the "Functional Options Pattern" may be more scalable.

Use-case: This allows requests to be routed based on their operation.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [ ] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
