### PR TITLE
Remove allow_broken_features

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ When releasing a new version:
   - allow `omitempty` on non-nullable input field, if the field has a default
   - allow `omitempty: false` on an input field, even when it is non-nullable
 - don't do `omitempty` and `pointer` input types validation when `use_struct_reference` is used, as the generated type is often not compatible with validation logic.
+- the `allow_broken_features` option, which no longer did anything, has been removed
 
 ## v0.7.0
 

--- a/generate/config.go
+++ b/generate/config.go
@@ -37,13 +37,6 @@ type Config struct {
 	StructReferences    bool                    `yaml:"use_struct_references"`
 	Extensions          bool                    `yaml:"use_extensions"`
 
-	// Set to true to use features that aren't fully ready to use.
-	//
-	// This is primarily intended for genqlient's own tests.  These features
-	// are likely BROKEN and come with NO EXPECTATION OF COMPATIBILITY.  Use
-	// them at your own risk!
-	AllowBrokenFeatures bool `yaml:"allow_broken_features"`
-
 	// The directory of the config-file (relative to which all the other paths
 	// are resolved).  Set by ValidateAndFillDefaults.
 	baseDir string

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -98,7 +98,6 @@ func TestGenerate(t *testing.T) {
 					},
 					"PokemonInput": {Type: "github.com/Khan/genqlient/internal/testutil.Pokemon"},
 				},
-				AllowBrokenFeatures: true,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -345,7 +344,6 @@ func TestGenerateErrors(t *testing.T) {
 						ExpectExactFields: "{ species level }",
 					},
 				},
-				AllowBrokenFeatures: true,
 			})
 			if err == nil {
 				t.Fatal("expected an error")

--- a/generate/testdata/snapshots/TestValidConfigs-Empty.yml
+++ b/generate/testdata/snapshots/TestValidConfigs-Empty.yml
@@ -16,7 +16,6 @@
   OptionalGenericType: (string) "",
   StructReferences: (bool) false,
   Extensions: (bool) false,
-  AllowBrokenFeatures: (bool) false,
   baseDir: (string) (len=20) "testdata/validConfig",
   pkgPath: (string) (len=55) "github.com/Khan/genqlient/generate/testdata/validConfig"
 })

--- a/generate/testdata/snapshots/TestValidConfigs-Lists.yaml
+++ b/generate/testdata/snapshots/TestValidConfigs-Lists.yaml
@@ -22,7 +22,6 @@
   OptionalGenericType: (string) "",
   StructReferences: (bool) false,
   Extensions: (bool) false,
-  AllowBrokenFeatures: (bool) false,
   baseDir: (string) (len=20) "testdata/validConfig",
   pkgPath: (string) (len=55) "github.com/Khan/genqlient/generate/testdata/validConfig"
 })

--- a/generate/testdata/snapshots/TestValidConfigs-Strings.yaml
+++ b/generate/testdata/snapshots/TestValidConfigs-Strings.yaml
@@ -20,7 +20,6 @@
   OptionalGenericType: (string) "",
   StructReferences: (bool) false,
   Extensions: (bool) false,
-  AllowBrokenFeatures: (bool) false,
   baseDir: (string) (len=20) "testdata/validConfig",
   pkgPath: (string) (len=55) "github.com/Khan/genqlient/generate/testdata/validConfig"
 })

--- a/internal/integration/genqlient.yaml
+++ b/internal/integration/genqlient.yaml
@@ -1,7 +1,6 @@
 schema: schema.graphql
 operations: "*_test.go"
 generated: generated.go
-allow_broken_features: true
 use_extensions: true
 bindings:
   Date:


### PR DESCRIPTION
This was a config option from the early days, when there were various things I wanted to be able to try but didn't really want users to use yet. With subscriptions merged, the last plausible need is long gone!

Technically this is a breaking change, but it was documented as unstable so I didn't mark it as one.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
