### PR TITLE
Generate slices containing all enum values

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ When releasing a new version:
 - genqlient now supports subscriptions; the websocket protocol is by default `graphql-transport-ws` but can be set to another value.  
   See the [documentation](FAQ.md) for how to `subscribe to an API 'subscription' endpoint`.
 - genqlient now supports double-star globs for schema and query files; see [`genqlient.yaml` docs](genqlient.yaml) for more.
+- genqlient now generates slices containing all enum values for each enum type.
 
 ### Bug fixes:
 

--- a/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
@@ -46,6 +46,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // __InputEnumQueryInput is used internally by genqlient
 type __InputEnumQueryInput struct {
 	Role Role `json:"role"`

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -51,6 +51,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -192,6 +192,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -77,6 +77,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -93,6 +93,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -93,6 +93,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
@@ -62,6 +62,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // The query executed by QueryWithEnums.
 const QueryWithEnums_Operation = `
 query QueryWithEnums {

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -24,6 +24,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // StructOptionResponse is returned by StructOption on success.
 type StructOptionResponse struct {
 	Root StructOptionRootTopic `json:"root"`

--- a/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
@@ -20,6 +20,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UsesEnumTwiceQueryMeUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
 //

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -25,6 +25,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingAll-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingAll-testdata-queries-generated.go
@@ -64,6 +64,11 @@ const (
 	Role_TEACHER Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	Role_STUDENT,
+	Role_TEACHER,
+}
+
 // The query executed by QueryWithEnums.
 const QueryWithEnums_Operation = `
 query QueryWithEnums {

--- a/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingSpecific-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingSpecific-testdata-queries-generated.go
@@ -64,6 +64,11 @@ const (
 	Role_TEACHER Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	Role_STUDENT,
+	Role_TEACHER,
+}
+
 // The query executed by QueryWithEnums.
 const QueryWithEnums_Operation = `
 query QueryWithEnums {

--- a/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated.go
@@ -100,6 +100,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/testdata/snapshots/TestGenerateWithConfig-StructReferencesAndOptionalPointer-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-StructReferencesAndOptionalPointer-testdata-queries-generated.go
@@ -100,6 +100,11 @@ const (
 	RoleTeacher Role = "TEACHER"
 )
 
+var AllRole = []Role{
+	RoleStudent,
+	RoleTeacher,
+}
+
 // UserQueryInput is the argument to Query.users.
 //
 // Ideally this would support anything and everything!

--- a/generate/types.go
+++ b/generate/types.go
@@ -147,6 +147,13 @@ func (typ *goEnumType) WriteDefinition(w io.Writer, g *generator) error {
 			val.GoName, typ.GoName, val.GraphQLName)
 	}
 	fmt.Fprintf(w, ")\n")
+
+	// Add slice with all enums.
+	fmt.Fprintf(w, "var All%s = []%s{\n", typ.GoName, typ.GoName)
+	for _, val := range typ.Values {
+		fmt.Fprintf(w, "%s,\n", val.GoName)
+	}
+	fmt.Fprintf(w, "}\n")
 	return nil
 }
 

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -928,6 +928,11 @@ const (
 	SpeciesCoelacanth Species = "COELACANTH"
 )
 
+var AllSpecies = []Species{
+	SpeciesDog,
+	SpeciesCoelacanth,
+}
+
 // UserFields includes the GraphQL fields of User requested by the fragment UserFields.
 type UserFields struct {
 	Id              string `json:"id"`


### PR DESCRIPTION
It would be useful to generate slices containing all enum values for each enum type. Then there will be no need to maintain such kind of slices manually. 

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
