### PR TITLE
Pin lint workflow's Go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.20'
       id: go
 
     - name: Git checkout

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.19', '1.20', '1.21', '1.22' ]
+        go: [ '1.18', '1.19', '1.20', '1.21' ]
 
     steps:
     - name: Set up Go
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
       id: go
 
     - name: Git checkout

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.19', '1.20' ]
+        go: [ '1.18', '1.19', '1.20', '1.21', '1.22' ]
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go }}
       id: go
@@ -36,10 +36,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+      id: go
+
     - name: Git checkout
       uses: actions/checkout@v2
 
     - name: Run lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         version: v1.52.2   # should match internal/lint/go.mod


### PR DESCRIPTION
We weren't pinning the Go version for golangci-lint (only the golangci-lint version); seemingly it breaks on 1.21+. Now we're using a new version making it easy to pin back to 1.20. Later I'll look at why 1.21+ are failing (#313).

While I was at it I added tests on 1.21 (1.22+ is failing, again will look later, #312), and upgraded the setup-go action itself.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable (n/a)
- [x] Included a link to the issue fixed, if applicable (n/a)
- [x] Included documentation, for new features (n/a)
- [x] Added an entry to the changelog (n/a)
