### PR TITLE
Standardize error return from HTTP requests in genqlient

### DIFF
--- a/graphql/client.go
+++ b/graphql/client.go
@@ -242,7 +242,10 @@ func (c *client) MakeRequest(ctx context.Context, req *Request, resp *Response) 
 		if err != nil {
 			respBody = []byte(fmt.Sprintf("<unreadable: %v>", err))
 		}
-		return fmt.Errorf("returned error %v: %s", httpResp.Status, respBody)
+		return &HTTPError{
+			StatusCode: httpResp.StatusCode,
+			Body:       string(respBody),
+		}
 	}
 
 	err = json.NewDecoder(httpResp.Body).Decode(resp)

--- a/graphql/client_test.go
+++ b/graphql/client_test.go
@@ -1,0 +1,90 @@
+package graphql
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeRequest_HTTPError(t *testing.T) {
+	testCases := []struct {
+		name               string
+		serverResponseCode int
+		serverResponseBody string
+		expectedStatusCode int
+		expectedErrorBody  string
+	}{
+		{
+			name:               "400 Bad Request",
+			serverResponseCode: http.StatusBadRequest,
+			serverResponseBody: "Bad Request",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErrorBody:  "Bad Request",
+		},
+		{
+			name:               "429 Too Many Requests",
+			serverResponseCode: http.StatusTooManyRequests,
+			serverResponseBody: "Rate limit exceeded",
+			expectedStatusCode: http.StatusTooManyRequests,
+			expectedErrorBody:  "Rate limit exceeded",
+		},
+		{
+			name:               "500 Internal Server Error",
+			serverResponseCode: http.StatusInternalServerError,
+			serverResponseBody: "Internal Server Error",
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedErrorBody:  "Internal Server Error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.serverResponseCode)
+				w.Write([]byte(tc.serverResponseBody))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL, server.Client())
+			req := &Request{
+				Query: "query { test }",
+			}
+			resp := &Response{}
+
+			err := client.MakeRequest(context.Background(), req, resp)
+
+			assert.Error(t, err)
+			httpErr, ok := err.(*HTTPError)
+			assert.True(t, ok, "Error should be of type *HTTPError")
+			assert.Equal(t, tc.expectedStatusCode, httpErr.StatusCode)
+			assert.Equal(t, tc.expectedErrorBody, httpErr.Body)
+		})
+	}
+}
+
+func TestMakeRequest_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]string{
+				"test": "success",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, server.Client())
+	req := &Request{
+		Query: "query { test }",
+	}
+	resp := &Response{}
+
+	err := client.MakeRequest(context.Background(), req, resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "success"}, resp.Data)
+}

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // HTTPError represents an HTTP error with status code and response body.
 type HTTPError struct {
-	StatusCode int
 	Body       string
+	StatusCode int
 }
 
 // Error implements the error interface for HTTPError.

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -1,0 +1,14 @@
+package graphql
+
+import "fmt"
+
+// HTTPError represents an HTTP error with status code and response body.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error implements the error interface for HTTPError.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("returned error %v: %s", e.StatusCode, e.Body)
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -7,6 +7,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -113,9 +114,10 @@ func TestServerError(t *testing.T) {
 		// response -- and indeed in this case it should even have another field
 		// (which didn't err) set.
 		assert.Error(t, err)
-		httpErr, ok := err.(*graphql.HTTPError)
-		assert.True(t, ok, "Error should be of type *HTTPError")
-		assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+		var httpErr *graphql.HTTPError
+		if assert.True(t, errors.As(err, &httpErr), "Error should be of type *HTTPError") {
+			assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+		}
 		assert.NotNil(t, resp)
 		assert.Equal(t, "1", resp.Me.Id)
 	}
@@ -133,8 +135,8 @@ func TestNetworkError(t *testing.T) {
 		//	return resp.Me.Id, err
 		// without a bunch of extra ceremony.
 		assert.Error(t, err)
-		_, ok := err.(*graphql.HTTPError)
-		assert.False(t, ok, "Error should not be of type *HTTPError for network errors")
+		var httpErr *graphql.HTTPError
+		assert.False(t, errors.As(err, &httpErr), "Error should not be of type *HTTPError for network errors")
 		assert.NotNil(t, resp)
 		assert.Equal(t, new(failingQueryResponse), resp)
 	}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -113,6 +113,9 @@ func TestServerError(t *testing.T) {
 		// response -- and indeed in this case it should even have another field
 		// (which didn't err) set.
 		assert.Error(t, err)
+		httpErr, ok := err.(*graphql.HTTPError)
+		assert.True(t, ok, "Error should be of type *HTTPError")
+		assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
 		assert.NotNil(t, resp)
 		assert.Equal(t, "1", resp.Me.Id)
 	}
@@ -130,6 +133,8 @@ func TestNetworkError(t *testing.T) {
 		//	return resp.Me.Id, err
 		// without a bunch of extra ceremony.
 		assert.Error(t, err)
+		_, ok := err.(*graphql.HTTPError)
+		assert.False(t, ok, "Error should not be of type *HTTPError for network errors")
 		assert.NotNil(t, resp)
 		assert.Equal(t, new(failingQueryResponse), resp)
 	}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/Khan/genqlient/internal/integration/server"
@@ -114,9 +115,14 @@ func TestServerError(t *testing.T) {
 		// response -- and indeed in this case it should even have another field
 		// (which didn't err) set.
 		assert.Error(t, err)
-		var httpErr *graphql.HTTPError
-		if assert.True(t, errors.As(err, &httpErr), "Error should be of type *HTTPError") {
-			assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+		t.Logf("Full error: %+v", err)
+		var gqlErrors gqlerror.List
+		if !assert.True(t, errors.As(err, &gqlErrors), "Error should be of type gqlerror.List") {
+			t.Logf("Actual error type: %T", err)
+			t.Logf("Error message: %v", err)
+		} else {
+			assert.Len(t, gqlErrors, 1, "Expected one GraphQL error")
+			assert.Equal(t, "oh no", gqlErrors[0].Message)
 		}
 		assert.NotNil(t, resp)
 		assert.Equal(t, "1", resp.Me.Id)
@@ -135,8 +141,8 @@ func TestNetworkError(t *testing.T) {
 		//	return resp.Me.Id, err
 		// without a bunch of extra ceremony.
 		assert.Error(t, err)
-		var httpErr *graphql.HTTPError
-		assert.False(t, errors.As(err, &httpErr), "Error should not be of type *HTTPError for network errors")
+		var gqlErrors gqlerror.List
+		assert.False(t, errors.As(err, &gqlErrors), "Error should not be of type gqlerror.List for network errors")
 		assert.NotNil(t, resp)
 		assert.Equal(t, new(failingQueryResponse), resp)
 	}


### PR DESCRIPTION
<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->

# Purpose
This pull request aims to standardize the error handling for HTTP requests in the genqlient library. The current implementation returns a generic error message that makes it difficult to handle specific error scenarios, such as retrying on rate limit errors.

Fixes #333


I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [ ] Included documentation, for new features
- [ ] Added an entry to the changelog
