### PR TITLE
Support more valid graphql file extensions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ When releasing a new version:
 
 ## next
 
-<!-- Add new changes in this section! -->
+- Support .graphqls and .gql file extensions
 
 ### Breaking changes:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ When releasing a new version:
 
 ## next
 
-- Support .graphqls and .gql file extensions
+<!-- Add new changes in this section! -->
 
 ### Breaking changes:
 
@@ -26,6 +26,7 @@ When releasing a new version:
 
 - The new `optional: generic` allows using a generic type to represent optionality. See the [documentation](genqlient.yaml) for details.
 - For schemas with enum values that differ only in casing, it's now possible to disable smart-casing in genqlient.yaml; see the [documentation](genqlient.yaml) for `casing` for details.
+- Support .graphqls and .gql file extensions
 
 ### Bug fixes:
 - The presence of negative pointer directives, i.e., `# @genqlient(pointer: false)` are now respected even in the when `optional: pointer` is set in the configuration file.

--- a/generate/parse.go
+++ b/generate/parse.go
@@ -130,7 +130,7 @@ func getQueries(basedir string, globs StringList) (*ast.QueryDocument, error) {
 		}
 
 		switch filepath.Ext(filename) {
-		case ".graphql":
+		case ".graphql", ".graphqls", ".gql":
 			queryDoc, err := getQueriesFromString(string(text), basedir, filename)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
There are two other commonly used graphql file extension we should support
.gql - used by apollo and other client library to differentiate query from schema
.graphqls - used by gqlgen and other server library to differentiate schema from query

https://github.com/apollographql/apollo-tooling/blob/a778ca162bdd20be9e60a914887302390c274644/packages/apollo/src/commands/client/download-schema.ts#L19


I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
