### PR TITLE
Only warn if a glob does not match any files, but error if total is 0

### DIFF
--- a/generate/parse.go
+++ b/generate/parse.go
@@ -22,10 +22,6 @@ func getSchema(globs StringList) (*ast.Schema, error) {
 		return nil, err
 	}
 
-	if len(filenames) == 0 {
-		return nil, errorf(nil, "no schema files found in: %v", globs)
-	}
-
 	sources := make([]*ast.Source, len(filenames))
 	for i, filename := range filenames {
 		text, err := os.ReadFile(filename)
@@ -102,6 +98,11 @@ func expandFilenames(globs []string) ([]string, error) {
 			uniqFilenames[match] = true
 		}
 	}
+
+	if len(uniqFilenames) == 0 {
+		return nil, errorf(nil, "no files found in any glob: %v", globs)
+	}
+
 	filenames := make([]string, 0, len(uniqFilenames))
 	for filename := range uniqFilenames {
 		filenames = append(filenames, filename)
@@ -125,10 +126,6 @@ func getQueries(basedir string, globs StringList) (*ast.QueryDocument, error) {
 	filenames, err := expandFilenames(globs)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(filenames) == 0 {
-		return nil, errorf(nil, "no query files found in: %v", globs)
 	}
 
 	for _, filename := range filenames {

--- a/generate/parse.go
+++ b/generate/parse.go
@@ -22,6 +22,10 @@ func getSchema(globs StringList) (*ast.Schema, error) {
 		return nil, err
 	}
 
+	if len(filenames) == 0 {
+		return nil, errorf(nil, "no schema files found in: %v", globs)
+	}
+
 	sources := make([]*ast.Source, len(filenames))
 	for i, filename := range filenames {
 		text, err := os.ReadFile(filename)
@@ -92,7 +96,7 @@ func expandFilenames(globs []string) ([]string, error) {
 			return nil, errorf(nil, "can't expand file-glob %v: %v", glob, err)
 		}
 		if len(matches) == 0 {
-			return nil, errorf(nil, "%v did not match any files", glob)
+			warn(errorf(nil, "%v did not match any files", glob))
 		}
 		for _, match := range matches {
 			uniqFilenames[match] = true
@@ -121,6 +125,10 @@ func getQueries(basedir string, globs StringList) (*ast.QueryDocument, error) {
 	filenames, err := expandFilenames(globs)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(filenames) == 0 {
+		return nil, errorf(nil, "no query files found in: %v", globs)
 	}
 
 	for _, filename := range filenames {


### PR DESCRIPTION
This changes the filename expansion to only warn on empty globs, and error only if no files in total were found.

This is a strawman proposal for issue #327 

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [?] Added tests covering my changes, if applicable _No current tests exist, but I can add ones for this case and check error messages_
- [ x] Included a link to the issue fixed, if applicable
- [ -] Included documentation, for new features
- [ -] Added an entry to the changelog
