### PR TITLE
feat: return zero value in getter methods if receiver is nil

### DIFF
--- a/example/generated.go
+++ b/example/generated.go
@@ -15,7 +15,12 @@ type __getUserInput struct {
 }
 
 // GetLogin returns __getUserInput.Login, and is useful for accessing the field via an interface.
-func (v *__getUserInput) GetLogin() string { return v.Login }
+func (v *__getUserInput) GetLogin() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Login
+}
 
 // getUserResponse is returned by getUser on success.
 type getUserResponse struct {
@@ -24,7 +29,12 @@ type getUserResponse struct {
 }
 
 // GetUser returns getUserResponse.User, and is useful for accessing the field via an interface.
-func (v *getUserResponse) GetUser() getUserUser { return v.User }
+func (v *getUserResponse) GetUser() (val getUserUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // getUserUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -38,10 +48,20 @@ type getUserUser struct {
 }
 
 // GetTheirName returns getUserUser.TheirName, and is useful for accessing the field via an interface.
-func (v *getUserUser) GetTheirName() string { return v.TheirName }
+func (v *getUserUser) GetTheirName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.TheirName
+}
 
 // GetCreatedAt returns getUserUser.CreatedAt, and is useful for accessing the field via an interface.
-func (v *getUserUser) GetCreatedAt() time.Time { return v.CreatedAt }
+func (v *getUserUser) GetCreatedAt() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.CreatedAt
+}
 
 // getViewerResponse is returned by getViewer on success.
 type getViewerResponse struct {
@@ -50,7 +70,12 @@ type getViewerResponse struct {
 }
 
 // GetViewer returns getViewerResponse.Viewer, and is useful for accessing the field via an interface.
-func (v *getViewerResponse) GetViewer() getViewerViewerUser { return v.Viewer }
+func (v *getViewerResponse) GetViewer() (val getViewerViewerUser) {
+	if v == nil {
+		return
+	}
+	return v.Viewer
+}
 
 // getViewerViewerUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -64,10 +89,20 @@ type getViewerViewerUser struct {
 }
 
 // GetMyName returns getViewerViewerUser.MyName, and is useful for accessing the field via an interface.
-func (v *getViewerViewerUser) GetMyName() string { return v.MyName }
+func (v *getViewerViewerUser) GetMyName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.MyName
+}
 
 // GetCreatedAt returns getViewerViewerUser.CreatedAt, and is useful for accessing the field via an interface.
-func (v *getViewerViewerUser) GetCreatedAt() time.Time { return v.CreatedAt }
+func (v *getViewerViewerUser) GetCreatedAt() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.CreatedAt
+}
 
 // The query executed by getUser.
 const getUser_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexInlineFragments.graphql-ComplexInlineFragments.graphql.go
@@ -17,10 +17,18 @@ type ComplexInlineFragmentsConflictingStuffArticle struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsConflictingStuffArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffArticle) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsConflictingStuffArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetThumbnail returns ComplexInlineFragmentsConflictingStuffArticle.Thumbnail, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffArticle) GetThumbnail() ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail {
+func (v *ComplexInlineFragmentsConflictingStuffArticle) GetThumbnail() (val ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) {
+	if v == nil {
+		return
+	}
 	return v.Thumbnail
 }
 
@@ -31,12 +39,18 @@ type ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail struct
 }
 
 // GetId returns ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) GetId() testutil.ID {
+func (v *ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetThumbnailUrl returns ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail.ThumbnailUrl, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) GetThumbnailUrl() string {
+func (v *ComplexInlineFragmentsConflictingStuffArticleThumbnailStuffThumbnail) GetThumbnailUrl() (val string) {
+	if v == nil {
+		return
+	}
 	return v.ThumbnailUrl
 }
 
@@ -136,7 +150,12 @@ type ComplexInlineFragmentsConflictingStuffTopic struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsConflictingStuffTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffTopic) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsConflictingStuffTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // ComplexInlineFragmentsConflictingStuffVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsConflictingStuffVideo struct {
@@ -145,10 +164,18 @@ type ComplexInlineFragmentsConflictingStuffVideo struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsConflictingStuffVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffVideo) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsConflictingStuffVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetThumbnail returns ComplexInlineFragmentsConflictingStuffVideo.Thumbnail, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffVideo) GetThumbnail() ComplexInlineFragmentsConflictingStuffVideoThumbnail {
+func (v *ComplexInlineFragmentsConflictingStuffVideo) GetThumbnail() (val ComplexInlineFragmentsConflictingStuffVideoThumbnail) {
+	if v == nil {
+		return
+	}
 	return v.Thumbnail
 }
 
@@ -159,10 +186,18 @@ type ComplexInlineFragmentsConflictingStuffVideoThumbnail struct {
 }
 
 // GetId returns ComplexInlineFragmentsConflictingStuffVideoThumbnail.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffVideoThumbnail) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsConflictingStuffVideoThumbnail) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetTimestampSec returns ComplexInlineFragmentsConflictingStuffVideoThumbnail.TimestampSec, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsConflictingStuffVideoThumbnail) GetTimestampSec() int {
+func (v *ComplexInlineFragmentsConflictingStuffVideoThumbnail) GetTimestampSec() (val int) {
+	if v == nil {
+		return
+	}
 	return v.TimestampSec
 }
 
@@ -172,7 +207,12 @@ type ComplexInlineFragmentsNestedStuffArticle struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffArticle) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsNestedStuffArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // ComplexInlineFragmentsNestedStuffContent includes the requested fields of the GraphQL interface Content.
 //
@@ -275,10 +315,18 @@ type ComplexInlineFragmentsNestedStuffTopic struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopic) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsNestedStuffTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetChildren returns ComplexInlineFragmentsNestedStuffTopic.Children, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopic) GetChildren() []ComplexInlineFragmentsNestedStuffTopicChildrenContent {
+func (v *ComplexInlineFragmentsNestedStuffTopic) GetChildren() (val []ComplexInlineFragmentsNestedStuffTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -370,18 +418,34 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticle struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetTypename() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetText returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Text, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetText() string { return v.Text }
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetText() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Text
+}
 
 // GetParent returns ComplexInlineFragmentsNestedStuffTopicChildrenArticle.Parent, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetParent() ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticle) GetParent() (val ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.Parent
 }
 
@@ -391,7 +455,10 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 }
 
 // GetChildren returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic.Children, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) GetChildren() []ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) GetChildren() (val []ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -479,17 +546,26 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetTypename() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetId() testutil.ID {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetName() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Name
 }
 
@@ -599,17 +675,26 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetTypename() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetId() testutil.ID {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetName() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Name
 }
 
@@ -622,17 +707,26 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTop
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetTypename() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetId() testutil.ID {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetName() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopicChildrenVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Name
 }
 
@@ -643,12 +737,18 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic struct {
 }
 
 // GetName returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) GetName() string {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Name
 }
 
 // GetParent returns ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic.Parent, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) GetParent() ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic {
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentTopic) GetParent() (val ComplexInlineFragmentsNestedStuffTopicChildrenArticleParentContentParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.Parent
 }
 
@@ -755,10 +855,20 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenTopic struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ComplexInlineFragmentsNestedStuffTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsNestedStuffTopicChildrenVideo struct {
@@ -768,10 +878,20 @@ type ComplexInlineFragmentsNestedStuffTopicChildrenVideo struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsNestedStuffTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsNestedStuffTopicChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ComplexInlineFragmentsNestedStuffVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsNestedStuffVideo struct {
@@ -779,7 +899,12 @@ type ComplexInlineFragmentsNestedStuffVideo struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsNestedStuffVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsNestedStuffVideo) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsNestedStuffVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // ComplexInlineFragmentsRandomItemArticle includes the requested fields of the GraphQL type Article.
 type ComplexInlineFragmentsRandomItemArticle struct {
@@ -791,16 +916,36 @@ type ComplexInlineFragmentsRandomItemArticle struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsRandomItemArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemArticle) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsRandomItemArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsRandomItemArticle.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemArticle) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsRandomItemArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetText returns ComplexInlineFragmentsRandomItemArticle.Text, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemArticle) GetText() string { return v.Text }
+func (v *ComplexInlineFragmentsRandomItemArticle) GetText() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Text
+}
 
 // GetName returns ComplexInlineFragmentsRandomItemArticle.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemArticle) GetName() string { return v.Name }
+func (v *ComplexInlineFragmentsRandomItemArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // ComplexInlineFragmentsRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
@@ -908,13 +1053,28 @@ type ComplexInlineFragmentsRandomItemTopic struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsRandomItemTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemTopic) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsRandomItemTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsRandomItemTopic.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemTopic) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsRandomItemTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns ComplexInlineFragmentsRandomItemTopic.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemTopic) GetName() string { return v.Name }
+func (v *ComplexInlineFragmentsRandomItemTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // ComplexInlineFragmentsRandomItemVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsRandomItemVideo struct {
@@ -926,16 +1086,36 @@ type ComplexInlineFragmentsRandomItemVideo struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsRandomItemVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemVideo) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsRandomItemVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsRandomItemVideo.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemVideo) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsRandomItemVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns ComplexInlineFragmentsRandomItemVideo.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemVideo) GetName() string { return v.Name }
+func (v *ComplexInlineFragmentsRandomItemVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetDuration returns ComplexInlineFragmentsRandomItemVideo.Duration, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRandomItemVideo) GetDuration() int { return v.Duration }
+func (v *ComplexInlineFragmentsRandomItemVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Duration
+}
 
 // ComplexInlineFragmentsRepeatedStuffArticle includes the requested fields of the GraphQL type Article.
 type ComplexInlineFragmentsRepeatedStuffArticle struct {
@@ -951,25 +1131,60 @@ type ComplexInlineFragmentsRepeatedStuffArticle struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsRepeatedStuffArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsRepeatedStuffArticle.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetUrl returns ComplexInlineFragmentsRepeatedStuffArticle.Url, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetUrl() string { return v.Url }
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // GetOtherId returns ComplexInlineFragmentsRepeatedStuffArticle.OtherId, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherId() testutil.ID { return v.OtherId }
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.OtherId
+}
 
 // GetName returns ComplexInlineFragmentsRepeatedStuffArticle.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetName() string { return v.Name }
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetText returns ComplexInlineFragmentsRepeatedStuffArticle.Text, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetText() string { return v.Text }
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetText() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Text
+}
 
 // GetOtherName returns ComplexInlineFragmentsRepeatedStuffArticle.OtherName, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherName() string { return v.OtherName }
+func (v *ComplexInlineFragmentsRepeatedStuffArticle) GetOtherName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.OtherName
+}
 
 // ComplexInlineFragmentsRepeatedStuffContent includes the requested fields of the GraphQL interface Content.
 //
@@ -1090,22 +1305,52 @@ type ComplexInlineFragmentsRepeatedStuffTopic struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsRepeatedStuffTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsRepeatedStuffTopic.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetUrl returns ComplexInlineFragmentsRepeatedStuffTopic.Url, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetUrl() string { return v.Url }
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // GetOtherId returns ComplexInlineFragmentsRepeatedStuffTopic.OtherId, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherId() testutil.ID { return v.OtherId }
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.OtherId
+}
 
 // GetName returns ComplexInlineFragmentsRepeatedStuffTopic.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetName() string { return v.Name }
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetOtherName returns ComplexInlineFragmentsRepeatedStuffTopic.OtherName, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherName() string { return v.OtherName }
+func (v *ComplexInlineFragmentsRepeatedStuffTopic) GetOtherName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.OtherName
+}
 
 // ComplexInlineFragmentsRepeatedStuffVideo includes the requested fields of the GraphQL type Video.
 type ComplexInlineFragmentsRepeatedStuffVideo struct {
@@ -1121,25 +1366,60 @@ type ComplexInlineFragmentsRepeatedStuffVideo struct {
 }
 
 // GetTypename returns ComplexInlineFragmentsRepeatedStuffVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetTypename() string { return v.Typename }
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ComplexInlineFragmentsRepeatedStuffVideo.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetUrl returns ComplexInlineFragmentsRepeatedStuffVideo.Url, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetUrl() string { return v.Url }
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // GetOtherId returns ComplexInlineFragmentsRepeatedStuffVideo.OtherId, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherId() testutil.ID { return v.OtherId }
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.OtherId
+}
 
 // GetName returns ComplexInlineFragmentsRepeatedStuffVideo.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetName() string { return v.Name }
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetOtherName returns ComplexInlineFragmentsRepeatedStuffVideo.OtherName, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherName() string { return v.OtherName }
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetOtherName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.OtherName
+}
 
 // GetDuration returns ComplexInlineFragmentsRepeatedStuffVideo.Duration, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetDuration() int { return v.Duration }
+func (v *ComplexInlineFragmentsRepeatedStuffVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Duration
+}
 
 // ComplexInlineFragmentsResponse is returned by ComplexInlineFragments on success.
 type ComplexInlineFragmentsResponse struct {
@@ -1151,25 +1431,42 @@ type ComplexInlineFragmentsResponse struct {
 }
 
 // GetRoot returns ComplexInlineFragmentsResponse.Root, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsResponse) GetRoot() ComplexInlineFragmentsRootTopic { return v.Root }
+func (v *ComplexInlineFragmentsResponse) GetRoot() (val ComplexInlineFragmentsRootTopic) {
+	if v == nil {
+		return
+	}
+	return v.Root
+}
 
 // GetRandomItem returns ComplexInlineFragmentsResponse.RandomItem, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsResponse) GetRandomItem() ComplexInlineFragmentsRandomItemContent {
+func (v *ComplexInlineFragmentsResponse) GetRandomItem() (val ComplexInlineFragmentsRandomItemContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomItem
 }
 
 // GetRepeatedStuff returns ComplexInlineFragmentsResponse.RepeatedStuff, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsResponse) GetRepeatedStuff() ComplexInlineFragmentsRepeatedStuffContent {
+func (v *ComplexInlineFragmentsResponse) GetRepeatedStuff() (val ComplexInlineFragmentsRepeatedStuffContent) {
+	if v == nil {
+		return
+	}
 	return v.RepeatedStuff
 }
 
 // GetConflictingStuff returns ComplexInlineFragmentsResponse.ConflictingStuff, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsResponse) GetConflictingStuff() ComplexInlineFragmentsConflictingStuffContent {
+func (v *ComplexInlineFragmentsResponse) GetConflictingStuff() (val ComplexInlineFragmentsConflictingStuffContent) {
+	if v == nil {
+		return
+	}
 	return v.ConflictingStuff
 }
 
 // GetNestedStuff returns ComplexInlineFragmentsResponse.NestedStuff, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsResponse) GetNestedStuff() ComplexInlineFragmentsNestedStuffContent {
+func (v *ComplexInlineFragmentsResponse) GetNestedStuff() (val ComplexInlineFragmentsNestedStuffContent) {
+	if v == nil {
+		return
+	}
 	return v.NestedStuff
 }
 
@@ -1332,13 +1629,28 @@ type ComplexInlineFragmentsRootTopic struct {
 }
 
 // GetId returns ComplexInlineFragmentsRootTopic.Id, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRootTopic) GetId() testutil.ID { return v.Id }
+func (v *ComplexInlineFragmentsRootTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetSchoolGrade returns ComplexInlineFragmentsRootTopic.SchoolGrade, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRootTopic) GetSchoolGrade() string { return v.SchoolGrade }
+func (v *ComplexInlineFragmentsRootTopic) GetSchoolGrade() (val string) {
+	if v == nil {
+		return
+	}
+	return v.SchoolGrade
+}
 
 // GetName returns ComplexInlineFragmentsRootTopic.Name, and is useful for accessing the field via an interface.
-func (v *ComplexInlineFragmentsRootTopic) GetName() string { return v.Name }
+func (v *ComplexInlineFragmentsRootTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by ComplexInlineFragments.
 const ComplexInlineFragments_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ComplexNamedFragments.graphql-ComplexNamedFragments.graphql.go
@@ -16,17 +16,26 @@ type ComplexNamedFragmentsResponse struct {
 }
 
 // GetRandomItem returns ComplexNamedFragmentsResponse.RandomItem, and is useful for accessing the field via an interface.
-func (v *ComplexNamedFragmentsResponse) GetRandomItem() InnerQueryFragmentRandomItemContent {
+func (v *ComplexNamedFragmentsResponse) GetRandomItem() (val InnerQueryFragmentRandomItemContent) {
+	if v == nil {
+		return
+	}
 	return v.QueryFragment.InnerQueryFragment.RandomItem
 }
 
 // GetRandomLeaf returns ComplexNamedFragmentsResponse.RandomLeaf, and is useful for accessing the field via an interface.
-func (v *ComplexNamedFragmentsResponse) GetRandomLeaf() InnerQueryFragmentRandomLeafLeafContent {
+func (v *ComplexNamedFragmentsResponse) GetRandomLeaf() (val InnerQueryFragmentRandomLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.QueryFragment.InnerQueryFragment.RandomLeaf
 }
 
 // GetOtherLeaf returns ComplexNamedFragmentsResponse.OtherLeaf, and is useful for accessing the field via an interface.
-func (v *ComplexNamedFragmentsResponse) GetOtherLeaf() InnerQueryFragmentOtherLeafLeafContent {
+func (v *ComplexNamedFragmentsResponse) GetOtherLeaf() (val InnerQueryFragmentOtherLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.QueryFragment.InnerQueryFragment.OtherLeaf
 }
 
@@ -124,12 +133,18 @@ type ComplexNamedFragmentsWithInlineUnionResponse struct {
 }
 
 // GetUser returns ComplexNamedFragmentsWithInlineUnionResponse.User, and is useful for accessing the field via an interface.
-func (v *ComplexNamedFragmentsWithInlineUnionResponse) GetUser() ComplexNamedFragmentsWithInlineUnionUser {
+func (v *ComplexNamedFragmentsWithInlineUnionResponse) GetUser() (val ComplexNamedFragmentsWithInlineUnionUser) {
+	if v == nil {
+		return
+	}
 	return v.User
 }
 
 // GetRoot returns ComplexNamedFragmentsWithInlineUnionResponse.Root, and is useful for accessing the field via an interface.
-func (v *ComplexNamedFragmentsWithInlineUnionResponse) GetRoot() ComplexNamedFragmentsWithInlineUnionRootTopic {
+func (v *ComplexNamedFragmentsWithInlineUnionResponse) GetRoot() (val ComplexNamedFragmentsWithInlineUnionRootTopic) {
+	if v == nil {
+		return
+	}
 	return v.Root
 }
 
@@ -139,7 +154,10 @@ type ComplexNamedFragmentsWithInlineUnionRootTopic struct {
 }
 
 // GetNewestContent returns ComplexNamedFragmentsWithInlineUnionRootTopic.NewestContent, and is useful for accessing the field via an interface.
-func (v *ComplexNamedFragmentsWithInlineUnionRootTopic) GetNewestContent() TopicNewestContentNewestContentLeafContent {
+func (v *ComplexNamedFragmentsWithInlineUnionRootTopic) GetNewestContent() (val TopicNewestContentNewestContentLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.TopicNewestContent.NewestContent
 }
 
@@ -207,7 +225,10 @@ type ComplexNamedFragmentsWithInlineUnionUser struct {
 }
 
 // GetLastContent returns ComplexNamedFragmentsWithInlineUnionUser.LastContent, and is useful for accessing the field via an interface.
-func (v *ComplexNamedFragmentsWithInlineUnionUser) GetLastContent() UserLastContentLastContentLeafContent {
+func (v *ComplexNamedFragmentsWithInlineUnionUser) GetLastContent() (val UserLastContentLastContentLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.UserLastContent.LastContent
 }
 
@@ -365,10 +386,20 @@ type ContentFieldsArticle struct {
 }
 
 // GetName returns ContentFieldsArticle.Name, and is useful for accessing the field via an interface.
-func (v *ContentFieldsArticle) GetName() string { return v.Name }
+func (v *ContentFieldsArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns ContentFieldsArticle.Url, and is useful for accessing the field via an interface.
-func (v *ContentFieldsArticle) GetUrl() string { return v.Url }
+func (v *ContentFieldsArticle) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // ContentFields includes the GraphQL fields of Topic requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -380,10 +411,20 @@ type ContentFieldsTopic struct {
 }
 
 // GetName returns ContentFieldsTopic.Name, and is useful for accessing the field via an interface.
-func (v *ContentFieldsTopic) GetName() string { return v.Name }
+func (v *ContentFieldsTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns ContentFieldsTopic.Url, and is useful for accessing the field via an interface.
-func (v *ContentFieldsTopic) GetUrl() string { return v.Url }
+func (v *ContentFieldsTopic) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // ContentFields includes the GraphQL fields of Video requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -395,10 +436,20 @@ type ContentFieldsVideo struct {
 }
 
 // GetName returns ContentFieldsVideo.Name, and is useful for accessing the field via an interface.
-func (v *ContentFieldsVideo) GetName() string { return v.Name }
+func (v *ContentFieldsVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns ContentFieldsVideo.Url, and is useful for accessing the field via an interface.
-func (v *ContentFieldsVideo) GetUrl() string { return v.Url }
+func (v *ContentFieldsVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // InnerQueryFragment includes the GraphQL fields of Query requested by the fragment InnerQueryFragment.
 // The GraphQL type's documentation follows.
@@ -411,15 +462,26 @@ type InnerQueryFragment struct {
 }
 
 // GetRandomItem returns InnerQueryFragment.RandomItem, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragment) GetRandomItem() InnerQueryFragmentRandomItemContent { return v.RandomItem }
+func (v *InnerQueryFragment) GetRandomItem() (val InnerQueryFragmentRandomItemContent) {
+	if v == nil {
+		return
+	}
+	return v.RandomItem
+}
 
 // GetRandomLeaf returns InnerQueryFragment.RandomLeaf, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragment) GetRandomLeaf() InnerQueryFragmentRandomLeafLeafContent {
+func (v *InnerQueryFragment) GetRandomLeaf() (val InnerQueryFragmentRandomLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomLeaf
 }
 
 // GetOtherLeaf returns InnerQueryFragment.OtherLeaf, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragment) GetOtherLeaf() InnerQueryFragmentOtherLeafLeafContent {
+func (v *InnerQueryFragment) GetOtherLeaf() (val InnerQueryFragmentOtherLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.OtherLeaf
 }
 
@@ -549,13 +611,28 @@ type InnerQueryFragmentOtherLeafArticle struct {
 }
 
 // GetTypename returns InnerQueryFragmentOtherLeafArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafArticle) GetTypename() string { return v.Typename }
+func (v *InnerQueryFragmentOtherLeafArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetName returns InnerQueryFragmentOtherLeafArticle.Name, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafArticle) GetName() string { return v.ContentFieldsArticle.Name }
+func (v *InnerQueryFragmentOtherLeafArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsArticle.Name
+}
 
 // GetUrl returns InnerQueryFragmentOtherLeafArticle.Url, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafArticle) GetUrl() string { return v.ContentFieldsArticle.Url }
+func (v *InnerQueryFragmentOtherLeafArticle) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsArticle.Url
+}
 
 func (v *InnerQueryFragmentOtherLeafArticle) UnmarshalJSON(b []byte) error {
 
@@ -699,21 +776,44 @@ type InnerQueryFragmentOtherLeafVideo struct {
 }
 
 // GetTypename returns InnerQueryFragmentOtherLeafVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafVideo) GetTypename() string { return v.Typename }
+func (v *InnerQueryFragmentOtherLeafVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InnerQueryFragmentOtherLeafVideo.Id, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafVideo) GetId() *testutil.ID { return v.MoreVideoFields.Id }
+func (v *InnerQueryFragmentOtherLeafVideo) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.MoreVideoFields.Id
+}
 
 // GetParent returns InnerQueryFragmentOtherLeafVideo.Parent, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafVideo) GetParent() *MoreVideoFieldsParentTopic {
+func (v *InnerQueryFragmentOtherLeafVideo) GetParent() (val *MoreVideoFieldsParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.MoreVideoFields.Parent
 }
 
 // GetName returns InnerQueryFragmentOtherLeafVideo.Name, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafVideo) GetName() string { return v.ContentFieldsVideo.Name }
+func (v *InnerQueryFragmentOtherLeafVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsVideo.Name
+}
 
 // GetUrl returns InnerQueryFragmentOtherLeafVideo.Url, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentOtherLeafVideo) GetUrl() string { return v.ContentFieldsVideo.Url }
+func (v *InnerQueryFragmentOtherLeafVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsVideo.Url
+}
 
 func (v *InnerQueryFragmentOtherLeafVideo) UnmarshalJSON(b []byte) error {
 
@@ -786,16 +886,36 @@ type InnerQueryFragmentRandomItemArticle struct {
 }
 
 // GetTypename returns InnerQueryFragmentRandomItemArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemArticle) GetTypename() string { return v.Typename }
+func (v *InnerQueryFragmentRandomItemArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InnerQueryFragmentRandomItemArticle.Id, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
+func (v *InnerQueryFragmentRandomItemArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InnerQueryFragmentRandomItemArticle.Name, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemArticle) GetName() string { return v.Name }
+func (v *InnerQueryFragmentRandomItemArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns InnerQueryFragmentRandomItemArticle.Url, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemArticle) GetUrl() string { return v.ContentFieldsArticle.Url }
+func (v *InnerQueryFragmentRandomItemArticle) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsArticle.Url
+}
 
 func (v *InnerQueryFragmentRandomItemArticle) UnmarshalJSON(b []byte) error {
 
@@ -970,16 +1090,36 @@ type InnerQueryFragmentRandomItemTopic struct {
 }
 
 // GetTypename returns InnerQueryFragmentRandomItemTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemTopic) GetTypename() string { return v.Typename }
+func (v *InnerQueryFragmentRandomItemTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InnerQueryFragmentRandomItemTopic.Id, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
+func (v *InnerQueryFragmentRandomItemTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InnerQueryFragmentRandomItemTopic.Name, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemTopic) GetName() string { return v.Name }
+func (v *InnerQueryFragmentRandomItemTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns InnerQueryFragmentRandomItemTopic.Url, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemTopic) GetUrl() string { return v.ContentFieldsTopic.Url }
+func (v *InnerQueryFragmentRandomItemTopic) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsTopic.Url
+}
 
 func (v *InnerQueryFragmentRandomItemTopic) UnmarshalJSON(b []byte) error {
 
@@ -1045,22 +1185,50 @@ type InnerQueryFragmentRandomItemVideo struct {
 }
 
 // GetTypename returns InnerQueryFragmentRandomItemVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemVideo) GetTypename() string { return v.Typename }
+func (v *InnerQueryFragmentRandomItemVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InnerQueryFragmentRandomItemVideo.Id, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
+func (v *InnerQueryFragmentRandomItemVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InnerQueryFragmentRandomItemVideo.Name, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemVideo) GetName() string { return v.Name }
+func (v *InnerQueryFragmentRandomItemVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns InnerQueryFragmentRandomItemVideo.Url, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemVideo) GetUrl() string { return v.VideoFields.Url }
+func (v *InnerQueryFragmentRandomItemVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Url
+}
 
 // GetDuration returns InnerQueryFragmentRandomItemVideo.Duration, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemVideo) GetDuration() int { return v.VideoFields.Duration }
+func (v *InnerQueryFragmentRandomItemVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Duration
+}
 
 // GetThumbnail returns InnerQueryFragmentRandomItemVideo.Thumbnail, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomItemVideo) GetThumbnail() VideoFieldsThumbnail {
+func (v *InnerQueryFragmentRandomItemVideo) GetThumbnail() (val VideoFieldsThumbnail) {
+	if v == nil {
+		return
+	}
 	return v.VideoFields.Thumbnail
 }
 
@@ -1135,13 +1303,28 @@ type InnerQueryFragmentRandomLeafArticle struct {
 }
 
 // GetTypename returns InnerQueryFragmentRandomLeafArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafArticle) GetTypename() string { return v.Typename }
+func (v *InnerQueryFragmentRandomLeafArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetName returns InnerQueryFragmentRandomLeafArticle.Name, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafArticle) GetName() string { return v.ContentFieldsArticle.Name }
+func (v *InnerQueryFragmentRandomLeafArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsArticle.Name
+}
 
 // GetUrl returns InnerQueryFragmentRandomLeafArticle.Url, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafArticle) GetUrl() string { return v.ContentFieldsArticle.Url }
+func (v *InnerQueryFragmentRandomLeafArticle) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.ContentFieldsArticle.Url
+}
 
 func (v *InnerQueryFragmentRandomLeafArticle) UnmarshalJSON(b []byte) error {
 
@@ -1286,27 +1469,58 @@ type InnerQueryFragmentRandomLeafVideo struct {
 }
 
 // GetTypename returns InnerQueryFragmentRandomLeafVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafVideo) GetTypename() string { return v.Typename }
+func (v *InnerQueryFragmentRandomLeafVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InnerQueryFragmentRandomLeafVideo.Id, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafVideo) GetId() testutil.ID { return v.VideoFields.Id }
+func (v *InnerQueryFragmentRandomLeafVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Id
+}
 
 // GetName returns InnerQueryFragmentRandomLeafVideo.Name, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafVideo) GetName() string { return v.VideoFields.Name }
+func (v *InnerQueryFragmentRandomLeafVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Name
+}
 
 // GetUrl returns InnerQueryFragmentRandomLeafVideo.Url, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafVideo) GetUrl() string { return v.VideoFields.Url }
+func (v *InnerQueryFragmentRandomLeafVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Url
+}
 
 // GetDuration returns InnerQueryFragmentRandomLeafVideo.Duration, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafVideo) GetDuration() int { return v.VideoFields.Duration }
+func (v *InnerQueryFragmentRandomLeafVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Duration
+}
 
 // GetThumbnail returns InnerQueryFragmentRandomLeafVideo.Thumbnail, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafVideo) GetThumbnail() VideoFieldsThumbnail {
+func (v *InnerQueryFragmentRandomLeafVideo) GetThumbnail() (val VideoFieldsThumbnail) {
+	if v == nil {
+		return
+	}
 	return v.VideoFields.Thumbnail
 }
 
 // GetParent returns InnerQueryFragmentRandomLeafVideo.Parent, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragmentRandomLeafVideo) GetParent() *MoreVideoFieldsParentTopic {
+func (v *InnerQueryFragmentRandomLeafVideo) GetParent() (val *MoreVideoFieldsParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.MoreVideoFields.Parent
 }
 
@@ -1390,10 +1604,20 @@ type MoreVideoFields struct {
 }
 
 // GetId returns MoreVideoFields.Id, and is useful for accessing the field via an interface.
-func (v *MoreVideoFields) GetId() *testutil.ID { return v.Id }
+func (v *MoreVideoFields) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetParent returns MoreVideoFields.Parent, and is useful for accessing the field via an interface.
-func (v *MoreVideoFields) GetParent() *MoreVideoFieldsParentTopic { return v.Parent }
+func (v *MoreVideoFields) GetParent() (val *MoreVideoFieldsParentTopic) {
+	if v == nil {
+		return
+	}
+	return v.Parent
+}
 
 // MoreVideoFieldsParentTopic includes the requested fields of the GraphQL type Topic.
 type MoreVideoFieldsParentTopic struct {
@@ -1404,13 +1628,26 @@ type MoreVideoFieldsParentTopic struct {
 }
 
 // GetName returns MoreVideoFieldsParentTopic.Name, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopic) GetName() *string { return v.Name }
+func (v *MoreVideoFieldsParentTopic) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns MoreVideoFieldsParentTopic.Url, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopic) GetUrl() *string { return v.Url }
+func (v *MoreVideoFieldsParentTopic) GetUrl() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // GetChildren returns MoreVideoFieldsParentTopic.Children, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopic) GetChildren() []MoreVideoFieldsParentTopicChildrenContent {
+func (v *MoreVideoFieldsParentTopic) GetChildren() (val []MoreVideoFieldsParentTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -1507,7 +1744,12 @@ type MoreVideoFieldsParentTopicChildrenArticle struct {
 }
 
 // GetTypename returns MoreVideoFieldsParentTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenArticle) GetTypename() *string { return v.Typename }
+func (v *MoreVideoFieldsParentTopicChildrenArticle) GetTypename() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // MoreVideoFieldsParentTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
@@ -1609,7 +1851,12 @@ type MoreVideoFieldsParentTopicChildrenTopic struct {
 }
 
 // GetTypename returns MoreVideoFieldsParentTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenTopic) GetTypename() *string { return v.Typename }
+func (v *MoreVideoFieldsParentTopicChildrenTopic) GetTypename() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // MoreVideoFieldsParentTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type MoreVideoFieldsParentTopicChildrenVideo struct {
@@ -1618,22 +1865,50 @@ type MoreVideoFieldsParentTopicChildrenVideo struct {
 }
 
 // GetTypename returns MoreVideoFieldsParentTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenVideo) GetTypename() *string { return v.Typename }
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetTypename() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns MoreVideoFieldsParentTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenVideo) GetId() testutil.ID { return v.VideoFields.Id }
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Id
+}
 
 // GetName returns MoreVideoFieldsParentTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenVideo) GetName() string { return v.VideoFields.Name }
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Name
+}
 
 // GetUrl returns MoreVideoFieldsParentTopicChildrenVideo.Url, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenVideo) GetUrl() string { return v.VideoFields.Url }
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Url
+}
 
 // GetDuration returns MoreVideoFieldsParentTopicChildrenVideo.Duration, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenVideo) GetDuration() int { return v.VideoFields.Duration }
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Duration
+}
 
 // GetThumbnail returns MoreVideoFieldsParentTopicChildrenVideo.Thumbnail, and is useful for accessing the field via an interface.
-func (v *MoreVideoFieldsParentTopicChildrenVideo) GetThumbnail() VideoFieldsThumbnail {
+func (v *MoreVideoFieldsParentTopicChildrenVideo) GetThumbnail() (val VideoFieldsThumbnail) {
+	if v == nil {
+		return
+	}
 	return v.VideoFields.Thumbnail
 }
 
@@ -1705,17 +1980,26 @@ type QueryFragment struct {
 }
 
 // GetRandomItem returns QueryFragment.RandomItem, and is useful for accessing the field via an interface.
-func (v *QueryFragment) GetRandomItem() InnerQueryFragmentRandomItemContent {
+func (v *QueryFragment) GetRandomItem() (val InnerQueryFragmentRandomItemContent) {
+	if v == nil {
+		return
+	}
 	return v.InnerQueryFragment.RandomItem
 }
 
 // GetRandomLeaf returns QueryFragment.RandomLeaf, and is useful for accessing the field via an interface.
-func (v *QueryFragment) GetRandomLeaf() InnerQueryFragmentRandomLeafLeafContent {
+func (v *QueryFragment) GetRandomLeaf() (val InnerQueryFragmentRandomLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.InnerQueryFragment.RandomLeaf
 }
 
 // GetOtherLeaf returns QueryFragment.OtherLeaf, and is useful for accessing the field via an interface.
-func (v *QueryFragment) GetOtherLeaf() InnerQueryFragmentOtherLeafLeafContent {
+func (v *QueryFragment) GetOtherLeaf() (val InnerQueryFragmentOtherLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.InnerQueryFragment.OtherLeaf
 }
 
@@ -1878,7 +2162,12 @@ type SimpleLeafContentArticle struct {
 }
 
 // GetId returns SimpleLeafContentArticle.Id, and is useful for accessing the field via an interface.
-func (v *SimpleLeafContentArticle) GetId() testutil.ID { return v.Id }
+func (v *SimpleLeafContentArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // # two fragments of different types with fields containing the same inline named fragment of a union
 type SimpleLeafContentVideo struct {
@@ -1887,7 +2176,12 @@ type SimpleLeafContentVideo struct {
 }
 
 // GetId returns SimpleLeafContentVideo.Id, and is useful for accessing the field via an interface.
-func (v *SimpleLeafContentVideo) GetId() testutil.ID { return v.Id }
+func (v *SimpleLeafContentVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // TopicNewestContent includes the GraphQL fields of Topic requested by the fragment TopicNewestContent.
 type TopicNewestContent struct {
@@ -1895,7 +2189,10 @@ type TopicNewestContent struct {
 }
 
 // GetNewestContent returns TopicNewestContent.NewestContent, and is useful for accessing the field via an interface.
-func (v *TopicNewestContent) GetNewestContent() TopicNewestContentNewestContentLeafContent {
+func (v *TopicNewestContent) GetNewestContent() (val TopicNewestContentNewestContentLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.NewestContent
 }
 
@@ -1969,10 +2266,18 @@ type TopicNewestContentNewestContentArticle struct {
 }
 
 // GetTypename returns TopicNewestContentNewestContentArticle.Typename, and is useful for accessing the field via an interface.
-func (v *TopicNewestContentNewestContentArticle) GetTypename() string { return v.Typename }
+func (v *TopicNewestContentNewestContentArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns TopicNewestContentNewestContentArticle.Id, and is useful for accessing the field via an interface.
-func (v *TopicNewestContentNewestContentArticle) GetId() testutil.ID {
+func (v *TopicNewestContentNewestContentArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.SimpleLeafContentArticle.Id
 }
 
@@ -2115,10 +2420,18 @@ type TopicNewestContentNewestContentVideo struct {
 }
 
 // GetTypename returns TopicNewestContentNewestContentVideo.Typename, and is useful for accessing the field via an interface.
-func (v *TopicNewestContentNewestContentVideo) GetTypename() string { return v.Typename }
+func (v *TopicNewestContentNewestContentVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns TopicNewestContentNewestContentVideo.Id, and is useful for accessing the field via an interface.
-func (v *TopicNewestContentNewestContentVideo) GetId() testutil.ID {
+func (v *TopicNewestContentNewestContentVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.SimpleLeafContentVideo.Id
 }
 
@@ -2178,7 +2491,10 @@ type UserLastContent struct {
 }
 
 // GetLastContent returns UserLastContent.LastContent, and is useful for accessing the field via an interface.
-func (v *UserLastContent) GetLastContent() UserLastContentLastContentLeafContent {
+func (v *UserLastContent) GetLastContent() (val UserLastContentLastContentLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.LastContent
 }
 
@@ -2252,10 +2568,20 @@ type UserLastContentLastContentArticle struct {
 }
 
 // GetTypename returns UserLastContentLastContentArticle.Typename, and is useful for accessing the field via an interface.
-func (v *UserLastContentLastContentArticle) GetTypename() string { return v.Typename }
+func (v *UserLastContentLastContentArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns UserLastContentLastContentArticle.Id, and is useful for accessing the field via an interface.
-func (v *UserLastContentLastContentArticle) GetId() testutil.ID { return v.SimpleLeafContentArticle.Id }
+func (v *UserLastContentLastContentArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.SimpleLeafContentArticle.Id
+}
 
 func (v *UserLastContentLastContentArticle) UnmarshalJSON(b []byte) error {
 
@@ -2396,10 +2722,20 @@ type UserLastContentLastContentVideo struct {
 }
 
 // GetTypename returns UserLastContentLastContentVideo.Typename, and is useful for accessing the field via an interface.
-func (v *UserLastContentLastContentVideo) GetTypename() string { return v.Typename }
+func (v *UserLastContentLastContentVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns UserLastContentLastContentVideo.Id, and is useful for accessing the field via an interface.
-func (v *UserLastContentLastContentVideo) GetId() testutil.ID { return v.SimpleLeafContentVideo.Id }
+func (v *UserLastContentLastContentVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.SimpleLeafContentVideo.Id
+}
 
 func (v *UserLastContentLastContentVideo) UnmarshalJSON(b []byte) error {
 
@@ -2460,19 +2796,44 @@ type VideoFields struct {
 }
 
 // GetId returns VideoFields.Id, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetId() testutil.ID { return v.Id }
+func (v *VideoFields) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns VideoFields.Name, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetName() string { return v.Name }
+func (v *VideoFields) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns VideoFields.Url, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetUrl() string { return v.Url }
+func (v *VideoFields) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // GetDuration returns VideoFields.Duration, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetDuration() int { return v.Duration }
+func (v *VideoFields) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Duration
+}
 
 // GetThumbnail returns VideoFields.Thumbnail, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetThumbnail() VideoFieldsThumbnail { return v.Thumbnail }
+func (v *VideoFields) GetThumbnail() (val VideoFieldsThumbnail) {
+	if v == nil {
+		return
+	}
+	return v.Thumbnail
+}
 
 func (v *VideoFields) UnmarshalJSON(b []byte) error {
 
@@ -2536,7 +2897,12 @@ type VideoFieldsThumbnail struct {
 }
 
 // GetId returns VideoFieldsThumbnail.Id, and is useful for accessing the field via an interface.
-func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
+func (v *VideoFieldsThumbnail) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by ComplexNamedFragments.
 const ComplexNamedFragments_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CovariantInterfaceImplementation.graphql-CovariantInterfaceImplementation.graphql.go
@@ -121,10 +121,20 @@ type ContentFieldsArticle struct {
 }
 
 // GetNext returns ContentFieldsArticle.Next, and is useful for accessing the field via an interface.
-func (v *ContentFieldsArticle) GetNext() ContentFieldsNextContent { return v.Next }
+func (v *ContentFieldsArticle) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
+	return v.Next
+}
 
 // GetRelated returns ContentFieldsArticle.Related, and is useful for accessing the field via an interface.
-func (v *ContentFieldsArticle) GetRelated() []ContentFieldsRelatedContent { return v.Related }
+func (v *ContentFieldsArticle) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
+	return v.Related
+}
 
 func (v *ContentFieldsArticle) UnmarshalJSON(b []byte) error {
 
@@ -237,10 +247,20 @@ type ContentFieldsNextArticle struct {
 }
 
 // GetTypename returns ContentFieldsNextArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ContentFieldsNextArticle) GetTypename() string { return v.Typename }
+func (v *ContentFieldsNextArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ContentFieldsNextArticle.Id, and is useful for accessing the field via an interface.
-func (v *ContentFieldsNextArticle) GetId() testutil.ID { return v.Id }
+func (v *ContentFieldsNextArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ContentFieldsNextContent includes the requested fields of the GraphQL interface Content.
 //
@@ -342,10 +362,20 @@ type ContentFieldsNextTopic struct {
 }
 
 // GetTypename returns ContentFieldsNextTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ContentFieldsNextTopic) GetTypename() string { return v.Typename }
+func (v *ContentFieldsNextTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ContentFieldsNextTopic.Id, and is useful for accessing the field via an interface.
-func (v *ContentFieldsNextTopic) GetId() testutil.ID { return v.Id }
+func (v *ContentFieldsNextTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ContentFieldsNextVideo includes the requested fields of the GraphQL type Video.
 type ContentFieldsNextVideo struct {
@@ -355,10 +385,20 @@ type ContentFieldsNextVideo struct {
 }
 
 // GetTypename returns ContentFieldsNextVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ContentFieldsNextVideo) GetTypename() string { return v.Typename }
+func (v *ContentFieldsNextVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ContentFieldsNextVideo.Id, and is useful for accessing the field via an interface.
-func (v *ContentFieldsNextVideo) GetId() testutil.ID { return v.Id }
+func (v *ContentFieldsNextVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ContentFieldsRelatedArticle includes the requested fields of the GraphQL type Article.
 type ContentFieldsRelatedArticle struct {
@@ -368,10 +408,20 @@ type ContentFieldsRelatedArticle struct {
 }
 
 // GetTypename returns ContentFieldsRelatedArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ContentFieldsRelatedArticle) GetTypename() string { return v.Typename }
+func (v *ContentFieldsRelatedArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ContentFieldsRelatedArticle.Id, and is useful for accessing the field via an interface.
-func (v *ContentFieldsRelatedArticle) GetId() testutil.ID { return v.Id }
+func (v *ContentFieldsRelatedArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ContentFieldsRelatedContent includes the requested fields of the GraphQL interface Content.
 //
@@ -473,10 +523,20 @@ type ContentFieldsRelatedTopic struct {
 }
 
 // GetTypename returns ContentFieldsRelatedTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ContentFieldsRelatedTopic) GetTypename() string { return v.Typename }
+func (v *ContentFieldsRelatedTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ContentFieldsRelatedTopic.Id, and is useful for accessing the field via an interface.
-func (v *ContentFieldsRelatedTopic) GetId() testutil.ID { return v.Id }
+func (v *ContentFieldsRelatedTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ContentFieldsRelatedVideo includes the requested fields of the GraphQL type Video.
 type ContentFieldsRelatedVideo struct {
@@ -486,10 +546,20 @@ type ContentFieldsRelatedVideo struct {
 }
 
 // GetTypename returns ContentFieldsRelatedVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ContentFieldsRelatedVideo) GetTypename() string { return v.Typename }
+func (v *ContentFieldsRelatedVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ContentFieldsRelatedVideo.Id, and is useful for accessing the field via an interface.
-func (v *ContentFieldsRelatedVideo) GetId() testutil.ID { return v.Id }
+func (v *ContentFieldsRelatedVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // ContentFields includes the GraphQL fields of Topic requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -501,10 +571,20 @@ type ContentFieldsTopic struct {
 }
 
 // GetNext returns ContentFieldsTopic.Next, and is useful for accessing the field via an interface.
-func (v *ContentFieldsTopic) GetNext() ContentFieldsNextContent { return v.Next }
+func (v *ContentFieldsTopic) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
+	return v.Next
+}
 
 // GetRelated returns ContentFieldsTopic.Related, and is useful for accessing the field via an interface.
-func (v *ContentFieldsTopic) GetRelated() []ContentFieldsRelatedContent { return v.Related }
+func (v *ContentFieldsTopic) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
+	return v.Related
+}
 
 func (v *ContentFieldsTopic) UnmarshalJSON(b []byte) error {
 
@@ -619,10 +699,20 @@ type ContentFieldsVideo struct {
 }
 
 // GetNext returns ContentFieldsVideo.Next, and is useful for accessing the field via an interface.
-func (v *ContentFieldsVideo) GetNext() ContentFieldsNextContent { return v.Next }
+func (v *ContentFieldsVideo) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
+	return v.Next
+}
 
 // GetRelated returns ContentFieldsVideo.Related, and is useful for accessing the field via an interface.
-func (v *ContentFieldsVideo) GetRelated() []ContentFieldsRelatedContent { return v.Related }
+func (v *ContentFieldsVideo) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
+	return v.Related
+}
 
 func (v *ContentFieldsVideo) UnmarshalJSON(b []byte) error {
 
@@ -737,18 +827,34 @@ type CovariantInterfaceImplementationRandomItemArticle struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemArticle.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemArticle) GetTypename() string { return v.Typename }
+func (v *CovariantInterfaceImplementationRandomItemArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns CovariantInterfaceImplementationRandomItemArticle.Id, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemArticle) GetId() testutil.ID { return v.Id }
+func (v *CovariantInterfaceImplementationRandomItemArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetNext returns CovariantInterfaceImplementationRandomItemArticle.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemArticle) GetNext() CovariantInterfaceImplementationRandomItemContentNextContent {
+func (v *CovariantInterfaceImplementationRandomItemArticle) GetNext() (val CovariantInterfaceImplementationRandomItemContentNextContent) {
+	if v == nil {
+		return
+	}
 	return v.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemArticle.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemArticle) GetRelated() []CovariantInterfaceImplementationRandomItemContentRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemArticle) GetRelated() (val []CovariantInterfaceImplementationRandomItemContentRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.Related
 }
 
@@ -979,17 +1085,26 @@ type CovariantInterfaceImplementationRandomItemContentNextArticle struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemContentNextArticle.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) GetTypename() string {
+func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetNext returns CovariantInterfaceImplementationRandomItemContentNextArticle.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) GetNext() ContentFieldsNextContent {
+func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsArticle.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemContentNextArticle.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) GetRelated() []ContentFieldsRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemContentNextArticle) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsArticle.Related
 }
 
@@ -1181,17 +1296,26 @@ type CovariantInterfaceImplementationRandomItemContentNextTopic struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemContentNextTopic.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) GetTypename() string {
+func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetNext returns CovariantInterfaceImplementationRandomItemContentNextTopic.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) GetNext() ContentFieldsNextContent {
+func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsTopic.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemContentNextTopic.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) GetRelated() []ContentFieldsRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemContentNextTopic) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsTopic.Related
 }
 
@@ -1280,17 +1404,26 @@ type CovariantInterfaceImplementationRandomItemContentNextVideo struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemContentNextVideo.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) GetTypename() string {
+func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetNext returns CovariantInterfaceImplementationRandomItemContentNextVideo.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) GetNext() ContentFieldsNextContent {
+func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsVideo.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemContentNextVideo.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) GetRelated() []ContentFieldsRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemContentNextVideo) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsVideo.Related
 }
 
@@ -1379,17 +1512,26 @@ type CovariantInterfaceImplementationRandomItemContentRelatedArticle struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemContentRelatedArticle.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) GetTypename() string {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetNext returns CovariantInterfaceImplementationRandomItemContentRelatedArticle.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) GetNext() ContentFieldsNextContent {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsArticle.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemContentRelatedArticle.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) GetRelated() []ContentFieldsRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedArticle) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsArticle.Related
 }
 
@@ -1581,17 +1723,26 @@ type CovariantInterfaceImplementationRandomItemContentRelatedTopic struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemContentRelatedTopic.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) GetTypename() string {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetNext returns CovariantInterfaceImplementationRandomItemContentRelatedTopic.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) GetNext() ContentFieldsNextContent {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsTopic.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemContentRelatedTopic.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) GetRelated() []ContentFieldsRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedTopic) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsTopic.Related
 }
 
@@ -1680,17 +1831,26 @@ type CovariantInterfaceImplementationRandomItemContentRelatedVideo struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemContentRelatedVideo.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) GetTypename() string {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetNext returns CovariantInterfaceImplementationRandomItemContentRelatedVideo.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) GetNext() ContentFieldsNextContent {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) GetNext() (val ContentFieldsNextContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsVideo.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemContentRelatedVideo.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) GetRelated() []ContentFieldsRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemContentRelatedVideo) GetRelated() (val []ContentFieldsRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.ContentFieldsVideo.Related
 }
 
@@ -1782,18 +1942,34 @@ type CovariantInterfaceImplementationRandomItemTopic struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemTopic.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemTopic) GetTypename() string { return v.Typename }
+func (v *CovariantInterfaceImplementationRandomItemTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns CovariantInterfaceImplementationRandomItemTopic.Id, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemTopic) GetId() testutil.ID { return v.Id }
+func (v *CovariantInterfaceImplementationRandomItemTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetNext returns CovariantInterfaceImplementationRandomItemTopic.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemTopic) GetNext() CovariantInterfaceImplementationRandomItemContentNextContent {
+func (v *CovariantInterfaceImplementationRandomItemTopic) GetNext() (val CovariantInterfaceImplementationRandomItemContentNextContent) {
+	if v == nil {
+		return
+	}
 	return v.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemTopic.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemTopic) GetRelated() []CovariantInterfaceImplementationRandomItemContentRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemTopic) GetRelated() (val []CovariantInterfaceImplementationRandomItemContentRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.Related
 }
 
@@ -1916,18 +2092,34 @@ type CovariantInterfaceImplementationRandomItemVideo struct {
 }
 
 // GetTypename returns CovariantInterfaceImplementationRandomItemVideo.Typename, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemVideo) GetTypename() string { return v.Typename }
+func (v *CovariantInterfaceImplementationRandomItemVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns CovariantInterfaceImplementationRandomItemVideo.Id, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemVideo) GetId() testutil.ID { return v.Id }
+func (v *CovariantInterfaceImplementationRandomItemVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetNext returns CovariantInterfaceImplementationRandomItemVideo.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemVideo) GetNext() CovariantInterfaceImplementationRandomItemContentNextContent {
+func (v *CovariantInterfaceImplementationRandomItemVideo) GetNext() (val CovariantInterfaceImplementationRandomItemContentNextContent) {
+	if v == nil {
+		return
+	}
 	return v.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRandomItemVideo.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRandomItemVideo) GetRelated() []CovariantInterfaceImplementationRandomItemContentRelatedContent {
+func (v *CovariantInterfaceImplementationRandomItemVideo) GetRelated() (val []CovariantInterfaceImplementationRandomItemContentRelatedContent) {
+	if v == nil {
+		return
+	}
 	return v.Related
 }
 
@@ -2047,12 +2239,18 @@ type CovariantInterfaceImplementationResponse struct {
 }
 
 // GetRandomItem returns CovariantInterfaceImplementationResponse.RandomItem, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationResponse) GetRandomItem() CovariantInterfaceImplementationRandomItemContent {
+func (v *CovariantInterfaceImplementationResponse) GetRandomItem() (val CovariantInterfaceImplementationRandomItemContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomItem
 }
 
 // GetRoot returns CovariantInterfaceImplementationResponse.Root, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationResponse) GetRoot() CovariantInterfaceImplementationRootTopic {
+func (v *CovariantInterfaceImplementationResponse) GetRoot() (val CovariantInterfaceImplementationRootTopic) {
+	if v == nil {
+		return
+	}
 	return v.Root
 }
 
@@ -2131,12 +2329,18 @@ type CovariantInterfaceImplementationRootTopic struct {
 }
 
 // GetNext returns CovariantInterfaceImplementationRootTopic.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRootTopic) GetNext() CovariantInterfaceImplementationRootTopicNextTopic {
+func (v *CovariantInterfaceImplementationRootTopic) GetNext() (val CovariantInterfaceImplementationRootTopicNextTopic) {
+	if v == nil {
+		return
+	}
 	return v.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRootTopic.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRootTopic) GetRelated() []CovariantInterfaceImplementationRootTopicRelatedTopic {
+func (v *CovariantInterfaceImplementationRootTopic) GetRelated() (val []CovariantInterfaceImplementationRootTopicRelatedTopic) {
+	if v == nil {
+		return
+	}
 	return v.Related
 }
 
@@ -2198,12 +2402,18 @@ type CovariantInterfaceImplementationRootTopicNextTopic struct {
 }
 
 // GetNext returns CovariantInterfaceImplementationRootTopicNextTopic.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRootTopicNextTopic) GetNext() TopicFieldsNextTopic {
+func (v *CovariantInterfaceImplementationRootTopicNextTopic) GetNext() (val TopicFieldsNextTopic) {
+	if v == nil {
+		return
+	}
 	return v.TopicFields.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRootTopicNextTopic.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRootTopicNextTopic) GetRelated() []TopicFieldsRelatedTopic {
+func (v *CovariantInterfaceImplementationRootTopicNextTopic) GetRelated() (val []TopicFieldsRelatedTopic) {
+	if v == nil {
+		return
+	}
 	return v.TopicFields.Related
 }
 
@@ -2260,12 +2470,18 @@ type CovariantInterfaceImplementationRootTopicRelatedTopic struct {
 }
 
 // GetNext returns CovariantInterfaceImplementationRootTopicRelatedTopic.Next, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRootTopicRelatedTopic) GetNext() TopicFieldsNextTopic {
+func (v *CovariantInterfaceImplementationRootTopicRelatedTopic) GetNext() (val TopicFieldsNextTopic) {
+	if v == nil {
+		return
+	}
 	return v.TopicFields.Next
 }
 
 // GetRelated returns CovariantInterfaceImplementationRootTopicRelatedTopic.Related, and is useful for accessing the field via an interface.
-func (v *CovariantInterfaceImplementationRootTopicRelatedTopic) GetRelated() []TopicFieldsRelatedTopic {
+func (v *CovariantInterfaceImplementationRootTopicRelatedTopic) GetRelated() (val []TopicFieldsRelatedTopic) {
+	if v == nil {
+		return
+	}
 	return v.TopicFields.Related
 }
 
@@ -2323,10 +2539,20 @@ type TopicFields struct {
 }
 
 // GetNext returns TopicFields.Next, and is useful for accessing the field via an interface.
-func (v *TopicFields) GetNext() TopicFieldsNextTopic { return v.Next }
+func (v *TopicFields) GetNext() (val TopicFieldsNextTopic) {
+	if v == nil {
+		return
+	}
+	return v.Next
+}
 
 // GetRelated returns TopicFields.Related, and is useful for accessing the field via an interface.
-func (v *TopicFields) GetRelated() []TopicFieldsRelatedTopic { return v.Related }
+func (v *TopicFields) GetRelated() (val []TopicFieldsRelatedTopic) {
+	if v == nil {
+		return
+	}
+	return v.Related
+}
 
 // TopicFieldsNextTopic includes the requested fields of the GraphQL type Topic.
 type TopicFieldsNextTopic struct {
@@ -2335,7 +2561,12 @@ type TopicFieldsNextTopic struct {
 }
 
 // GetId returns TopicFieldsNextTopic.Id, and is useful for accessing the field via an interface.
-func (v *TopicFieldsNextTopic) GetId() testutil.ID { return v.Id }
+func (v *TopicFieldsNextTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // TopicFieldsRelatedTopic includes the requested fields of the GraphQL type Topic.
 type TopicFieldsRelatedTopic struct {
@@ -2344,7 +2575,12 @@ type TopicFieldsRelatedTopic struct {
 }
 
 // GetId returns TopicFieldsRelatedTopic.Id, and is useful for accessing the field via an interface.
-func (v *TopicFieldsRelatedTopic) GetId() testutil.ID { return v.Id }
+func (v *TopicFieldsRelatedTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by CovariantInterfaceImplementation.
 const CovariantInterfaceImplementation_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshal.graphql-CustomMarshal.graphql.go
@@ -17,7 +17,12 @@ type CustomMarshalResponse struct {
 }
 
 // GetUsersBornOn returns CustomMarshalResponse.UsersBornOn, and is useful for accessing the field via an interface.
-func (v *CustomMarshalResponse) GetUsersBornOn() []CustomMarshalUsersBornOnUser { return v.UsersBornOn }
+func (v *CustomMarshalResponse) GetUsersBornOn() (val []CustomMarshalUsersBornOnUser) {
+	if v == nil {
+		return
+	}
+	return v.UsersBornOn
+}
 
 // CustomMarshalUsersBornOnUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,10 +37,20 @@ type CustomMarshalUsersBornOnUser struct {
 }
 
 // GetId returns CustomMarshalUsersBornOnUser.Id, and is useful for accessing the field via an interface.
-func (v *CustomMarshalUsersBornOnUser) GetId() testutil.ID { return v.Id }
+func (v *CustomMarshalUsersBornOnUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetBirthdate returns CustomMarshalUsersBornOnUser.Birthdate, and is useful for accessing the field via an interface.
-func (v *CustomMarshalUsersBornOnUser) GetBirthdate() time.Time { return v.Birthdate }
+func (v *CustomMarshalUsersBornOnUser) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *CustomMarshalUsersBornOnUser) UnmarshalJSON(b []byte) error {
 
@@ -109,7 +124,12 @@ type __CustomMarshalInput struct {
 }
 
 // GetDate returns __CustomMarshalInput.Date, and is useful for accessing the field via an interface.
-func (v *__CustomMarshalInput) GetDate() time.Time { return v.Date }
+func (v *__CustomMarshalInput) GetDate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Date
+}
 
 func (v *__CustomMarshalInput) UnmarshalJSON(b []byte) error {
 

--- a/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-CustomMarshalSlice.graphql-CustomMarshalSlice.graphql.go
@@ -18,12 +18,20 @@ type CustomMarshalSliceResponse struct {
 }
 
 // GetAcceptsListOfListOfListsOfDates returns CustomMarshalSliceResponse.AcceptsListOfListOfListsOfDates, and is useful for accessing the field via an interface.
-func (v *CustomMarshalSliceResponse) GetAcceptsListOfListOfListsOfDates() bool {
+func (v *CustomMarshalSliceResponse) GetAcceptsListOfListOfListsOfDates() (val bool) {
+	if v == nil {
+		return
+	}
 	return v.AcceptsListOfListOfListsOfDates
 }
 
 // GetWithPointer returns CustomMarshalSliceResponse.WithPointer, and is useful for accessing the field via an interface.
-func (v *CustomMarshalSliceResponse) GetWithPointer() bool { return v.WithPointer }
+func (v *CustomMarshalSliceResponse) GetWithPointer() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.WithPointer
+}
 
 // __CustomMarshalSliceInput is used internally by genqlient
 type __CustomMarshalSliceInput struct {
@@ -32,10 +40,20 @@ type __CustomMarshalSliceInput struct {
 }
 
 // GetDatesss returns __CustomMarshalSliceInput.Datesss, and is useful for accessing the field via an interface.
-func (v *__CustomMarshalSliceInput) GetDatesss() [][][]time.Time { return v.Datesss }
+func (v *__CustomMarshalSliceInput) GetDatesss() (val [][][]time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Datesss
+}
 
 // GetDatesssp returns __CustomMarshalSliceInput.Datesssp, and is useful for accessing the field via an interface.
-func (v *__CustomMarshalSliceInput) GetDatesssp() [][][]*time.Time { return v.Datesssp }
+func (v *__CustomMarshalSliceInput) GetDatesssp() (val [][][]*time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Datesssp
+}
 
 func (v *__CustomMarshalSliceInput) UnmarshalJSON(b []byte) error {
 

--- a/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DateTime.graphql-DateTime.graphql.go
@@ -15,10 +15,20 @@ type __convertTimezoneInput struct {
 }
 
 // GetDt returns __convertTimezoneInput.Dt, and is useful for accessing the field via an interface.
-func (v *__convertTimezoneInput) GetDt() time.Time { return v.Dt }
+func (v *__convertTimezoneInput) GetDt() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Dt
+}
 
 // GetTz returns __convertTimezoneInput.Tz, and is useful for accessing the field via an interface.
-func (v *__convertTimezoneInput) GetTz() string { return v.Tz }
+func (v *__convertTimezoneInput) GetTz() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Tz
+}
 
 // convertTimezoneResponse is returned by convertTimezone on success.
 type convertTimezoneResponse struct {
@@ -26,7 +36,12 @@ type convertTimezoneResponse struct {
 }
 
 // GetConvert returns convertTimezoneResponse.Convert, and is useful for accessing the field via an interface.
-func (v *convertTimezoneResponse) GetConvert() time.Time { return v.Convert }
+func (v *convertTimezoneResponse) GetConvert() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Convert
+}
 
 // The query executed by convertTimezone.
 const convertTimezone_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-DefaultInputs.graphql-DefaultInputs.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DefaultInputs.graphql-DefaultInputs.graphql.go
@@ -12,7 +12,12 @@ type DefaultInputsResponse struct {
 }
 
 // GetDefault returns DefaultInputsResponse.Default, and is useful for accessing the field via an interface.
-func (v *DefaultInputsResponse) GetDefault() bool { return v.Default }
+func (v *DefaultInputsResponse) GetDefault() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.Default
+}
 
 type InputWithDefaults struct {
 	Field         string `json:"field"`
@@ -20,10 +25,20 @@ type InputWithDefaults struct {
 }
 
 // GetField returns InputWithDefaults.Field, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetField() string { return v.Field }
+func (v *InputWithDefaults) GetField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Field
+}
 
 // GetNullableField returns InputWithDefaults.NullableField, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetNullableField() string { return v.NullableField }
+func (v *InputWithDefaults) GetNullableField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.NullableField
+}
 
 // __DefaultInputsInput is used internally by genqlient
 type __DefaultInputsInput struct {
@@ -31,7 +46,12 @@ type __DefaultInputsInput struct {
 }
 
 // GetInput returns __DefaultInputsInput.Input, and is useful for accessing the field via an interface.
-func (v *__DefaultInputsInput) GetInput() InputWithDefaults { return v.Input }
+func (v *__DefaultInputsInput) GetInput() (val InputWithDefaults) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by DefaultInputs.
 const DefaultInputs_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-DefaultInputsPointer.graphql-DefaultInputsPointer.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DefaultInputsPointer.graphql-DefaultInputsPointer.graphql.go
@@ -12,7 +12,12 @@ type DefaultInputsResponse struct {
 }
 
 // GetDefault returns DefaultInputsResponse.Default, and is useful for accessing the field via an interface.
-func (v *DefaultInputsResponse) GetDefault() bool { return v.Default }
+func (v *DefaultInputsResponse) GetDefault() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.Default
+}
 
 type InputWithDefaults struct {
 	Field         string  `json:"field"`
@@ -20,10 +25,20 @@ type InputWithDefaults struct {
 }
 
 // GetField returns InputWithDefaults.Field, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetField() string { return v.Field }
+func (v *InputWithDefaults) GetField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Field
+}
 
 // GetNullableField returns InputWithDefaults.NullableField, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetNullableField() *string { return v.NullableField }
+func (v *InputWithDefaults) GetNullableField() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.NullableField
+}
 
 // __DefaultInputsInput is used internally by genqlient
 type __DefaultInputsInput struct {
@@ -31,7 +46,12 @@ type __DefaultInputsInput struct {
 }
 
 // GetInput returns __DefaultInputsInput.Input, and is useful for accessing the field via an interface.
-func (v *__DefaultInputsInput) GetInput() InputWithDefaults { return v.Input }
+func (v *__DefaultInputsInput) GetInput() (val InputWithDefaults) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by DefaultInputs.
 const DefaultInputs_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-DefaultInputsWithDirective.graphql-DefaultInputsWithDirective.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DefaultInputsWithDirective.graphql-DefaultInputsWithDirective.graphql.go
@@ -12,7 +12,12 @@ type DefaultInputsResponse struct {
 }
 
 // GetDefault returns DefaultInputsResponse.Default, and is useful for accessing the field via an interface.
-func (v *DefaultInputsResponse) GetDefault() bool { return v.Default }
+func (v *DefaultInputsResponse) GetDefault() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.Default
+}
 
 type InputWithDefaults struct {
 	Field         string `json:"field,omitempty"`
@@ -20,10 +25,20 @@ type InputWithDefaults struct {
 }
 
 // GetField returns InputWithDefaults.Field, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetField() string { return v.Field }
+func (v *InputWithDefaults) GetField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Field
+}
 
 // GetNullableField returns InputWithDefaults.NullableField, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetNullableField() string { return v.NullableField }
+func (v *InputWithDefaults) GetNullableField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.NullableField
+}
 
 // __DefaultInputsInput is used internally by genqlient
 type __DefaultInputsInput struct {
@@ -31,7 +46,12 @@ type __DefaultInputsInput struct {
 }
 
 // GetInput returns __DefaultInputsInput.Input, and is useful for accessing the field via an interface.
-func (v *__DefaultInputsInput) GetInput() InputWithDefaults { return v.Input }
+func (v *__DefaultInputsInput) GetInput() (val InputWithDefaults) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by DefaultInputs.
 const DefaultInputs_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-DefaultInputsWithForDirective.graphql-DefaultInputsWithForDirective.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-DefaultInputsWithForDirective.graphql-DefaultInputsWithForDirective.graphql.go
@@ -12,7 +12,12 @@ type DefaultInputsResponse struct {
 }
 
 // GetDefault returns DefaultInputsResponse.Default, and is useful for accessing the field via an interface.
-func (v *DefaultInputsResponse) GetDefault() bool { return v.Default }
+func (v *DefaultInputsResponse) GetDefault() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.Default
+}
 
 type InputWithDefaults struct {
 	Field         string `json:"field,omitempty"`
@@ -20,10 +25,20 @@ type InputWithDefaults struct {
 }
 
 // GetField returns InputWithDefaults.Field, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetField() string { return v.Field }
+func (v *InputWithDefaults) GetField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Field
+}
 
 // GetNullableField returns InputWithDefaults.NullableField, and is useful for accessing the field via an interface.
-func (v *InputWithDefaults) GetNullableField() string { return v.NullableField }
+func (v *InputWithDefaults) GetNullableField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.NullableField
+}
 
 // __DefaultInputsInput is used internally by genqlient
 type __DefaultInputsInput struct {
@@ -31,7 +46,12 @@ type __DefaultInputsInput struct {
 }
 
 // GetInput returns __DefaultInputsInput.Input, and is useful for accessing the field via an interface.
-func (v *__DefaultInputsInput) GetInput() InputWithDefaults { return v.Input }
+func (v *__DefaultInputsInput) GetInput() (val InputWithDefaults) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by DefaultInputs.
 const DefaultInputs_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-EmptyInterface.graphql-EmptyInterface.graphql.go
@@ -13,10 +13,18 @@ type EmptyInterfaceResponse struct {
 }
 
 // GetGetJunk returns EmptyInterfaceResponse.GetJunk, and is useful for accessing the field via an interface.
-func (v *EmptyInterfaceResponse) GetGetJunk() interface{} { return v.GetJunk }
+func (v *EmptyInterfaceResponse) GetGetJunk() (val interface{}) {
+	if v == nil {
+		return
+	}
+	return v.GetJunk
+}
 
 // GetGetComplexJunk returns EmptyInterfaceResponse.GetComplexJunk, and is useful for accessing the field via an interface.
-func (v *EmptyInterfaceResponse) GetGetComplexJunk() []map[string]*[]*map[string]interface{} {
+func (v *EmptyInterfaceResponse) GetGetComplexJunk() (val []map[string]*[]*map[string]interface{}) {
+	if v == nil {
+		return
+	}
 	return v.GetComplexJunk
 }
 

--- a/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Flatten.graphql-Flatten.graphql.go
@@ -18,10 +18,20 @@ type ChildVideoFields struct {
 }
 
 // GetId returns ChildVideoFields.Id, and is useful for accessing the field via an interface.
-func (v *ChildVideoFields) GetId() testutil.ID { return v.Id }
+func (v *ChildVideoFields) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns ChildVideoFields.Name, and is useful for accessing the field via an interface.
-func (v *ChildVideoFields) GetName() string { return v.Name }
+func (v *ChildVideoFields) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // ContentFields includes the GraphQL fields of Content requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -122,10 +132,20 @@ type ContentFieldsArticle struct {
 }
 
 // GetName returns ContentFieldsArticle.Name, and is useful for accessing the field via an interface.
-func (v *ContentFieldsArticle) GetName() string { return v.Name }
+func (v *ContentFieldsArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns ContentFieldsArticle.Url, and is useful for accessing the field via an interface.
-func (v *ContentFieldsArticle) GetUrl() string { return v.Url }
+func (v *ContentFieldsArticle) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // ContentFields includes the GraphQL fields of Topic requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -137,10 +157,20 @@ type ContentFieldsTopic struct {
 }
 
 // GetName returns ContentFieldsTopic.Name, and is useful for accessing the field via an interface.
-func (v *ContentFieldsTopic) GetName() string { return v.Name }
+func (v *ContentFieldsTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns ContentFieldsTopic.Url, and is useful for accessing the field via an interface.
-func (v *ContentFieldsTopic) GetUrl() string { return v.Url }
+func (v *ContentFieldsTopic) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // ContentFields includes the GraphQL fields of Video requested by the fragment ContentFields.
 // The GraphQL type's documentation follows.
@@ -152,10 +182,20 @@ type ContentFieldsVideo struct {
 }
 
 // GetName returns ContentFieldsVideo.Name, and is useful for accessing the field via an interface.
-func (v *ContentFieldsVideo) GetName() string { return v.Name }
+func (v *ContentFieldsVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns ContentFieldsVideo.Url, and is useful for accessing the field via an interface.
-func (v *ContentFieldsVideo) GetUrl() string { return v.Url }
+func (v *ContentFieldsVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // InnerQueryFragment includes the GraphQL fields of Query requested by the fragment InnerQueryFragment.
 // The GraphQL type's documentation follows.
@@ -168,13 +208,28 @@ type InnerQueryFragment struct {
 }
 
 // GetRandomVideo returns InnerQueryFragment.RandomVideo, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragment) GetRandomVideo() VideoFields { return v.RandomVideo }
+func (v *InnerQueryFragment) GetRandomVideo() (val VideoFields) {
+	if v == nil {
+		return
+	}
+	return v.RandomVideo
+}
 
 // GetRandomItem returns InnerQueryFragment.RandomItem, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragment) GetRandomItem() ContentFields { return v.RandomItem }
+func (v *InnerQueryFragment) GetRandomItem() (val ContentFields) {
+	if v == nil {
+		return
+	}
+	return v.RandomItem
+}
 
 // GetOtherVideo returns InnerQueryFragment.OtherVideo, and is useful for accessing the field via an interface.
-func (v *InnerQueryFragment) GetOtherVideo() ContentFieldsVideo { return v.OtherVideo }
+func (v *InnerQueryFragment) GetOtherVideo() (val ContentFieldsVideo) {
+	if v == nil {
+		return
+	}
+	return v.OtherVideo
+}
 
 func (v *InnerQueryFragment) UnmarshalJSON(b []byte) error {
 
@@ -253,10 +308,20 @@ type VideoFields struct {
 }
 
 // GetId returns VideoFields.Id, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetId() testutil.ID { return v.Id }
+func (v *VideoFields) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetParent returns VideoFields.Parent, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetParent() VideoFieldsParentTopic { return v.Parent }
+func (v *VideoFields) GetParent() (val VideoFieldsParentTopic) {
+	if v == nil {
+		return
+	}
+	return v.Parent
+}
 
 // VideoFieldsParentTopic includes the requested fields of the GraphQL type Topic.
 type VideoFieldsParentTopic struct {
@@ -264,7 +329,12 @@ type VideoFieldsParentTopic struct {
 }
 
 // GetVideoChildren returns VideoFieldsParentTopic.VideoChildren, and is useful for accessing the field via an interface.
-func (v *VideoFieldsParentTopic) GetVideoChildren() []ChildVideoFields { return v.VideoChildren }
+func (v *VideoFieldsParentTopic) GetVideoChildren() (val []ChildVideoFields) {
+	if v == nil {
+		return
+	}
+	return v.VideoChildren
+}
 
 // The query executed by ComplexNamedFragments.
 const ComplexNamedFragments_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-Hasura.graphql-Hasura.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Hasura.graphql-Hasura.graphql.go
@@ -15,16 +15,36 @@ type GetPokemonBoolExp struct {
 }
 
 // GetAnd returns GetPokemonBoolExp.And, and is useful for accessing the field via an interface.
-func (v *GetPokemonBoolExp) GetAnd() []*GetPokemonBoolExp { return v.And }
+func (v *GetPokemonBoolExp) GetAnd() (val []*GetPokemonBoolExp) {
+	if v == nil {
+		return
+	}
+	return v.And
+}
 
 // GetNot returns GetPokemonBoolExp.Not, and is useful for accessing the field via an interface.
-func (v *GetPokemonBoolExp) GetNot() *GetPokemonBoolExp { return v.Not }
+func (v *GetPokemonBoolExp) GetNot() (val *GetPokemonBoolExp) {
+	if v == nil {
+		return
+	}
+	return v.Not
+}
 
 // GetOr returns GetPokemonBoolExp.Or, and is useful for accessing the field via an interface.
-func (v *GetPokemonBoolExp) GetOr() []*GetPokemonBoolExp { return v.Or }
+func (v *GetPokemonBoolExp) GetOr() (val []*GetPokemonBoolExp) {
+	if v == nil {
+		return
+	}
+	return v.Or
+}
 
 // GetLevel returns GetPokemonBoolExp.Level, and is useful for accessing the field via an interface.
-func (v *GetPokemonBoolExp) GetLevel() *IntComparisonExp { return v.Level }
+func (v *GetPokemonBoolExp) GetLevel() (val *IntComparisonExp) {
+	if v == nil {
+		return
+	}
+	return v.Level
+}
 
 // GetPokemonResponse is returned by GetPokemon on success.
 type GetPokemonResponse struct {
@@ -32,7 +52,12 @@ type GetPokemonResponse struct {
 }
 
 // GetGetPokemon returns GetPokemonResponse.GetPokemon, and is useful for accessing the field via an interface.
-func (v *GetPokemonResponse) GetGetPokemon() []*testutil.Pokemon { return v.GetPokemon }
+func (v *GetPokemonResponse) GetGetPokemon() (val []*testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.GetPokemon
+}
 
 type IntComparisonExp struct {
 	Eq     *int   `json:"_eq"`
@@ -47,31 +72,76 @@ type IntComparisonExp struct {
 }
 
 // GetEq returns IntComparisonExp.Eq, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetEq() *int { return v.Eq }
+func (v *IntComparisonExp) GetEq() (val *int) {
+	if v == nil {
+		return
+	}
+	return v.Eq
+}
 
 // GetGt returns IntComparisonExp.Gt, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetGt() *int { return v.Gt }
+func (v *IntComparisonExp) GetGt() (val *int) {
+	if v == nil {
+		return
+	}
+	return v.Gt
+}
 
 // GetGte returns IntComparisonExp.Gte, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetGte() *int { return v.Gte }
+func (v *IntComparisonExp) GetGte() (val *int) {
+	if v == nil {
+		return
+	}
+	return v.Gte
+}
 
 // GetIn returns IntComparisonExp.In, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetIn() []*int { return v.In }
+func (v *IntComparisonExp) GetIn() (val []*int) {
+	if v == nil {
+		return
+	}
+	return v.In
+}
 
 // GetIsNull returns IntComparisonExp.IsNull, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetIsNull() *bool { return v.IsNull }
+func (v *IntComparisonExp) GetIsNull() (val *bool) {
+	if v == nil {
+		return
+	}
+	return v.IsNull
+}
 
 // GetLt returns IntComparisonExp.Lt, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetLt() *int { return v.Lt }
+func (v *IntComparisonExp) GetLt() (val *int) {
+	if v == nil {
+		return
+	}
+	return v.Lt
+}
 
 // GetLte returns IntComparisonExp.Lte, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetLte() *int { return v.Lte }
+func (v *IntComparisonExp) GetLte() (val *int) {
+	if v == nil {
+		return
+	}
+	return v.Lte
+}
 
 // GetNeq returns IntComparisonExp.Neq, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetNeq() *int { return v.Neq }
+func (v *IntComparisonExp) GetNeq() (val *int) {
+	if v == nil {
+		return
+	}
+	return v.Neq
+}
 
 // GetNin returns IntComparisonExp.Nin, and is useful for accessing the field via an interface.
-func (v *IntComparisonExp) GetNin() []*int { return v.Nin }
+func (v *IntComparisonExp) GetNin() (val []*int) {
+	if v == nil {
+		return
+	}
+	return v.Nin
+}
 
 // __GetPokemonInput is used internally by genqlient
 type __GetPokemonInput struct {
@@ -79,7 +149,12 @@ type __GetPokemonInput struct {
 }
 
 // GetWhere returns __GetPokemonInput.Where, and is useful for accessing the field via an interface.
-func (v *__GetPokemonInput) GetWhere() *GetPokemonBoolExp { return v.Where }
+func (v *__GetPokemonInput) GetWhere() (val *GetPokemonBoolExp) {
+	if v == nil {
+		return
+	}
+	return v.Where
+}
 
 // The query executed by GetPokemon.
 const GetPokemon_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputEnum.graphql-InputEnum.graphql.go
@@ -14,7 +14,10 @@ type InputEnumQueryResponse struct {
 }
 
 // GetUsersWithRole returns InputEnumQueryResponse.UsersWithRole, and is useful for accessing the field via an interface.
-func (v *InputEnumQueryResponse) GetUsersWithRole() []InputEnumQueryUsersWithRoleUser {
+func (v *InputEnumQueryResponse) GetUsersWithRole() (val []InputEnumQueryUsersWithRoleUser) {
+	if v == nil {
+		return
+	}
 	return v.UsersWithRole
 }
 
@@ -30,7 +33,12 @@ type InputEnumQueryUsersWithRoleUser struct {
 }
 
 // GetId returns InputEnumQueryUsersWithRoleUser.Id, and is useful for accessing the field via an interface.
-func (v *InputEnumQueryUsersWithRoleUser) GetId() testutil.ID { return v.Id }
+func (v *InputEnumQueryUsersWithRoleUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // Role is a type a user may have.
 type Role string
@@ -57,7 +65,12 @@ type __InputEnumQueryInput struct {
 }
 
 // GetRole returns __InputEnumQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *__InputEnumQueryInput) GetRole() Role { return v.Role }
+func (v *__InputEnumQueryInput) GetRole() (val Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // The query executed by InputEnumQuery.
 const InputEnumQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InputObject.graphql-InputObject.graphql.go
@@ -21,7 +21,12 @@ type InputObjectQueryResponse struct {
 }
 
 // GetUser returns InputObjectQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *InputObjectQueryResponse) GetUser() InputObjectQueryUser { return v.User }
+func (v *InputObjectQueryResponse) GetUser() (val InputObjectQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // InputObjectQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -35,7 +40,12 @@ type InputObjectQueryUser struct {
 }
 
 // GetId returns InputObjectQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *InputObjectQueryUser) GetId() testutil.ID { return v.Id }
+func (v *InputObjectQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // Role is a type a user may have.
 type Role string
@@ -73,25 +83,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() string { return v.Name }
+func (v *UserQueryInput) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+func (v *UserQueryInput) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -180,7 +225,12 @@ type __InputObjectQueryInput struct {
 }
 
 // GetQuery returns __InputObjectQueryInput.Query, and is useful for accessing the field via an interface.
-func (v *__InputObjectQueryInput) GetQuery() UserQueryInput { return v.Query }
+func (v *__InputObjectQueryInput) GetQuery() (val UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // The query executed by InputObjectQuery.
 const InputObjectQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListField.graphql-InterfaceListField.graphql.go
@@ -17,10 +17,18 @@ type InterfaceListFieldResponse struct {
 }
 
 // GetRoot returns InterfaceListFieldResponse.Root, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldResponse) GetRoot() InterfaceListFieldRootTopic { return v.Root }
+func (v *InterfaceListFieldResponse) GetRoot() (val InterfaceListFieldRootTopic) {
+	if v == nil {
+		return
+	}
+	return v.Root
+}
 
 // GetWithPointer returns InterfaceListFieldResponse.WithPointer, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldResponse) GetWithPointer() *InterfaceListFieldWithPointerTopic {
+func (v *InterfaceListFieldResponse) GetWithPointer() (val *InterfaceListFieldWithPointerTopic) {
+	if v == nil {
+		return
+	}
 	return v.WithPointer
 }
 
@@ -33,13 +41,26 @@ type InterfaceListFieldRootTopic struct {
 }
 
 // GetId returns InterfaceListFieldRootTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldRootTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldRootTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopic) GetName() string { return v.Name }
+func (v *InterfaceListFieldRootTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetChildren returns InterfaceListFieldRootTopic.Children, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopic) GetChildren() []InterfaceListFieldRootTopicChildrenContent {
+func (v *InterfaceListFieldRootTopic) GetChildren() (val []InterfaceListFieldRootTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -133,13 +154,28 @@ type InterfaceListFieldRootTopicChildrenArticle struct {
 }
 
 // GetTypename returns InterfaceListFieldRootTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenArticle) GetTypename() string { return v.Typename }
+func (v *InterfaceListFieldRootTopicChildrenArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListFieldRootTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldRootTopicChildrenArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldRootTopicChildrenArticle.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenArticle) GetName() string { return v.Name }
+func (v *InterfaceListFieldRootTopicChildrenArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceListFieldRootTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
@@ -247,13 +283,28 @@ type InterfaceListFieldRootTopicChildrenTopic struct {
 }
 
 // GetTypename returns InterfaceListFieldRootTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenTopic) GetTypename() string { return v.Typename }
+func (v *InterfaceListFieldRootTopicChildrenTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListFieldRootTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldRootTopicChildrenTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldRootTopicChildrenTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenTopic) GetName() string { return v.Name }
+func (v *InterfaceListFieldRootTopicChildrenTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceListFieldRootTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type InterfaceListFieldRootTopicChildrenVideo struct {
@@ -264,13 +315,28 @@ type InterfaceListFieldRootTopicChildrenVideo struct {
 }
 
 // GetTypename returns InterfaceListFieldRootTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenVideo) GetTypename() string { return v.Typename }
+func (v *InterfaceListFieldRootTopicChildrenVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListFieldRootTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldRootTopicChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldRootTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldRootTopicChildrenVideo) GetName() string { return v.Name }
+func (v *InterfaceListFieldRootTopicChildrenVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceListFieldWithPointerTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceListFieldWithPointerTopic struct {
@@ -281,13 +347,26 @@ type InterfaceListFieldWithPointerTopic struct {
 }
 
 // GetId returns InterfaceListFieldWithPointerTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldWithPointerTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldWithPointerTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopic) GetName() string { return v.Name }
+func (v *InterfaceListFieldWithPointerTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetChildren returns InterfaceListFieldWithPointerTopic.Children, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopic) GetChildren() []InterfaceListFieldWithPointerTopicChildrenContent {
+func (v *InterfaceListFieldWithPointerTopic) GetChildren() (val []InterfaceListFieldWithPointerTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -381,13 +460,28 @@ type InterfaceListFieldWithPointerTopicChildrenArticle struct {
 }
 
 // GetTypename returns InterfaceListFieldWithPointerTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetTypename() string { return v.Typename }
+func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListFieldWithPointerTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldWithPointerTopicChildrenArticle.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetName() string { return v.Name }
+func (v *InterfaceListFieldWithPointerTopicChildrenArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceListFieldWithPointerTopicChildrenContent includes the requested fields of the GraphQL interface Content.
 //
@@ -495,13 +589,28 @@ type InterfaceListFieldWithPointerTopicChildrenTopic struct {
 }
 
 // GetTypename returns InterfaceListFieldWithPointerTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetTypename() string { return v.Typename }
+func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListFieldWithPointerTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldWithPointerTopicChildrenTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetName() string { return v.Name }
+func (v *InterfaceListFieldWithPointerTopicChildrenTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceListFieldWithPointerTopicChildrenVideo includes the requested fields of the GraphQL type Video.
 type InterfaceListFieldWithPointerTopicChildrenVideo struct {
@@ -512,13 +621,28 @@ type InterfaceListFieldWithPointerTopicChildrenVideo struct {
 }
 
 // GetTypename returns InterfaceListFieldWithPointerTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetTypename() string { return v.Typename }
+func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListFieldWithPointerTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListFieldWithPointerTopicChildrenVideo.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetName() string { return v.Name }
+func (v *InterfaceListFieldWithPointerTopicChildrenVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by InterfaceListField.
 const InterfaceListField_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceListOfListsOfListsField.graphql-InterfaceListOfListsOfListsField.graphql.go
@@ -116,17 +116,26 @@ type InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle struct {
 }
 
 // GetTypename returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetTypename() string {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetId() testutil.ID {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetName returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetName() string {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Name
 }
 
@@ -139,17 +148,26 @@ type InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic struct {
 }
 
 // GetTypename returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetTypename() string {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetId() testutil.ID {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetName returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetName() string {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Name
 }
 
@@ -162,17 +180,26 @@ type InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo struct {
 }
 
 // GetTypename returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetTypename() string {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetId() testutil.ID {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetName returns InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetName() string {
+func (v *InterfaceListOfListOfListsFieldListOfListsOfListsOfContentVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Name
 }
 
@@ -183,12 +210,18 @@ type InterfaceListOfListOfListsFieldResponse struct {
 }
 
 // GetListOfListsOfListsOfContent returns InterfaceListOfListOfListsFieldResponse.ListOfListsOfListsOfContent, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldResponse) GetListOfListsOfListsOfContent() [][][]InterfaceListOfListOfListsFieldListOfListsOfListsOfContent {
+func (v *InterfaceListOfListOfListsFieldResponse) GetListOfListsOfListsOfContent() (val [][][]InterfaceListOfListOfListsFieldListOfListsOfListsOfContent) {
+	if v == nil {
+		return
+	}
 	return v.ListOfListsOfListsOfContent
 }
 
 // GetWithPointer returns InterfaceListOfListOfListsFieldResponse.WithPointer, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldResponse) GetWithPointer() [][][]*InterfaceListOfListOfListsFieldWithPointerContent {
+func (v *InterfaceListOfListOfListsFieldResponse) GetWithPointer() (val [][][]*InterfaceListOfListOfListsFieldWithPointerContent) {
+	if v == nil {
+		return
+	}
 	return v.WithPointer
 }
 
@@ -367,13 +400,28 @@ type InterfaceListOfListOfListsFieldWithPointerArticle struct {
 }
 
 // GetTypename returns InterfaceListOfListOfListsFieldWithPointerArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetTypename() string { return v.Typename }
+func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListOfListOfListsFieldWithPointerArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetId() *testutil.ID { return v.Id }
+func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListOfListOfListsFieldWithPointerArticle.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetName() *string { return v.Name }
+func (v *InterfaceListOfListOfListsFieldWithPointerArticle) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceListOfListOfListsFieldWithPointerContent includes the requested fields of the GraphQL interface Content.
 //
@@ -481,13 +529,28 @@ type InterfaceListOfListOfListsFieldWithPointerTopic struct {
 }
 
 // GetTypename returns InterfaceListOfListOfListsFieldWithPointerTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetTypename() string { return v.Typename }
+func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListOfListOfListsFieldWithPointerTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetId() *testutil.ID { return v.Id }
+func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListOfListOfListsFieldWithPointerTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetName() *string { return v.Name }
+func (v *InterfaceListOfListOfListsFieldWithPointerTopic) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceListOfListOfListsFieldWithPointerVideo includes the requested fields of the GraphQL type Video.
 type InterfaceListOfListOfListsFieldWithPointerVideo struct {
@@ -498,13 +561,28 @@ type InterfaceListOfListOfListsFieldWithPointerVideo struct {
 }
 
 // GetTypename returns InterfaceListOfListOfListsFieldWithPointerVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetTypename() string { return v.Typename }
+func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceListOfListOfListsFieldWithPointerVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetId() *testutil.ID { return v.Id }
+func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceListOfListOfListsFieldWithPointerVideo.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetName() *string { return v.Name }
+func (v *InterfaceListOfListOfListsFieldWithPointerVideo) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by InterfaceListOfListOfListsField.
 const InterfaceListOfListOfListsField_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNesting.graphql-InterfaceNesting.graphql.go
@@ -16,7 +16,12 @@ type InterfaceNestingResponse struct {
 }
 
 // GetRoot returns InterfaceNestingResponse.Root, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingResponse) GetRoot() InterfaceNestingRootTopic { return v.Root }
+func (v *InterfaceNestingResponse) GetRoot() (val InterfaceNestingRootTopic) {
+	if v == nil {
+		return
+	}
+	return v.Root
+}
 
 // InterfaceNestingRootTopic includes the requested fields of the GraphQL type Topic.
 type InterfaceNestingRootTopic struct {
@@ -26,10 +31,18 @@ type InterfaceNestingRootTopic struct {
 }
 
 // GetId returns InterfaceNestingRootTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNestingRootTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetChildren returns InterfaceNestingRootTopic.Children, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopic) GetChildren() []InterfaceNestingRootTopicChildrenContent {
+func (v *InterfaceNestingRootTopic) GetChildren() (val []InterfaceNestingRootTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -120,13 +133,26 @@ type InterfaceNestingRootTopicChildrenArticle struct {
 }
 
 // GetTypename returns InterfaceNestingRootTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenArticle) GetTypename() string { return v.Typename }
+func (v *InterfaceNestingRootTopicChildrenArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNestingRootTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenArticle) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNestingRootTopicChildrenArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetParent returns InterfaceNestingRootTopicChildrenArticle.Parent, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenArticle) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
+func (v *InterfaceNestingRootTopicChildrenArticle) GetParent() (val InterfaceNestingRootTopicChildrenContentParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.Parent
 }
 
@@ -235,10 +261,18 @@ type InterfaceNestingRootTopicChildrenContentParentTopic struct {
 }
 
 // GetId returns InterfaceNestingRootTopicChildrenContentParentTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNestingRootTopicChildrenContentParentTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetChildren returns InterfaceNestingRootTopicChildrenContentParentTopic.Children, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopic) GetChildren() []InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent {
+func (v *InterfaceNestingRootTopicChildrenContentParentTopic) GetChildren() (val []InterfaceNestingRootTopicChildrenContentParentTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -328,12 +362,18 @@ type InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle struct {
 }
 
 // GetTypename returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetTypename() string {
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetId() testutil.ID {
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
@@ -440,12 +480,18 @@ type InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic struct {
 }
 
 // GetTypename returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetTypename() string {
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetId() testutil.ID {
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
@@ -457,12 +503,18 @@ type InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo struct {
 }
 
 // GetTypename returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetTypename() string {
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetId() testutil.ID {
+func (v *InterfaceNestingRootTopicChildrenContentParentTopicChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
@@ -475,13 +527,26 @@ type InterfaceNestingRootTopicChildrenTopic struct {
 }
 
 // GetTypename returns InterfaceNestingRootTopicChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenTopic) GetTypename() string { return v.Typename }
+func (v *InterfaceNestingRootTopicChildrenTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNestingRootTopicChildrenTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNestingRootTopicChildrenTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetParent returns InterfaceNestingRootTopicChildrenTopic.Parent, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenTopic) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
+func (v *InterfaceNestingRootTopicChildrenTopic) GetParent() (val InterfaceNestingRootTopicChildrenContentParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.Parent
 }
 
@@ -494,13 +559,26 @@ type InterfaceNestingRootTopicChildrenVideo struct {
 }
 
 // GetTypename returns InterfaceNestingRootTopicChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenVideo) GetTypename() string { return v.Typename }
+func (v *InterfaceNestingRootTopicChildrenVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNestingRootTopicChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenVideo) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNestingRootTopicChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetParent returns InterfaceNestingRootTopicChildrenVideo.Parent, and is useful for accessing the field via an interface.
-func (v *InterfaceNestingRootTopicChildrenVideo) GetParent() InterfaceNestingRootTopicChildrenContentParentTopic {
+func (v *InterfaceNestingRootTopicChildrenVideo) GetParent() (val InterfaceNestingRootTopicChildrenContentParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.Parent
 }
 

--- a/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-InterfaceNoFragments.graphql-InterfaceNoFragments.graphql.go
@@ -19,13 +19,28 @@ type InterfaceNoFragmentsQueryRandomItemArticle struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryRandomItemArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetTypename() string { return v.Typename }
+func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNoFragmentsQueryRandomItemArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryRandomItemArticle.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetName() string { return v.Name }
+func (v *InterfaceNoFragmentsQueryRandomItemArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
@@ -133,13 +148,28 @@ type InterfaceNoFragmentsQueryRandomItemTopic struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryRandomItemTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetTypename() string { return v.Typename }
+func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNoFragmentsQueryRandomItemTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryRandomItemTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetName() string { return v.Name }
+func (v *InterfaceNoFragmentsQueryRandomItemTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryRandomItemVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNoFragmentsQueryRandomItemVideo struct {
@@ -150,13 +180,28 @@ type InterfaceNoFragmentsQueryRandomItemVideo struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryRandomItemVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetTypename() string { return v.Typename }
+func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNoFragmentsQueryRandomItemVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryRandomItemVideo.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetName() string { return v.Name }
+func (v *InterfaceNoFragmentsQueryRandomItemVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle includes the requested fields of the GraphQL type Article.
 type InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle struct {
@@ -167,15 +212,28 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetTypename() string {
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetName() string { return v.Name }
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameContent includes the requested fields of the GraphQL interface Content.
 //
@@ -283,15 +341,28 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetTypename() string {
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetName() string { return v.Name }
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo struct {
@@ -302,15 +373,28 @@ type InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetTypename() string {
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetName() string { return v.Name }
+func (v *InterfaceNoFragmentsQueryRandomItemWithTypeNameVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryResponse is returned by InterfaceNoFragmentsQuery on success.
 type InterfaceNoFragmentsQueryResponse struct {
@@ -321,22 +405,34 @@ type InterfaceNoFragmentsQueryResponse struct {
 }
 
 // GetRoot returns InterfaceNoFragmentsQueryResponse.Root, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryResponse) GetRoot() InterfaceNoFragmentsQueryRootTopic {
+func (v *InterfaceNoFragmentsQueryResponse) GetRoot() (val InterfaceNoFragmentsQueryRootTopic) {
+	if v == nil {
+		return
+	}
 	return v.Root
 }
 
 // GetRandomItem returns InterfaceNoFragmentsQueryResponse.RandomItem, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryResponse) GetRandomItem() InterfaceNoFragmentsQueryRandomItemContent {
+func (v *InterfaceNoFragmentsQueryResponse) GetRandomItem() (val InterfaceNoFragmentsQueryRandomItemContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomItem
 }
 
 // GetRandomItemWithTypeName returns InterfaceNoFragmentsQueryResponse.RandomItemWithTypeName, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryResponse) GetRandomItemWithTypeName() InterfaceNoFragmentsQueryRandomItemWithTypeNameContent {
+func (v *InterfaceNoFragmentsQueryResponse) GetRandomItemWithTypeName() (val InterfaceNoFragmentsQueryRandomItemWithTypeNameContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomItemWithTypeName
 }
 
 // GetWithPointer returns InterfaceNoFragmentsQueryResponse.WithPointer, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryResponse) GetWithPointer() *InterfaceNoFragmentsQueryWithPointerContent {
+func (v *InterfaceNoFragmentsQueryResponse) GetWithPointer() (val *InterfaceNoFragmentsQueryWithPointerContent) {
+	if v == nil {
+		return
+	}
 	return v.WithPointer
 }
 
@@ -473,10 +569,20 @@ type InterfaceNoFragmentsQueryRootTopic struct {
 }
 
 // GetId returns InterfaceNoFragmentsQueryRootTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRootTopic) GetId() testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryRootTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryRootTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryRootTopic) GetName() string { return v.Name }
+func (v *InterfaceNoFragmentsQueryRootTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryWithPointerArticle includes the requested fields of the GraphQL type Article.
 type InterfaceNoFragmentsQueryWithPointerArticle struct {
@@ -487,13 +593,28 @@ type InterfaceNoFragmentsQueryWithPointerArticle struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryWithPointerArticle.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetTypename() string { return v.Typename }
+func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNoFragmentsQueryWithPointerArticle.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetId() *testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryWithPointerArticle.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetName() *string { return v.Name }
+func (v *InterfaceNoFragmentsQueryWithPointerArticle) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryWithPointerContent includes the requested fields of the GraphQL interface Content.
 //
@@ -601,13 +722,28 @@ type InterfaceNoFragmentsQueryWithPointerTopic struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryWithPointerTopic.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetTypename() string { return v.Typename }
+func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNoFragmentsQueryWithPointerTopic.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetId() *testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryWithPointerTopic.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetName() *string { return v.Name }
+func (v *InterfaceNoFragmentsQueryWithPointerTopic) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InterfaceNoFragmentsQueryWithPointerVideo includes the requested fields of the GraphQL type Video.
 type InterfaceNoFragmentsQueryWithPointerVideo struct {
@@ -618,13 +754,28 @@ type InterfaceNoFragmentsQueryWithPointerVideo struct {
 }
 
 // GetTypename returns InterfaceNoFragmentsQueryWithPointerVideo.Typename, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetTypename() string { return v.Typename }
+func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns InterfaceNoFragmentsQueryWithPointerVideo.Id, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetId() *testutil.ID { return v.Id }
+func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InterfaceNoFragmentsQueryWithPointerVideo.Name, and is useful for accessing the field via an interface.
-func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetName() *string { return v.Name }
+func (v *InterfaceNoFragmentsQueryWithPointerVideo) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by InterfaceNoFragmentsQuery.
 const InterfaceNoFragmentsQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListInput.graphql-ListInput.graphql.go
@@ -17,7 +17,12 @@ type ListInputQueryResponse struct {
 }
 
 // GetUser returns ListInputQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *ListInputQueryResponse) GetUser() ListInputQueryUser { return v.User }
+func (v *ListInputQueryResponse) GetUser() (val ListInputQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // ListInputQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -31,7 +36,12 @@ type ListInputQueryUser struct {
 }
 
 // GetId returns ListInputQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *ListInputQueryUser) GetId() testutil.ID { return v.Id }
+func (v *ListInputQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // __ListInputQueryInput is used internally by genqlient
 type __ListInputQueryInput struct {
@@ -39,7 +49,12 @@ type __ListInputQueryInput struct {
 }
 
 // GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
+func (v *__ListInputQueryInput) GetNames() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // The query executed by ListInputQuery.
 const ListInputQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-ListOfListsOfLists.graphql-ListOfListsOfLists.graphql.go
@@ -12,7 +12,10 @@ type ListOfListsOfListsResponse struct {
 }
 
 // GetListOfListsOfLists returns ListOfListsOfListsResponse.ListOfListsOfLists, and is useful for accessing the field via an interface.
-func (v *ListOfListsOfListsResponse) GetListOfListsOfLists() [][][]string {
+func (v *ListOfListsOfListsResponse) GetListOfListsOfLists() (val [][][]string) {
+	if v == nil {
+		return
+	}
 	return v.ListOfListsOfLists
 }
 

--- a/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MultipleDirectives.graphql-MultipleDirectives.graphql.go
@@ -28,25 +28,60 @@ type MyInput struct {
 }
 
 // GetEmail returns MyInput.Email, and is useful for accessing the field via an interface.
-func (v *MyInput) GetEmail() *string { return v.Email }
+func (v *MyInput) GetEmail() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns MyInput.Name, and is useful for accessing the field via an interface.
-func (v *MyInput) GetName() *string { return v.Name }
+func (v *MyInput) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns MyInput.Id, and is useful for accessing the field via an interface.
-func (v *MyInput) GetId() *testutil.ID { return v.Id }
+func (v *MyInput) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns MyInput.Role, and is useful for accessing the field via an interface.
-func (v *MyInput) GetRole() *Role { return v.Role }
+func (v *MyInput) GetRole() (val *Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns MyInput.Names, and is useful for accessing the field via an interface.
-func (v *MyInput) GetNames() []*string { return v.Names }
+func (v *MyInput) GetNames() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns MyInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *MyInput) GetHasPokemon() *testutil.Pokemon { return v.HasPokemon }
+func (v *MyInput) GetHasPokemon() (val *testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns MyInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *MyInput) GetBirthdate() *time.Time { return v.Birthdate }
+func (v *MyInput) GetBirthdate() (val *time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *MyInput) UnmarshalJSON(b []byte) error {
 
@@ -143,10 +178,18 @@ type MyMultipleDirectivesResponse struct {
 }
 
 // GetUser returns MyMultipleDirectivesResponse.User, and is useful for accessing the field via an interface.
-func (v *MyMultipleDirectivesResponse) GetUser() *MyMultipleDirectivesResponseUser { return v.User }
+func (v *MyMultipleDirectivesResponse) GetUser() (val *MyMultipleDirectivesResponseUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetUsers returns MyMultipleDirectivesResponse.Users, and is useful for accessing the field via an interface.
-func (v *MyMultipleDirectivesResponse) GetUsers() []*MyMultipleDirectivesResponseUsersUser {
+func (v *MyMultipleDirectivesResponse) GetUsers() (val []*MyMultipleDirectivesResponseUsersUser) {
+	if v == nil {
+		return
+	}
 	return v.Users
 }
 
@@ -162,7 +205,12 @@ type MyMultipleDirectivesResponseUser struct {
 }
 
 // GetId returns MyMultipleDirectivesResponseUser.Id, and is useful for accessing the field via an interface.
-func (v *MyMultipleDirectivesResponseUser) GetId() *testutil.ID { return v.Id }
+func (v *MyMultipleDirectivesResponseUser) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // MyMultipleDirectivesResponseUsersUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -176,7 +224,12 @@ type MyMultipleDirectivesResponseUsersUser struct {
 }
 
 // GetId returns MyMultipleDirectivesResponseUsersUser.Id, and is useful for accessing the field via an interface.
-func (v *MyMultipleDirectivesResponseUsersUser) GetId() *testutil.ID { return v.Id }
+func (v *MyMultipleDirectivesResponseUsersUser) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // Role is a type a user may have.
 type Role string
@@ -214,25 +267,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() *string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() *string { return v.Name }
+func (v *UserQueryInput) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() *testutil.ID { return v.Id }
+func (v *UserQueryInput) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() *Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val *Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []*string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() *testutil.Pokemon { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val *testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() *time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val *time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -325,10 +413,20 @@ type __MultipleDirectivesInput struct {
 }
 
 // GetQuery returns __MultipleDirectivesInput.Query, and is useful for accessing the field via an interface.
-func (v *__MultipleDirectivesInput) GetQuery() MyInput { return v.Query }
+func (v *__MultipleDirectivesInput) GetQuery() (val MyInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // GetQueries returns __MultipleDirectivesInput.Queries, and is useful for accessing the field via an interface.
-func (v *__MultipleDirectivesInput) GetQueries() []*UserQueryInput { return v.Queries }
+func (v *__MultipleDirectivesInput) GetQueries() (val []*UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Queries
+}
 
 // The query executed by MultipleDirectives.
 const MultipleDirectives_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-MutationArgsWithCollidingNames.graphql-MutationArgsWithCollidingNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-MutationArgsWithCollidingNames.graphql-MutationArgsWithCollidingNames.graphql.go
@@ -13,7 +13,10 @@ type MutationArgsWithCollidingNamesResponse struct {
 }
 
 // GetUpdateUser returns MutationArgsWithCollidingNamesResponse.UpdateUser, and is useful for accessing the field via an interface.
-func (v *MutationArgsWithCollidingNamesResponse) GetUpdateUser() MutationArgsWithCollidingNamesUpdateUser {
+func (v *MutationArgsWithCollidingNamesResponse) GetUpdateUser() (val MutationArgsWithCollidingNamesUpdateUser) {
+	if v == nil {
+		return
+	}
 	return v.UpdateUser
 }
 
@@ -29,7 +32,12 @@ type MutationArgsWithCollidingNamesUpdateUser struct {
 }
 
 // GetId returns MutationArgsWithCollidingNamesUpdateUser.Id, and is useful for accessing the field via an interface.
-func (v *MutationArgsWithCollidingNamesUpdateUser) GetId() testutil.ID { return v.Id }
+func (v *MutationArgsWithCollidingNamesUpdateUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // __MutationArgsWithCollidingNamesInput is used internally by genqlient
 type __MutationArgsWithCollidingNamesInput struct {
@@ -40,16 +48,36 @@ type __MutationArgsWithCollidingNamesInput struct {
 }
 
 // GetData returns __MutationArgsWithCollidingNamesInput.Data, and is useful for accessing the field via an interface.
-func (v *__MutationArgsWithCollidingNamesInput) GetData() string { return v.Data }
+func (v *__MutationArgsWithCollidingNamesInput) GetData() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Data
+}
 
 // GetReq returns __MutationArgsWithCollidingNamesInput.Req, and is useful for accessing the field via an interface.
-func (v *__MutationArgsWithCollidingNamesInput) GetReq() int { return v.Req }
+func (v *__MutationArgsWithCollidingNamesInput) GetReq() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Req
+}
 
 // GetResp returns __MutationArgsWithCollidingNamesInput.Resp, and is useful for accessing the field via an interface.
-func (v *__MutationArgsWithCollidingNamesInput) GetResp() int { return v.Resp }
+func (v *__MutationArgsWithCollidingNamesInput) GetResp() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Resp
+}
 
 // GetClient returns __MutationArgsWithCollidingNamesInput.Client, and is useful for accessing the field via an interface.
-func (v *__MutationArgsWithCollidingNamesInput) GetClient() string { return v.Client }
+func (v *__MutationArgsWithCollidingNamesInput) GetClient() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Client
+}
 
 // The mutation executed by MutationArgsWithCollidingNames.
 const MutationArgsWithCollidingNames_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Omitempty.graphql-Omitempty.graphql.go
@@ -24,16 +24,36 @@ type OmitEmptyQueryResponse struct {
 }
 
 // GetUser returns OmitEmptyQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *OmitEmptyQueryResponse) GetUser() OmitEmptyQueryUser { return v.User }
+func (v *OmitEmptyQueryResponse) GetUser() (val OmitEmptyQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetUsers returns OmitEmptyQueryResponse.Users, and is useful for accessing the field via an interface.
-func (v *OmitEmptyQueryResponse) GetUsers() []OmitEmptyQueryUsersUser { return v.Users }
+func (v *OmitEmptyQueryResponse) GetUsers() (val []OmitEmptyQueryUsersUser) {
+	if v == nil {
+		return
+	}
+	return v.Users
+}
 
 // GetMaybeConvert returns OmitEmptyQueryResponse.MaybeConvert, and is useful for accessing the field via an interface.
-func (v *OmitEmptyQueryResponse) GetMaybeConvert() time.Time { return v.MaybeConvert }
+func (v *OmitEmptyQueryResponse) GetMaybeConvert() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.MaybeConvert
+}
 
 // GetConvert2 returns OmitEmptyQueryResponse.Convert2, and is useful for accessing the field via an interface.
-func (v *OmitEmptyQueryResponse) GetConvert2() time.Time { return v.Convert2 }
+func (v *OmitEmptyQueryResponse) GetConvert2() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Convert2
+}
 
 // OmitEmptyQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -47,7 +67,12 @@ type OmitEmptyQueryUser struct {
 }
 
 // GetId returns OmitEmptyQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *OmitEmptyQueryUser) GetId() testutil.ID { return v.Id }
+func (v *OmitEmptyQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // OmitEmptyQueryUsersUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -61,7 +86,12 @@ type OmitEmptyQueryUsersUser struct {
 }
 
 // GetId returns OmitEmptyQueryUsersUser.Id, and is useful for accessing the field via an interface.
-func (v *OmitEmptyQueryUsersUser) GetId() testutil.ID { return v.Id }
+func (v *OmitEmptyQueryUsersUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // Role is a type a user may have.
 type Role string
@@ -99,25 +129,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() string { return v.Name }
+func (v *UserQueryInput) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+func (v *UserQueryInput) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -210,19 +275,44 @@ type __OmitEmptyQueryInput struct {
 }
 
 // GetQuery returns __OmitEmptyQueryInput.Query, and is useful for accessing the field via an interface.
-func (v *__OmitEmptyQueryInput) GetQuery() UserQueryInput { return v.Query }
+func (v *__OmitEmptyQueryInput) GetQuery() (val UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // GetQueries returns __OmitEmptyQueryInput.Queries, and is useful for accessing the field via an interface.
-func (v *__OmitEmptyQueryInput) GetQueries() []UserQueryInput { return v.Queries }
+func (v *__OmitEmptyQueryInput) GetQueries() (val []UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Queries
+}
 
 // GetDt returns __OmitEmptyQueryInput.Dt, and is useful for accessing the field via an interface.
-func (v *__OmitEmptyQueryInput) GetDt() time.Time { return v.Dt }
+func (v *__OmitEmptyQueryInput) GetDt() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Dt
+}
 
 // GetTz returns __OmitEmptyQueryInput.Tz, and is useful for accessing the field via an interface.
-func (v *__OmitEmptyQueryInput) GetTz() string { return v.Tz }
+func (v *__OmitEmptyQueryInput) GetTz() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Tz
+}
 
 // GetTzNoOmitEmpty returns __OmitEmptyQueryInput.TzNoOmitEmpty, and is useful for accessing the field via an interface.
-func (v *__OmitEmptyQueryInput) GetTzNoOmitEmpty() string { return v.TzNoOmitEmpty }
+func (v *__OmitEmptyQueryInput) GetTzNoOmitEmpty() (val string) {
+	if v == nil {
+		return
+	}
+	return v.TzNoOmitEmpty
+}
 
 // The query executed by OmitEmptyQuery.
 const OmitEmptyQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-OmitemptyFalse.graphql-OmitemptyFalse.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-OmitemptyFalse.graphql-OmitemptyFalse.graphql.go
@@ -12,7 +12,12 @@ type OmitemptyFalseResponse struct {
 }
 
 // GetOmitempty returns OmitemptyFalseResponse.Omitempty, and is useful for accessing the field via an interface.
-func (v *OmitemptyFalseResponse) GetOmitempty() bool { return v.Omitempty }
+func (v *OmitemptyFalseResponse) GetOmitempty() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.Omitempty
+}
 
 type OmitemptyInput struct {
 	Field         string `json:"field"`
@@ -20,10 +25,20 @@ type OmitemptyInput struct {
 }
 
 // GetField returns OmitemptyInput.Field, and is useful for accessing the field via an interface.
-func (v *OmitemptyInput) GetField() string { return v.Field }
+func (v *OmitemptyInput) GetField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Field
+}
 
 // GetNullableField returns OmitemptyInput.NullableField, and is useful for accessing the field via an interface.
-func (v *OmitemptyInput) GetNullableField() string { return v.NullableField }
+func (v *OmitemptyInput) GetNullableField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.NullableField
+}
 
 // __OmitemptyFalseInput is used internally by genqlient
 type __OmitemptyFalseInput struct {
@@ -31,7 +46,12 @@ type __OmitemptyFalseInput struct {
 }
 
 // GetInput returns __OmitemptyFalseInput.Input, and is useful for accessing the field via an interface.
-func (v *__OmitemptyFalseInput) GetInput() OmitemptyInput { return v.Input }
+func (v *__OmitemptyFalseInput) GetInput() (val OmitemptyInput) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by OmitemptyFalse.
 const OmitemptyFalse_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pointers.graphql-Pointers.graphql.go
@@ -23,7 +23,12 @@ type PointersQueryOtherUser struct {
 }
 
 // GetId returns PointersQueryOtherUser.Id, and is useful for accessing the field via an interface.
-func (v *PointersQueryOtherUser) GetId() testutil.ID { return v.Id }
+func (v *PointersQueryOtherUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // PointersQueryResponse is returned by PointersQuery on success.
 type PointersQueryResponse struct {
@@ -41,13 +46,28 @@ type PointersQueryResponse struct {
 }
 
 // GetUser returns PointersQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *PointersQueryResponse) GetUser() *PointersQueryUser { return v.User }
+func (v *PointersQueryResponse) GetUser() (val *PointersQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetOtherUser returns PointersQueryResponse.OtherUser, and is useful for accessing the field via an interface.
-func (v *PointersQueryResponse) GetOtherUser() *PointersQueryOtherUser { return v.OtherUser }
+func (v *PointersQueryResponse) GetOtherUser() (val *PointersQueryOtherUser) {
+	if v == nil {
+		return
+	}
+	return v.OtherUser
+}
 
 // GetMaybeConvert returns PointersQueryResponse.MaybeConvert, and is useful for accessing the field via an interface.
-func (v *PointersQueryResponse) GetMaybeConvert() *time.Time { return v.MaybeConvert }
+func (v *PointersQueryResponse) GetMaybeConvert() (val *time.Time) {
+	if v == nil {
+		return
+	}
+	return v.MaybeConvert
+}
 
 // PointersQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -65,19 +85,44 @@ type PointersQueryUser struct {
 }
 
 // GetId returns PointersQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetId() *testutil.ID { return v.Id }
+func (v *PointersQueryUser) GetId() (val *testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRoles returns PointersQueryUser.Roles, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetRoles() []*Role { return v.Roles }
+func (v *PointersQueryUser) GetRoles() (val []*Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // GetName returns PointersQueryUser.Name, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetName() *string { return v.Name }
+func (v *PointersQueryUser) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetEmails returns PointersQueryUser.Emails, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetEmails() []*string { return v.Emails }
+func (v *PointersQueryUser) GetEmails() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.Emails
+}
 
 // GetEmailsNoPtr returns PointersQueryUser.EmailsNoPtr, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetEmailsNoPtr() []string { return v.EmailsNoPtr }
+func (v *PointersQueryUser) GetEmailsNoPtr() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsNoPtr
+}
 
 // Role is a type a user may have.
 type Role string
@@ -115,25 +160,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() *string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() *string { return v.Name }
+func (v *UserQueryInput) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+func (v *UserQueryInput) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() *Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val *Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []*string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() *testutil.Pokemon { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val *testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() *time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val *time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -227,13 +307,28 @@ type __PointersQueryInput struct {
 }
 
 // GetQuery returns __PointersQueryInput.Query, and is useful for accessing the field via an interface.
-func (v *__PointersQueryInput) GetQuery() *UserQueryInput { return v.Query }
+func (v *__PointersQueryInput) GetQuery() (val *UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // GetDt returns __PointersQueryInput.Dt, and is useful for accessing the field via an interface.
-func (v *__PointersQueryInput) GetDt() time.Time { return v.Dt }
+func (v *__PointersQueryInput) GetDt() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Dt
+}
 
 // GetTz returns __PointersQueryInput.Tz, and is useful for accessing the field via an interface.
-func (v *__PointersQueryInput) GetTz() *string { return v.Tz }
+func (v *__PointersQueryInput) GetTz() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Tz
+}
 
 // The query executed by PointersQuery.
 const PointersQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-PointersInline.graphql-PointersInline.graphql.go
@@ -23,7 +23,12 @@ type PointersQueryOtherUser struct {
 }
 
 // GetId returns PointersQueryOtherUser.Id, and is useful for accessing the field via an interface.
-func (v *PointersQueryOtherUser) GetId() testutil.ID { return v.Id }
+func (v *PointersQueryOtherUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // PointersQueryResponse is returned by PointersQuery on success.
 type PointersQueryResponse struct {
@@ -41,13 +46,28 @@ type PointersQueryResponse struct {
 }
 
 // GetUser returns PointersQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *PointersQueryResponse) GetUser() *PointersQueryUser { return v.User }
+func (v *PointersQueryResponse) GetUser() (val *PointersQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetOtherUser returns PointersQueryResponse.OtherUser, and is useful for accessing the field via an interface.
-func (v *PointersQueryResponse) GetOtherUser() *PointersQueryOtherUser { return v.OtherUser }
+func (v *PointersQueryResponse) GetOtherUser() (val *PointersQueryOtherUser) {
+	if v == nil {
+		return
+	}
+	return v.OtherUser
+}
 
 // GetMaybeConvert returns PointersQueryResponse.MaybeConvert, and is useful for accessing the field via an interface.
-func (v *PointersQueryResponse) GetMaybeConvert() time.Time { return v.MaybeConvert }
+func (v *PointersQueryResponse) GetMaybeConvert() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.MaybeConvert
+}
 
 // PointersQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -65,19 +85,44 @@ type PointersQueryUser struct {
 }
 
 // GetId returns PointersQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetId() testutil.ID { return v.Id }
+func (v *PointersQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRoles returns PointersQueryUser.Roles, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetRoles() []Role { return v.Roles }
+func (v *PointersQueryUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // GetName returns PointersQueryUser.Name, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetName() *string { return v.Name }
+func (v *PointersQueryUser) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetEmails returns PointersQueryUser.Emails, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetEmails() []*string { return v.Emails }
+func (v *PointersQueryUser) GetEmails() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.Emails
+}
 
 // GetEmailsNoPtr returns PointersQueryUser.EmailsNoPtr, and is useful for accessing the field via an interface.
-func (v *PointersQueryUser) GetEmailsNoPtr() []*string { return v.EmailsNoPtr }
+func (v *PointersQueryUser) GetEmailsNoPtr() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsNoPtr
+}
 
 // Role is a type a user may have.
 type Role string
@@ -115,25 +160,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() string { return v.Name }
+func (v *UserQueryInput) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+func (v *UserQueryInput) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -224,13 +304,28 @@ type __PointersQueryInput struct {
 }
 
 // GetQuery returns __PointersQueryInput.Query, and is useful for accessing the field via an interface.
-func (v *__PointersQueryInput) GetQuery() *UserQueryInput { return v.Query }
+func (v *__PointersQueryInput) GetQuery() (val *UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // GetDt returns __PointersQueryInput.Dt, and is useful for accessing the field via an interface.
-func (v *__PointersQueryInput) GetDt() *time.Time { return v.Dt }
+func (v *__PointersQueryInput) GetDt() (val *time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Dt
+}
 
 // GetTz returns __PointersQueryInput.Tz, and is useful for accessing the field via an interface.
-func (v *__PointersQueryInput) GetTz() string { return v.Tz }
+func (v *__PointersQueryInput) GetTz() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Tz
+}
 
 // The query executed by PointersQuery.
 const PointersQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Pokemon.graphql-Pokemon.graphql.go
@@ -17,7 +17,12 @@ type GetPokemonSiblingsResponse struct {
 }
 
 // GetUser returns GetPokemonSiblingsResponse.User, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsResponse) GetUser() GetPokemonSiblingsUser { return v.User }
+func (v *GetPokemonSiblingsResponse) GetUser() (val GetPokemonSiblingsUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetPokemonSiblingsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -35,19 +40,42 @@ type GetPokemonSiblingsUser struct {
 }
 
 // GetId returns GetPokemonSiblingsUser.Id, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsUser) GetId() string { return v.Id }
+func (v *GetPokemonSiblingsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRoles returns GetPokemonSiblingsUser.Roles, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsUser) GetRoles() []string { return v.Roles }
+func (v *GetPokemonSiblingsUser) GetRoles() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // GetName returns GetPokemonSiblingsUser.Name, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsUser) GetName() string { return v.Name }
+func (v *GetPokemonSiblingsUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetPokemon returns GetPokemonSiblingsUser.Pokemon, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsUser) GetPokemon() []testutil.Pokemon { return v.Pokemon }
+func (v *GetPokemonSiblingsUser) GetPokemon() (val []testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.Pokemon
+}
 
 // GetGenqlientPokemon returns GetPokemonSiblingsUser.GenqlientPokemon, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsUser) GetGenqlientPokemon() []GetPokemonSiblingsUserGenqlientPokemon {
+func (v *GetPokemonSiblingsUser) GetGenqlientPokemon() (val []GetPokemonSiblingsUserGenqlientPokemon) {
+	if v == nil {
+		return
+	}
 	return v.GenqlientPokemon
 }
 
@@ -58,10 +86,20 @@ type GetPokemonSiblingsUserGenqlientPokemon struct {
 }
 
 // GetSpecies returns GetPokemonSiblingsUserGenqlientPokemon.Species, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsUserGenqlientPokemon) GetSpecies() string { return v.Species }
+func (v *GetPokemonSiblingsUserGenqlientPokemon) GetSpecies() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Species
+}
 
 // GetLevel returns GetPokemonSiblingsUserGenqlientPokemon.Level, and is useful for accessing the field via an interface.
-func (v *GetPokemonSiblingsUserGenqlientPokemon) GetLevel() int { return v.Level }
+func (v *GetPokemonSiblingsUserGenqlientPokemon) GetLevel() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Level
+}
 
 // __GetPokemonSiblingsInput is used internally by genqlient
 type __GetPokemonSiblingsInput struct {
@@ -69,7 +107,12 @@ type __GetPokemonSiblingsInput struct {
 }
 
 // GetInput returns __GetPokemonSiblingsInput.Input, and is useful for accessing the field via an interface.
-func (v *__GetPokemonSiblingsInput) GetInput() testutil.Pokemon { return v.Input }
+func (v *__GetPokemonSiblingsInput) GetInput() (val testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by GetPokemonSiblings.
 const GetPokemonSiblings_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithAlias.graphql-QueryWithAlias.graphql.go
@@ -17,7 +17,12 @@ type QueryWithAliasResponse struct {
 }
 
 // GetUser returns QueryWithAliasResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithAliasResponse) GetUser() QueryWithAliasUser { return v.User }
+func (v *QueryWithAliasResponse) GetUser() (val QueryWithAliasUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithAliasUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -35,10 +40,20 @@ type QueryWithAliasUser struct {
 }
 
 // GetID returns QueryWithAliasUser.ID, and is useful for accessing the field via an interface.
-func (v *QueryWithAliasUser) GetID() testutil.ID { return v.ID }
+func (v *QueryWithAliasUser) GetID() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.ID
+}
 
 // GetOtherID returns QueryWithAliasUser.OtherID, and is useful for accessing the field via an interface.
-func (v *QueryWithAliasUser) GetOtherID() testutil.ID { return v.OtherID }
+func (v *QueryWithAliasUser) GetOtherID() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.OtherID
+}
 
 // The query executed by QueryWithAlias.
 const QueryWithAlias_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithDoubleAlias.graphql-QueryWithDoubleAlias.graphql.go
@@ -17,7 +17,12 @@ type QueryWithDoubleAliasResponse struct {
 }
 
 // GetUser returns QueryWithDoubleAliasResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithDoubleAliasResponse) GetUser() QueryWithDoubleAliasUser { return v.User }
+func (v *QueryWithDoubleAliasResponse) GetUser() (val QueryWithDoubleAliasUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithDoubleAliasUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -35,10 +40,20 @@ type QueryWithDoubleAliasUser struct {
 }
 
 // GetID returns QueryWithDoubleAliasUser.ID, and is useful for accessing the field via an interface.
-func (v *QueryWithDoubleAliasUser) GetID() testutil.ID { return v.ID }
+func (v *QueryWithDoubleAliasUser) GetID() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.ID
+}
 
 // GetAlsoID returns QueryWithDoubleAliasUser.AlsoID, and is useful for accessing the field via an interface.
-func (v *QueryWithDoubleAliasUser) GetAlsoID() testutil.ID { return v.AlsoID }
+func (v *QueryWithDoubleAliasUser) GetAlsoID() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.AlsoID
+}
 
 // The query executed by QueryWithDoubleAlias.
 const QueryWithDoubleAlias_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithEnums.graphql-QueryWithEnums.graphql.go
@@ -15,7 +15,12 @@ type QueryWithEnumsOtherUser struct {
 }
 
 // GetRoles returns QueryWithEnumsOtherUser.Roles, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsOtherUser) GetRoles() []Role { return v.Roles }
+func (v *QueryWithEnumsOtherUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // QueryWithEnumsResponse is returned by QueryWithEnums on success.
 type QueryWithEnumsResponse struct {
@@ -32,10 +37,20 @@ type QueryWithEnumsResponse struct {
 }
 
 // GetUser returns QueryWithEnumsResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsResponse) GetUser() QueryWithEnumsUser { return v.User }
+func (v *QueryWithEnumsResponse) GetUser() (val QueryWithEnumsUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetOtherUser returns QueryWithEnumsResponse.OtherUser, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsResponse) GetOtherUser() QueryWithEnumsOtherUser { return v.OtherUser }
+func (v *QueryWithEnumsResponse) GetOtherUser() (val QueryWithEnumsOtherUser) {
+	if v == nil {
+		return
+	}
+	return v.OtherUser
+}
 
 // QueryWithEnumsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -46,7 +61,12 @@ type QueryWithEnumsUser struct {
 }
 
 // GetRoles returns QueryWithEnumsUser.Roles, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsUser) GetRoles() []Role { return v.Roles }
+func (v *QueryWithEnumsUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // Role is a type a user may have.
 type Role string

--- a/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithSlices.graphql-QueryWithSlices.graphql.go
@@ -16,7 +16,12 @@ type QueryWithSlicesResponse struct {
 }
 
 // GetUser returns QueryWithSlicesResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesResponse) GetUser() QueryWithSlicesUser { return v.User }
+func (v *QueryWithSlicesResponse) GetUser() (val QueryWithSlicesUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithSlicesUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -30,16 +35,36 @@ type QueryWithSlicesUser struct {
 }
 
 // GetEmails returns QueryWithSlicesUser.Emails, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmails() []string { return v.Emails }
+func (v *QueryWithSlicesUser) GetEmails() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Emails
+}
 
 // GetEmailsOrNull returns QueryWithSlicesUser.EmailsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsOrNull() []string { return v.EmailsOrNull }
+func (v *QueryWithSlicesUser) GetEmailsOrNull() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsOrNull
+}
 
 // GetEmailsWithNulls returns QueryWithSlicesUser.EmailsWithNulls, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNulls() []string { return v.EmailsWithNulls }
+func (v *QueryWithSlicesUser) GetEmailsWithNulls() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsWithNulls
+}
 
 // GetEmailsWithNullsOrNull returns QueryWithSlicesUser.EmailsWithNullsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []string { return v.EmailsWithNullsOrNull }
+func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsWithNullsOrNull
+}
 
 // The query executed by QueryWithSlices.
 const QueryWithSlices_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-QueryWithStructs.graphql-QueryWithStructs.graphql.go
@@ -16,7 +16,12 @@ type QueryWithStructsResponse struct {
 }
 
 // GetUser returns QueryWithStructsResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsResponse) GetUser() QueryWithStructsUser { return v.User }
+func (v *QueryWithStructsResponse) GetUser() (val QueryWithStructsUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithStructsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -27,7 +32,10 @@ type QueryWithStructsUser struct {
 }
 
 // GetAuthMethods returns QueryWithStructsUser.AuthMethods, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUser) GetAuthMethods() []QueryWithStructsUserAuthMethodsAuthMethod {
+func (v *QueryWithStructsUser) GetAuthMethods() (val []QueryWithStructsUserAuthMethodsAuthMethod) {
+	if v == nil {
+		return
+	}
 	return v.AuthMethods
 }
 
@@ -38,10 +46,20 @@ type QueryWithStructsUserAuthMethodsAuthMethod struct {
 }
 
 // GetProvider returns QueryWithStructsUserAuthMethodsAuthMethod.Provider, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() string { return v.Provider }
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Provider
+}
 
 // GetEmail returns QueryWithStructsUserAuthMethodsAuthMethod.Email, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() string { return v.Email }
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // The query executed by QueryWithStructs.
 const QueryWithStructs_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-Recursion.graphql-Recursion.graphql.go
@@ -13,7 +13,12 @@ type RecursionRecurRecursive struct {
 }
 
 // GetRec returns RecursionRecurRecursive.Rec, and is useful for accessing the field via an interface.
-func (v *RecursionRecurRecursive) GetRec() RecursionRecurRecursiveRecRecursive { return v.Rec }
+func (v *RecursionRecurRecursive) GetRec() (val RecursionRecurRecursiveRecRecursive) {
+	if v == nil {
+		return
+	}
+	return v.Rec
+}
 
 // RecursionRecurRecursiveRecRecursive includes the requested fields of the GraphQL type Recursive.
 type RecursionRecurRecursiveRecRecursive struct {
@@ -21,7 +26,10 @@ type RecursionRecurRecursiveRecRecursive struct {
 }
 
 // GetRec returns RecursionRecurRecursiveRecRecursive.Rec, and is useful for accessing the field via an interface.
-func (v *RecursionRecurRecursiveRecRecursive) GetRec() RecursionRecurRecursiveRecRecursiveRecRecursive {
+func (v *RecursionRecurRecursiveRecRecursive) GetRec() (val RecursionRecurRecursiveRecRecursiveRecRecursive) {
+	if v == nil {
+		return
+	}
 	return v.Rec
 }
 
@@ -31,7 +39,10 @@ type RecursionRecurRecursiveRecRecursiveRecRecursive struct {
 }
 
 // GetRec returns RecursionRecurRecursiveRecRecursiveRecRecursive.Rec, and is useful for accessing the field via an interface.
-func (v *RecursionRecurRecursiveRecRecursiveRecRecursive) GetRec() RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive {
+func (v *RecursionRecurRecursiveRecRecursiveRecRecursive) GetRec() (val RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive) {
+	if v == nil {
+		return
+	}
 	return v.Rec
 }
 
@@ -41,7 +52,10 @@ type RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive struct {
 }
 
 // GetId returns RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive.Id, and is useful for accessing the field via an interface.
-func (v *RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive) GetId() testutil.ID {
+func (v *RecursionRecurRecursiveRecRecursiveRecRecursiveRecRecursive) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
@@ -51,14 +65,24 @@ type RecursionResponse struct {
 }
 
 // GetRecur returns RecursionResponse.Recur, and is useful for accessing the field via an interface.
-func (v *RecursionResponse) GetRecur() RecursionRecurRecursive { return v.Recur }
+func (v *RecursionResponse) GetRecur() (val RecursionRecurRecursive) {
+	if v == nil {
+		return
+	}
+	return v.Recur
+}
 
 type RecursiveInput struct {
 	Rec []RecursiveInput `json:"rec"`
 }
 
 // GetRec returns RecursiveInput.Rec, and is useful for accessing the field via an interface.
-func (v *RecursiveInput) GetRec() []RecursiveInput { return v.Rec }
+func (v *RecursiveInput) GetRec() (val []RecursiveInput) {
+	if v == nil {
+		return
+	}
+	return v.Rec
+}
 
 // __RecursionInput is used internally by genqlient
 type __RecursionInput struct {
@@ -66,7 +90,12 @@ type __RecursionInput struct {
 }
 
 // GetInput returns __RecursionInput.Input, and is useful for accessing the field via an interface.
-func (v *__RecursionInput) GetInput() RecursiveInput { return v.Input }
+func (v *__RecursionInput) GetInput() (val RecursiveInput) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by Recursion.
 const Recursion_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInlineFragment.graphql-SimpleInlineFragment.graphql.go
@@ -20,16 +20,36 @@ type SimpleInlineFragmentRandomItemArticle struct {
 }
 
 // GetTypename returns SimpleInlineFragmentRandomItemArticle.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemArticle) GetTypename() string { return v.Typename }
+func (v *SimpleInlineFragmentRandomItemArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns SimpleInlineFragmentRandomItemArticle.Id, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
+func (v *SimpleInlineFragmentRandomItemArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleInlineFragmentRandomItemArticle.Name, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemArticle) GetName() string { return v.Name }
+func (v *SimpleInlineFragmentRandomItemArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetText returns SimpleInlineFragmentRandomItemArticle.Text, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemArticle) GetText() string { return v.Text }
+func (v *SimpleInlineFragmentRandomItemArticle) GetText() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Text
+}
 
 // SimpleInlineFragmentRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
@@ -137,13 +157,28 @@ type SimpleInlineFragmentRandomItemTopic struct {
 }
 
 // GetTypename returns SimpleInlineFragmentRandomItemTopic.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemTopic) GetTypename() string { return v.Typename }
+func (v *SimpleInlineFragmentRandomItemTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns SimpleInlineFragmentRandomItemTopic.Id, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
+func (v *SimpleInlineFragmentRandomItemTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleInlineFragmentRandomItemTopic.Name, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemTopic) GetName() string { return v.Name }
+func (v *SimpleInlineFragmentRandomItemTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // SimpleInlineFragmentRandomItemVideo includes the requested fields of the GraphQL type Video.
 type SimpleInlineFragmentRandomItemVideo struct {
@@ -155,16 +190,36 @@ type SimpleInlineFragmentRandomItemVideo struct {
 }
 
 // GetTypename returns SimpleInlineFragmentRandomItemVideo.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemVideo) GetTypename() string { return v.Typename }
+func (v *SimpleInlineFragmentRandomItemVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns SimpleInlineFragmentRandomItemVideo.Id, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
+func (v *SimpleInlineFragmentRandomItemVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleInlineFragmentRandomItemVideo.Name, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemVideo) GetName() string { return v.Name }
+func (v *SimpleInlineFragmentRandomItemVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetDuration returns SimpleInlineFragmentRandomItemVideo.Duration, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentRandomItemVideo) GetDuration() int { return v.Duration }
+func (v *SimpleInlineFragmentRandomItemVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Duration
+}
 
 // SimpleInlineFragmentResponse is returned by SimpleInlineFragment on success.
 type SimpleInlineFragmentResponse struct {
@@ -172,7 +227,10 @@ type SimpleInlineFragmentResponse struct {
 }
 
 // GetRandomItem returns SimpleInlineFragmentResponse.RandomItem, and is useful for accessing the field via an interface.
-func (v *SimpleInlineFragmentResponse) GetRandomItem() SimpleInlineFragmentRandomItemContent {
+func (v *SimpleInlineFragmentResponse) GetRandomItem() (val SimpleInlineFragmentRandomItemContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomItem
 }
 

--- a/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleInput.graphql-SimpleInput.graphql.go
@@ -17,7 +17,12 @@ type SimpleInputQueryResponse struct {
 }
 
 // GetUser returns SimpleInputQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleInputQueryResponse) GetUser() SimpleInputQueryUser { return v.User }
+func (v *SimpleInputQueryResponse) GetUser() (val SimpleInputQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleInputQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -31,7 +36,12 @@ type SimpleInputQueryUser struct {
 }
 
 // GetId returns SimpleInputQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleInputQueryUser) GetId() testutil.ID { return v.Id }
+func (v *SimpleInputQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // __SimpleInputQueryInput is used internally by genqlient
 type __SimpleInputQueryInput struct {
@@ -39,7 +49,12 @@ type __SimpleInputQueryInput struct {
 }
 
 // GetName returns __SimpleInputQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *__SimpleInputQueryInput) GetName() string { return v.Name }
+func (v *__SimpleInputQueryInput) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by SimpleInputQuery.
 const SimpleInputQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleMutation.graphql-SimpleMutation.graphql.go
@@ -20,10 +20,20 @@ type SimpleMutationCreateUser struct {
 }
 
 // GetId returns SimpleMutationCreateUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleMutationCreateUser) GetId() testutil.ID { return v.Id }
+func (v *SimpleMutationCreateUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleMutationCreateUser.Name, and is useful for accessing the field via an interface.
-func (v *SimpleMutationCreateUser) GetName() string { return v.Name }
+func (v *SimpleMutationCreateUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // SimpleMutationResponse is returned by SimpleMutation on success.
 type SimpleMutationResponse struct {
@@ -31,7 +41,12 @@ type SimpleMutationResponse struct {
 }
 
 // GetCreateUser returns SimpleMutationResponse.CreateUser, and is useful for accessing the field via an interface.
-func (v *SimpleMutationResponse) GetCreateUser() SimpleMutationCreateUser { return v.CreateUser }
+func (v *SimpleMutationResponse) GetCreateUser() (val SimpleMutationCreateUser) {
+	if v == nil {
+		return
+	}
+	return v.CreateUser
+}
 
 // __SimpleMutationInput is used internally by genqlient
 type __SimpleMutationInput struct {
@@ -39,7 +54,12 @@ type __SimpleMutationInput struct {
 }
 
 // GetName returns __SimpleMutationInput.Name, and is useful for accessing the field via an interface.
-func (v *__SimpleMutationInput) GetName() string { return v.Name }
+func (v *__SimpleMutationInput) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The mutation executed by SimpleMutation.
 const SimpleMutation_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleNamedFragment.graphql-SimpleNamedFragment.graphql.go
@@ -19,13 +19,28 @@ type SimpleNamedFragmentRandomItemArticle struct {
 }
 
 // GetTypename returns SimpleNamedFragmentRandomItemArticle.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemArticle) GetTypename() string { return v.Typename }
+func (v *SimpleNamedFragmentRandomItemArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns SimpleNamedFragmentRandomItemArticle.Id, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemArticle) GetId() testutil.ID { return v.Id }
+func (v *SimpleNamedFragmentRandomItemArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleNamedFragmentRandomItemArticle.Name, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemArticle) GetName() string { return v.Name }
+func (v *SimpleNamedFragmentRandomItemArticle) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // SimpleNamedFragmentRandomItemContent includes the requested fields of the GraphQL interface Content.
 //
@@ -137,13 +152,28 @@ type SimpleNamedFragmentRandomItemTopic struct {
 }
 
 // GetTypename returns SimpleNamedFragmentRandomItemTopic.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemTopic) GetTypename() string { return v.Typename }
+func (v *SimpleNamedFragmentRandomItemTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns SimpleNamedFragmentRandomItemTopic.Id, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemTopic) GetId() testutil.ID { return v.Id }
+func (v *SimpleNamedFragmentRandomItemTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleNamedFragmentRandomItemTopic.Name, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemTopic) GetName() string { return v.Name }
+func (v *SimpleNamedFragmentRandomItemTopic) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // SimpleNamedFragmentRandomItemVideo includes the requested fields of the GraphQL type Video.
 type SimpleNamedFragmentRandomItemVideo struct {
@@ -155,22 +185,50 @@ type SimpleNamedFragmentRandomItemVideo struct {
 }
 
 // GetTypename returns SimpleNamedFragmentRandomItemVideo.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemVideo) GetTypename() string { return v.Typename }
+func (v *SimpleNamedFragmentRandomItemVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns SimpleNamedFragmentRandomItemVideo.Id, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemVideo) GetId() testutil.ID { return v.Id }
+func (v *SimpleNamedFragmentRandomItemVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleNamedFragmentRandomItemVideo.Name, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemVideo) GetName() string { return v.Name }
+func (v *SimpleNamedFragmentRandomItemVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns SimpleNamedFragmentRandomItemVideo.Url, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemVideo) GetUrl() string { return v.VideoFields.Url }
+func (v *SimpleNamedFragmentRandomItemVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Url
+}
 
 // GetDuration returns SimpleNamedFragmentRandomItemVideo.Duration, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemVideo) GetDuration() int { return v.VideoFields.Duration }
+func (v *SimpleNamedFragmentRandomItemVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Duration
+}
 
 // GetThumbnail returns SimpleNamedFragmentRandomItemVideo.Thumbnail, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomItemVideo) GetThumbnail() VideoFieldsThumbnail {
+func (v *SimpleNamedFragmentRandomItemVideo) GetThumbnail() (val VideoFieldsThumbnail) {
+	if v == nil {
+		return
+	}
 	return v.VideoFields.Thumbnail
 }
 
@@ -239,7 +297,12 @@ type SimpleNamedFragmentRandomLeafArticle struct {
 }
 
 // GetTypename returns SimpleNamedFragmentRandomLeafArticle.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomLeafArticle) GetTypename() string { return v.Typename }
+func (v *SimpleNamedFragmentRandomLeafArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // SimpleNamedFragmentRandomLeafLeafContent includes the requested fields of the GraphQL interface LeafContent.
 //
@@ -328,22 +391,50 @@ type SimpleNamedFragmentRandomLeafVideo struct {
 }
 
 // GetTypename returns SimpleNamedFragmentRandomLeafVideo.Typename, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomLeafVideo) GetTypename() string { return v.Typename }
+func (v *SimpleNamedFragmentRandomLeafVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns SimpleNamedFragmentRandomLeafVideo.Id, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomLeafVideo) GetId() testutil.ID { return v.VideoFields.Id }
+func (v *SimpleNamedFragmentRandomLeafVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Id
+}
 
 // GetName returns SimpleNamedFragmentRandomLeafVideo.Name, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomLeafVideo) GetName() string { return v.VideoFields.Name }
+func (v *SimpleNamedFragmentRandomLeafVideo) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Name
+}
 
 // GetUrl returns SimpleNamedFragmentRandomLeafVideo.Url, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomLeafVideo) GetUrl() string { return v.VideoFields.Url }
+func (v *SimpleNamedFragmentRandomLeafVideo) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Url
+}
 
 // GetDuration returns SimpleNamedFragmentRandomLeafVideo.Duration, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomLeafVideo) GetDuration() int { return v.VideoFields.Duration }
+func (v *SimpleNamedFragmentRandomLeafVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.VideoFields.Duration
+}
 
 // GetThumbnail returns SimpleNamedFragmentRandomLeafVideo.Thumbnail, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentRandomLeafVideo) GetThumbnail() VideoFieldsThumbnail {
+func (v *SimpleNamedFragmentRandomLeafVideo) GetThumbnail() (val VideoFieldsThumbnail) {
+	if v == nil {
+		return
+	}
 	return v.VideoFields.Thumbnail
 }
 
@@ -413,12 +504,18 @@ type SimpleNamedFragmentResponse struct {
 }
 
 // GetRandomItem returns SimpleNamedFragmentResponse.RandomItem, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentResponse) GetRandomItem() SimpleNamedFragmentRandomItemContent {
+func (v *SimpleNamedFragmentResponse) GetRandomItem() (val SimpleNamedFragmentRandomItemContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomItem
 }
 
 // GetRandomLeaf returns SimpleNamedFragmentResponse.RandomLeaf, and is useful for accessing the field via an interface.
-func (v *SimpleNamedFragmentResponse) GetRandomLeaf() SimpleNamedFragmentRandomLeafLeafContent {
+func (v *SimpleNamedFragmentResponse) GetRandomLeaf() (val SimpleNamedFragmentRandomLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomLeaf
 }
 
@@ -524,19 +621,44 @@ type VideoFields struct {
 }
 
 // GetId returns VideoFields.Id, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetId() testutil.ID { return v.Id }
+func (v *VideoFields) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns VideoFields.Name, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetName() string { return v.Name }
+func (v *VideoFields) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetUrl returns VideoFields.Url, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetUrl() string { return v.Url }
+func (v *VideoFields) GetUrl() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Url
+}
 
 // GetDuration returns VideoFields.Duration, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetDuration() int { return v.Duration }
+func (v *VideoFields) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Duration
+}
 
 // GetThumbnail returns VideoFields.Thumbnail, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetThumbnail() VideoFieldsThumbnail { return v.Thumbnail }
+func (v *VideoFields) GetThumbnail() (val VideoFieldsThumbnail) {
+	if v == nil {
+		return
+	}
+	return v.Thumbnail
+}
 
 // VideoFieldsThumbnail includes the requested fields of the GraphQL type Thumbnail.
 type VideoFieldsThumbnail struct {
@@ -544,7 +666,12 @@ type VideoFieldsThumbnail struct {
 }
 
 // GetId returns VideoFieldsThumbnail.Id, and is useful for accessing the field via an interface.
-func (v *VideoFieldsThumbnail) GetId() testutil.ID { return v.Id }
+func (v *VideoFieldsThumbnail) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleNamedFragment.
 const SimpleNamedFragment_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleQuery.graphql-SimpleQuery.graphql.go
@@ -17,7 +17,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -31,7 +36,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
+func (v *SimpleQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-SimpleQueryNoOverride.graphql-SimpleQueryNoOverride.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleQueryNoOverride.graphql-SimpleQueryNoOverride.graphql.go
@@ -17,7 +17,12 @@ type SimpleQueryNoOverrideResponse struct {
 }
 
 // GetUser returns SimpleQueryNoOverrideResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryNoOverrideResponse) GetUser() SimpleQueryNoOverrideUser { return v.User }
+func (v *SimpleQueryNoOverrideResponse) GetUser() (val SimpleQueryNoOverrideUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryNoOverrideUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,10 +37,20 @@ type SimpleQueryNoOverrideUser struct {
 }
 
 // GetId returns SimpleQueryNoOverrideUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryNoOverrideUser) GetId() testutil.ID { return v.Id }
+func (v *SimpleQueryNoOverrideUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleQueryNoOverrideUser.Name, and is useful for accessing the field via an interface.
-func (v *SimpleQueryNoOverrideUser) GetName() string { return v.Name }
+func (v *SimpleQueryNoOverrideUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by SimpleQueryNoOverride.
 const SimpleQueryNoOverride_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-SimpleQueryWithPointerFalseOverride.graphql-SimpleQueryWithPointerFalseOverride.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleQueryWithPointerFalseOverride.graphql-SimpleQueryWithPointerFalseOverride.graphql.go
@@ -17,7 +17,10 @@ type SimpleQueryWithPointerFalseOverrideResponse struct {
 }
 
 // GetUser returns SimpleQueryWithPointerFalseOverrideResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryWithPointerFalseOverrideResponse) GetUser() SimpleQueryWithPointerFalseOverrideUser {
+func (v *SimpleQueryWithPointerFalseOverrideResponse) GetUser() (val SimpleQueryWithPointerFalseOverrideUser) {
+	if v == nil {
+		return
+	}
 	return v.User
 }
 
@@ -34,10 +37,20 @@ type SimpleQueryWithPointerFalseOverrideUser struct {
 }
 
 // GetId returns SimpleQueryWithPointerFalseOverrideUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryWithPointerFalseOverrideUser) GetId() testutil.ID { return v.Id }
+func (v *SimpleQueryWithPointerFalseOverrideUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleQueryWithPointerFalseOverrideUser.Name, and is useful for accessing the field via an interface.
-func (v *SimpleQueryWithPointerFalseOverrideUser) GetName() string { return v.Name }
+func (v *SimpleQueryWithPointerFalseOverrideUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by SimpleQueryWithPointerFalseOverride.
 const SimpleQueryWithPointerFalseOverride_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-SimpleSubscription.graphql-SimpleSubscription.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-SimpleSubscription.graphql-SimpleSubscription.graphql.go
@@ -15,7 +15,12 @@ type SimpleSubscriptionResponse struct {
 }
 
 // GetCount returns SimpleSubscriptionResponse.Count, and is useful for accessing the field via an interface.
-func (v *SimpleSubscriptionResponse) GetCount() int { return v.Count }
+func (v *SimpleSubscriptionResponse) GetCount() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Count
+}
 
 // The subscription executed by SimpleSubscription.
 const SimpleSubscription_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-StructOption.graphql-StructOption.graphql.go
@@ -40,10 +40,20 @@ type StructOptionResponse struct {
 }
 
 // GetRoot returns StructOptionResponse.Root, and is useful for accessing the field via an interface.
-func (v *StructOptionResponse) GetRoot() StructOptionRootTopic { return v.Root }
+func (v *StructOptionResponse) GetRoot() (val StructOptionRootTopic) {
+	if v == nil {
+		return
+	}
+	return v.Root
+}
 
 // GetUser returns StructOptionResponse.User, and is useful for accessing the field via an interface.
-func (v *StructOptionResponse) GetUser() StructOptionUser { return v.User }
+func (v *StructOptionResponse) GetUser() (val StructOptionUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // StructOptionRootTopic includes the requested fields of the GraphQL type Topic.
 type StructOptionRootTopic struct {
@@ -53,10 +63,18 @@ type StructOptionRootTopic struct {
 }
 
 // GetId returns StructOptionRootTopic.Id, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopic) GetId() testutil.ID { return v.Id }
+func (v *StructOptionRootTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetChildren returns StructOptionRootTopic.Children, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopic) GetChildren() []StructOptionRootTopicChildrenContent {
+func (v *StructOptionRootTopic) GetChildren() (val []StructOptionRootTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
@@ -72,13 +90,26 @@ type StructOptionRootTopicChildrenContent struct {
 }
 
 // GetTypename returns StructOptionRootTopicChildrenContent.Typename, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContent) GetTypename() string { return v.Typename }
+func (v *StructOptionRootTopicChildrenContent) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns StructOptionRootTopicChildrenContent.Id, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContent) GetId() testutil.ID { return v.Id }
+func (v *StructOptionRootTopicChildrenContent) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetParent returns StructOptionRootTopicChildrenContent.Parent, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContent) GetParent() StructOptionRootTopicChildrenContentParentTopic {
+func (v *StructOptionRootTopicChildrenContent) GetParent() (val StructOptionRootTopicChildrenContentParentTopic) {
+	if v == nil {
+		return
+	}
 	return v.Parent
 }
 
@@ -91,15 +122,26 @@ type StructOptionRootTopicChildrenContentParentTopic struct {
 }
 
 // GetId returns StructOptionRootTopicChildrenContentParentTopic.Id, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopic) GetId() testutil.ID { return v.Id }
+func (v *StructOptionRootTopicChildrenContentParentTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetChildren returns StructOptionRootTopicChildrenContentParentTopic.Children, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopic) GetChildren() []StructOptionRootTopicChildrenContentParentTopicChildrenContent {
+func (v *StructOptionRootTopicChildrenContentParentTopic) GetChildren() (val []StructOptionRootTopicChildrenContentParentTopicChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.Children
 }
 
 // GetInterfaceChildren returns StructOptionRootTopicChildrenContentParentTopic.InterfaceChildren, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopic) GetInterfaceChildren() []StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent {
+func (v *StructOptionRootTopicChildrenContentParentTopic) GetInterfaceChildren() (val []StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenContent) {
+	if v == nil {
+		return
+	}
 	return v.InterfaceChildren
 }
 
@@ -195,12 +237,18 @@ type StructOptionRootTopicChildrenContentParentTopicChildrenContent struct {
 }
 
 // GetTypename returns StructOptionRootTopicChildrenContentParentTopicChildrenContent.Typename, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicChildrenContent) GetTypename() string {
+func (v *StructOptionRootTopicChildrenContentParentTopicChildrenContent) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns StructOptionRootTopicChildrenContentParentTopicChildrenContent.Id, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicChildrenContent) GetId() testutil.ID {
+func (v *StructOptionRootTopicChildrenContentParentTopicChildrenContent) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
@@ -212,12 +260,18 @@ type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle str
 }
 
 // GetTypename returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle.Typename, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetTypename() string {
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle.Id, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetId() testutil.ID {
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
@@ -328,12 +382,18 @@ type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic struc
 }
 
 // GetTypename returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic.Typename, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetTypename() string {
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic.Id, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetId() testutil.ID {
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
@@ -346,17 +406,26 @@ type StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo struc
 }
 
 // GetTypename returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo.Typename, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetTypename() string {
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
 	return v.Typename
 }
 
 // GetId returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo.Id, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetId() testutil.ID {
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
 	return v.Id
 }
 
 // GetDuration returns StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo.Duration, and is useful for accessing the field via an interface.
-func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetDuration() int {
+func (v *StructOptionRootTopicChildrenContentParentTopicInterfaceChildrenVideo) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
 	return v.VideoFields.Duration
 }
 
@@ -419,7 +488,12 @@ type StructOptionUser struct {
 }
 
 // GetRoles returns StructOptionUser.Roles, and is useful for accessing the field via an interface.
-func (v *StructOptionUser) GetRoles() []Role { return v.Roles }
+func (v *StructOptionUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // VideoFields includes the GraphQL fields of Video requested by the fragment VideoFields.
 type VideoFields struct {
@@ -427,7 +501,12 @@ type VideoFields struct {
 }
 
 // GetDuration returns VideoFields.Duration, and is useful for accessing the field via an interface.
-func (v *VideoFields) GetDuration() int { return v.Duration }
+func (v *VideoFields) GetDuration() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Duration
+}
 
 // The query executed by StructOption.
 const StructOption_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeName.graphql-TypeName.graphql.go
@@ -17,7 +17,12 @@ type TypeNameQueryResponse struct {
 }
 
 // GetUser returns TypeNameQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *TypeNameQueryResponse) GetUser() TypeNameQueryUser { return v.User }
+func (v *TypeNameQueryResponse) GetUser() (val TypeNameQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // TypeNameQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,10 +37,20 @@ type TypeNameQueryUser struct {
 }
 
 // GetTypename returns TypeNameQueryUser.Typename, and is useful for accessing the field via an interface.
-func (v *TypeNameQueryUser) GetTypename() string { return v.Typename }
+func (v *TypeNameQueryUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns TypeNameQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *TypeNameQueryUser) GetId() testutil.ID { return v.Id }
+func (v *TypeNameQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by TypeNameQuery.
 const TypeNameQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-TypeNames.graphql-TypeNames.graphql.go
@@ -113,13 +113,28 @@ type ItemArticle struct {
 }
 
 // GetTypename returns ItemArticle.Typename, and is useful for accessing the field via an interface.
-func (v *ItemArticle) GetTypename() string { return v.Typename }
+func (v *ItemArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ItemArticle.Id, and is useful for accessing the field via an interface.
-func (v *ItemArticle) GetId() testutil.ID { return v.Id }
+func (v *ItemArticle) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns ItemArticle.Name, and is useful for accessing the field via an interface.
-func (v *ItemArticle) GetName() NameType { return v.Name }
+func (v *ItemArticle) GetName() (val NameType) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // ItemTopic includes the requested fields of the GraphQL type Topic.
 type ItemTopic struct {
@@ -130,13 +145,28 @@ type ItemTopic struct {
 }
 
 // GetTypename returns ItemTopic.Typename, and is useful for accessing the field via an interface.
-func (v *ItemTopic) GetTypename() string { return v.Typename }
+func (v *ItemTopic) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ItemTopic.Id, and is useful for accessing the field via an interface.
-func (v *ItemTopic) GetId() testutil.ID { return v.Id }
+func (v *ItemTopic) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns ItemTopic.Name, and is useful for accessing the field via an interface.
-func (v *ItemTopic) GetName() NameType { return v.Name }
+func (v *ItemTopic) GetName() (val NameType) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // ItemVideo includes the requested fields of the GraphQL type Video.
 type ItemVideo struct {
@@ -147,13 +177,28 @@ type ItemVideo struct {
 }
 
 // GetTypename returns ItemVideo.Typename, and is useful for accessing the field via an interface.
-func (v *ItemVideo) GetTypename() string { return v.Typename }
+func (v *ItemVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns ItemVideo.Id, and is useful for accessing the field via an interface.
-func (v *ItemVideo) GetId() testutil.ID { return v.Id }
+func (v *ItemVideo) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns ItemVideo.Name, and is useful for accessing the field via an interface.
-func (v *ItemVideo) GetName() NameType { return v.Name }
+func (v *ItemVideo) GetName() (val NameType) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 type NameType string
 
@@ -169,13 +214,28 @@ type Resp struct {
 }
 
 // GetUser returns Resp.User, and is useful for accessing the field via an interface.
-func (v *Resp) GetUser() User { return v.User }
+func (v *Resp) GetUser() (val User) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetRandomItem returns Resp.RandomItem, and is useful for accessing the field via an interface.
-func (v *Resp) GetRandomItem() Item { return v.RandomItem }
+func (v *Resp) GetRandomItem() (val Item) {
+	if v == nil {
+		return
+	}
+	return v.RandomItem
+}
 
 // GetUsers returns Resp.Users, and is useful for accessing the field via an interface.
-func (v *Resp) GetUsers() []User { return v.Users }
+func (v *Resp) GetUsers() (val []User) {
+	if v == nil {
+		return
+	}
+	return v.Users
+}
 
 func (v *Resp) UnmarshalJSON(b []byte) error {
 
@@ -259,10 +319,20 @@ type User struct {
 }
 
 // GetId returns User.Id, and is useful for accessing the field via an interface.
-func (v *User) GetId() testutil.ID { return v.Id }
+func (v *User) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns User.Name, and is useful for accessing the field via an interface.
-func (v *User) GetName() string { return v.Name }
+func (v *User) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // The query executed by TypeNames.
 const TypeNames_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UnionNoFragments.graphql-UnionNoFragments.graphql.go
@@ -15,7 +15,12 @@ type UnionNoFragmentsQueryRandomLeafArticle struct {
 }
 
 // GetTypename returns UnionNoFragmentsQueryRandomLeafArticle.Typename, and is useful for accessing the field via an interface.
-func (v *UnionNoFragmentsQueryRandomLeafArticle) GetTypename() string { return v.Typename }
+func (v *UnionNoFragmentsQueryRandomLeafArticle) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // UnionNoFragmentsQueryRandomLeafLeafContent includes the requested fields of the GraphQL interface LeafContent.
 //
@@ -99,7 +104,12 @@ type UnionNoFragmentsQueryRandomLeafVideo struct {
 }
 
 // GetTypename returns UnionNoFragmentsQueryRandomLeafVideo.Typename, and is useful for accessing the field via an interface.
-func (v *UnionNoFragmentsQueryRandomLeafVideo) GetTypename() string { return v.Typename }
+func (v *UnionNoFragmentsQueryRandomLeafVideo) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // UnionNoFragmentsQueryResponse is returned by UnionNoFragmentsQuery on success.
 type UnionNoFragmentsQueryResponse struct {
@@ -107,7 +117,10 @@ type UnionNoFragmentsQueryResponse struct {
 }
 
 // GetRandomLeaf returns UnionNoFragmentsQueryResponse.RandomLeaf, and is useful for accessing the field via an interface.
-func (v *UnionNoFragmentsQueryResponse) GetRandomLeaf() UnionNoFragmentsQueryRandomLeafLeafContent {
+func (v *UnionNoFragmentsQueryResponse) GetRandomLeaf() (val UnionNoFragmentsQueryRandomLeafLeafContent) {
+	if v == nil {
+		return
+	}
 	return v.RandomLeaf
 }
 

--- a/generate/testdata/snapshots/TestGenerate-UseStructReference.graphql-UseStructReference.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UseStructReference.graphql-UseStructReference.graphql.go
@@ -11,7 +11,12 @@ type StructInput struct {
 }
 
 // GetField returns StructInput.Field, and is useful for accessing the field via an interface.
-func (v *StructInput) GetField() string { return v.Field }
+func (v *StructInput) GetField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Field
+}
 
 // UseStructReferenceResponse is returned by UseStructReference on success.
 type UseStructReferenceResponse struct {
@@ -19,7 +24,10 @@ type UseStructReferenceResponse struct {
 }
 
 // GetUseStructReferencesInput returns UseStructReferenceResponse.UseStructReferencesInput, and is useful for accessing the field via an interface.
-func (v *UseStructReferenceResponse) GetUseStructReferencesInput() bool {
+func (v *UseStructReferenceResponse) GetUseStructReferencesInput() (val bool) {
+	if v == nil {
+		return
+	}
 	return v.UseStructReferencesInput
 }
 
@@ -32,19 +40,44 @@ type UseStructReferencesInput struct {
 }
 
 // GetStruct returns UseStructReferencesInput.Struct, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetStruct() StructInput { return v.Struct }
+func (v *UseStructReferencesInput) GetStruct() (val StructInput) {
+	if v == nil {
+		return
+	}
+	return v.Struct
+}
 
 // GetNullableStruct returns UseStructReferencesInput.NullableStruct, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetNullableStruct() StructInput { return v.NullableStruct }
+func (v *UseStructReferencesInput) GetNullableStruct() (val StructInput) {
+	if v == nil {
+		return
+	}
+	return v.NullableStruct
+}
 
 // GetList returns UseStructReferencesInput.List, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetList() []StructInput { return v.List }
+func (v *UseStructReferencesInput) GetList() (val []StructInput) {
+	if v == nil {
+		return
+	}
+	return v.List
+}
 
 // GetListOfNullable returns UseStructReferencesInput.ListOfNullable, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetListOfNullable() []StructInput { return v.ListOfNullable }
+func (v *UseStructReferencesInput) GetListOfNullable() (val []StructInput) {
+	if v == nil {
+		return
+	}
+	return v.ListOfNullable
+}
 
 // GetNullableList returns UseStructReferencesInput.NullableList, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetNullableList() []StructInput { return v.NullableList }
+func (v *UseStructReferencesInput) GetNullableList() (val []StructInput) {
+	if v == nil {
+		return
+	}
+	return v.NullableList
+}
 
 // __UseStructReferenceInput is used internally by genqlient
 type __UseStructReferenceInput struct {
@@ -52,7 +85,12 @@ type __UseStructReferenceInput struct {
 }
 
 // GetInput returns __UseStructReferenceInput.Input, and is useful for accessing the field via an interface.
-func (v *__UseStructReferenceInput) GetInput() UseStructReferencesInput { return v.Input }
+func (v *__UseStructReferenceInput) GetInput() (val UseStructReferencesInput) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by UseStructReference.
 const UseStructReference_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-UsesEnumTwice.graphql-UsesEnumTwice.graphql.go
@@ -34,7 +34,12 @@ type UsesEnumTwiceQueryMeUser struct {
 }
 
 // GetRoles returns UsesEnumTwiceQueryMeUser.Roles, and is useful for accessing the field via an interface.
-func (v *UsesEnumTwiceQueryMeUser) GetRoles() []Role { return v.Roles }
+func (v *UsesEnumTwiceQueryMeUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // UsesEnumTwiceQueryOtherUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -45,7 +50,12 @@ type UsesEnumTwiceQueryOtherUser struct {
 }
 
 // GetRoles returns UsesEnumTwiceQueryOtherUser.Roles, and is useful for accessing the field via an interface.
-func (v *UsesEnumTwiceQueryOtherUser) GetRoles() []Role { return v.Roles }
+func (v *UsesEnumTwiceQueryOtherUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // UsesEnumTwiceQueryResponse is returned by UsesEnumTwiceQuery on success.
 type UsesEnumTwiceQueryResponse struct {
@@ -62,10 +72,20 @@ type UsesEnumTwiceQueryResponse struct {
 }
 
 // GetMe returns UsesEnumTwiceQueryResponse.Me, and is useful for accessing the field via an interface.
-func (v *UsesEnumTwiceQueryResponse) GetMe() UsesEnumTwiceQueryMeUser { return v.Me }
+func (v *UsesEnumTwiceQueryResponse) GetMe() (val UsesEnumTwiceQueryMeUser) {
+	if v == nil {
+		return
+	}
+	return v.Me
+}
 
 // GetOtherUser returns UsesEnumTwiceQueryResponse.OtherUser, and is useful for accessing the field via an interface.
-func (v *UsesEnumTwiceQueryResponse) GetOtherUser() UsesEnumTwiceQueryOtherUser { return v.OtherUser }
+func (v *UsesEnumTwiceQueryResponse) GetOtherUser() (val UsesEnumTwiceQueryOtherUser) {
+	if v == nil {
+		return
+	}
+	return v.OtherUser
+}
 
 // The query executed by UsesEnumTwiceQuery.
 const UsesEnumTwiceQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
+++ b/generate/testdata/snapshots/TestGenerate-unexported.graphql-unexported.graphql.go
@@ -47,25 +47,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() string { return v.Name }
+func (v *UserQueryInput) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() testutil.ID { return v.Id }
+func (v *UserQueryInput) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() testutil.Pokemon { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val testutil.Pokemon) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -154,7 +189,12 @@ type __unexportedInput struct {
 }
 
 // GetQuery returns __unexportedInput.Query, and is useful for accessing the field via an interface.
-func (v *__unexportedInput) GetQuery() UserQueryInput { return v.Query }
+func (v *__unexportedInput) GetQuery() (val UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // unexportedResponse is returned by unexported on success.
 type unexportedResponse struct {
@@ -166,7 +206,12 @@ type unexportedResponse struct {
 }
 
 // GetUser returns unexportedResponse.User, and is useful for accessing the field via an interface.
-func (v *unexportedResponse) GetUser() unexportedUser { return v.User }
+func (v *unexportedResponse) GetUser() (val unexportedUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // unexportedUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -180,7 +225,12 @@ type unexportedUser struct {
 }
 
 // GetId returns unexportedUser.Id, and is useful for accessing the field via an interface.
-func (v *unexportedUser) GetId() testutil.ID { return v.Id }
+func (v *unexportedUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by unexported.
 const unexported_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetter-testdata-queries-generated.go
@@ -19,7 +19,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -33,7 +38,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterCustomContext-testdata-queries-generated.go
@@ -22,7 +22,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -36,7 +41,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ClientGetterNoContext-testdata-queries-generated.go
@@ -17,7 +17,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -31,7 +36,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContext-testdata-queries-generated.go
@@ -22,7 +22,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -36,7 +41,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-CustomContextWithAlias-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-CustomContextWithAlias-testdata-queries-generated.go
@@ -22,7 +22,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -36,7 +41,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-DefaultConfig-testdata-queries-generated.go
@@ -18,7 +18,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingAll-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingAll-testdata-queries-generated.go
@@ -17,7 +17,12 @@ type QueryWithEnumsOtherUser struct {
 }
 
 // GetRoles returns QueryWithEnumsOtherUser.Roles, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsOtherUser) GetRoles() []Role { return v.Roles }
+func (v *QueryWithEnumsOtherUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // QueryWithEnumsResponse is returned by QueryWithEnums on success.
 type QueryWithEnumsResponse struct {
@@ -34,10 +39,20 @@ type QueryWithEnumsResponse struct {
 }
 
 // GetUser returns QueryWithEnumsResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsResponse) GetUser() QueryWithEnumsUser { return v.User }
+func (v *QueryWithEnumsResponse) GetUser() (val QueryWithEnumsUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetOtherUser returns QueryWithEnumsResponse.OtherUser, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsResponse) GetOtherUser() QueryWithEnumsOtherUser { return v.OtherUser }
+func (v *QueryWithEnumsResponse) GetOtherUser() (val QueryWithEnumsOtherUser) {
+	if v == nil {
+		return
+	}
+	return v.OtherUser
+}
 
 // QueryWithEnumsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -48,7 +63,12 @@ type QueryWithEnumsUser struct {
 }
 
 // GetRoles returns QueryWithEnumsUser.Roles, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsUser) GetRoles() []Role { return v.Roles }
+func (v *QueryWithEnumsUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // Role is a type a user may have.
 type Role string

--- a/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingSpecific-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-EnumRawCasingSpecific-testdata-queries-generated.go
@@ -17,7 +17,12 @@ type QueryWithEnumsOtherUser struct {
 }
 
 // GetRoles returns QueryWithEnumsOtherUser.Roles, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsOtherUser) GetRoles() []Role { return v.Roles }
+func (v *QueryWithEnumsOtherUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // QueryWithEnumsResponse is returned by QueryWithEnums on success.
 type QueryWithEnumsResponse struct {
@@ -34,10 +39,20 @@ type QueryWithEnumsResponse struct {
 }
 
 // GetUser returns QueryWithEnumsResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsResponse) GetUser() QueryWithEnumsUser { return v.User }
+func (v *QueryWithEnumsResponse) GetUser() (val QueryWithEnumsUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // GetOtherUser returns QueryWithEnumsResponse.OtherUser, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsResponse) GetOtherUser() QueryWithEnumsOtherUser { return v.OtherUser }
+func (v *QueryWithEnumsResponse) GetOtherUser() (val QueryWithEnumsOtherUser) {
+	if v == nil {
+		return
+	}
+	return v.OtherUser
+}
 
 // QueryWithEnumsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -48,7 +63,12 @@ type QueryWithEnumsUser struct {
 }
 
 // GetRoles returns QueryWithEnumsUser.Roles, and is useful for accessing the field via an interface.
-func (v *QueryWithEnumsUser) GetRoles() []Role { return v.Roles }
+func (v *QueryWithEnumsUser) GetRoles() (val []Role) {
+	if v == nil {
+		return
+	}
+	return v.Roles
+}
 
 // Role is a type a user may have.
 type Role string

--- a/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-ExportOperations-testdata-queries-generated.go
@@ -18,7 +18,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Extensions-testdata-queries-generated.go
@@ -18,7 +18,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-NoContext-testdata-queries-generated.go
@@ -16,7 +16,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -30,7 +35,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalGeneric-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalGeneric-testdata-queries-generated.go
@@ -19,7 +19,12 @@ type ListInputQueryResponse struct {
 }
 
 // GetUser returns ListInputQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *ListInputQueryResponse) GetUser() testutil.Option[ListInputQueryUser] { return v.User }
+func (v *ListInputQueryResponse) GetUser() (val testutil.Option[ListInputQueryUser]) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // ListInputQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -33,7 +38,12 @@ type ListInputQueryUser struct {
 }
 
 // GetId returns ListInputQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *ListInputQueryUser) GetId() string { return v.Id }
+func (v *ListInputQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // QueryWithSlicesResponse is returned by QueryWithSlices on success.
 type QueryWithSlicesResponse struct {
@@ -45,7 +55,12 @@ type QueryWithSlicesResponse struct {
 }
 
 // GetUser returns QueryWithSlicesResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesResponse) GetUser() testutil.Option[QueryWithSlicesUser] { return v.User }
+func (v *QueryWithSlicesResponse) GetUser() (val testutil.Option[QueryWithSlicesUser]) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithSlicesUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -59,18 +74,34 @@ type QueryWithSlicesUser struct {
 }
 
 // GetEmails returns QueryWithSlicesUser.Emails, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmails() []string { return v.Emails }
+func (v *QueryWithSlicesUser) GetEmails() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Emails
+}
 
 // GetEmailsOrNull returns QueryWithSlicesUser.EmailsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsOrNull() []string { return v.EmailsOrNull }
+func (v *QueryWithSlicesUser) GetEmailsOrNull() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsOrNull
+}
 
 // GetEmailsWithNulls returns QueryWithSlicesUser.EmailsWithNulls, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNulls() []testutil.Option[string] {
+func (v *QueryWithSlicesUser) GetEmailsWithNulls() (val []testutil.Option[string]) {
+	if v == nil {
+		return
+	}
 	return v.EmailsWithNulls
 }
 
 // GetEmailsWithNullsOrNull returns QueryWithSlicesUser.EmailsWithNullsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []testutil.Option[string] {
+func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() (val []testutil.Option[string]) {
+	if v == nil {
+		return
+	}
 	return v.EmailsWithNullsOrNull
 }
 
@@ -80,7 +111,12 @@ type __ListInputQueryInput struct {
 }
 
 // GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *__ListInputQueryInput) GetNames() []testutil.Option[string] { return v.Names }
+func (v *__ListInputQueryInput) GetNames() (val []testutil.Option[string]) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // The query executed by ListInputQuery.
 const ListInputQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalPointer-testdata-queries-generated.go
@@ -18,7 +18,12 @@ type ListInputQueryResponse struct {
 }
 
 // GetUser returns ListInputQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *ListInputQueryResponse) GetUser() *ListInputQueryUser { return v.User }
+func (v *ListInputQueryResponse) GetUser() (val *ListInputQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // ListInputQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type ListInputQueryUser struct {
 }
 
 // GetId returns ListInputQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *ListInputQueryUser) GetId() string { return v.Id }
+func (v *ListInputQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // QueryWithSlicesResponse is returned by QueryWithSlices on success.
 type QueryWithSlicesResponse struct {
@@ -44,7 +54,12 @@ type QueryWithSlicesResponse struct {
 }
 
 // GetUser returns QueryWithSlicesResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesResponse) GetUser() *QueryWithSlicesUser { return v.User }
+func (v *QueryWithSlicesResponse) GetUser() (val *QueryWithSlicesUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithSlicesUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -58,16 +73,36 @@ type QueryWithSlicesUser struct {
 }
 
 // GetEmails returns QueryWithSlicesUser.Emails, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmails() []string { return v.Emails }
+func (v *QueryWithSlicesUser) GetEmails() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Emails
+}
 
 // GetEmailsOrNull returns QueryWithSlicesUser.EmailsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsOrNull() []string { return v.EmailsOrNull }
+func (v *QueryWithSlicesUser) GetEmailsOrNull() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsOrNull
+}
 
 // GetEmailsWithNulls returns QueryWithSlicesUser.EmailsWithNulls, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNulls() []*string { return v.EmailsWithNulls }
+func (v *QueryWithSlicesUser) GetEmailsWithNulls() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsWithNulls
+}
 
 // GetEmailsWithNullsOrNull returns QueryWithSlicesUser.EmailsWithNullsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []*string { return v.EmailsWithNullsOrNull }
+func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsWithNullsOrNull
+}
 
 // SimpleQueryNoOverrideResponse is returned by SimpleQueryNoOverride on success.
 type SimpleQueryNoOverrideResponse struct {
@@ -79,7 +114,12 @@ type SimpleQueryNoOverrideResponse struct {
 }
 
 // GetUser returns SimpleQueryNoOverrideResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryNoOverrideResponse) GetUser() *SimpleQueryNoOverrideUser { return v.User }
+func (v *SimpleQueryNoOverrideResponse) GetUser() (val *SimpleQueryNoOverrideUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryNoOverrideUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -94,10 +134,20 @@ type SimpleQueryNoOverrideUser struct {
 }
 
 // GetId returns SimpleQueryNoOverrideUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryNoOverrideUser) GetId() string { return v.Id }
+func (v *SimpleQueryNoOverrideUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleQueryNoOverrideUser.Name, and is useful for accessing the field via an interface.
-func (v *SimpleQueryNoOverrideUser) GetName() *string { return v.Name }
+func (v *SimpleQueryNoOverrideUser) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // SimpleQueryWithPointerFalseOverrideResponse is returned by SimpleQueryWithPointerFalseOverride on success.
 type SimpleQueryWithPointerFalseOverrideResponse struct {
@@ -109,7 +159,10 @@ type SimpleQueryWithPointerFalseOverrideResponse struct {
 }
 
 // GetUser returns SimpleQueryWithPointerFalseOverrideResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryWithPointerFalseOverrideResponse) GetUser() *SimpleQueryWithPointerFalseOverrideUser {
+func (v *SimpleQueryWithPointerFalseOverrideResponse) GetUser() (val *SimpleQueryWithPointerFalseOverrideUser) {
+	if v == nil {
+		return
+	}
 	return v.User
 }
 
@@ -126,10 +179,20 @@ type SimpleQueryWithPointerFalseOverrideUser struct {
 }
 
 // GetId returns SimpleQueryWithPointerFalseOverrideUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryWithPointerFalseOverrideUser) GetId() string { return v.Id }
+func (v *SimpleQueryWithPointerFalseOverrideUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns SimpleQueryWithPointerFalseOverrideUser.Name, and is useful for accessing the field via an interface.
-func (v *SimpleQueryWithPointerFalseOverrideUser) GetName() string { return v.Name }
+func (v *SimpleQueryWithPointerFalseOverrideUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // __ListInputQueryInput is used internally by genqlient
 type __ListInputQueryInput struct {
@@ -137,7 +200,12 @@ type __ListInputQueryInput struct {
 }
 
 // GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *__ListInputQueryInput) GetNames() []*string { return v.Names }
+func (v *__ListInputQueryInput) GetNames() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // The query executed by ListInputQuery.
 const ListInputQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-OptionalValue-testdata-queries-generated.go
@@ -18,7 +18,12 @@ type ListInputQueryResponse struct {
 }
 
 // GetUser returns ListInputQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *ListInputQueryResponse) GetUser() ListInputQueryUser { return v.User }
+func (v *ListInputQueryResponse) GetUser() (val ListInputQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // ListInputQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type ListInputQueryUser struct {
 }
 
 // GetId returns ListInputQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *ListInputQueryUser) GetId() string { return v.Id }
+func (v *ListInputQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // QueryWithSlicesResponse is returned by QueryWithSlices on success.
 type QueryWithSlicesResponse struct {
@@ -44,7 +54,12 @@ type QueryWithSlicesResponse struct {
 }
 
 // GetUser returns QueryWithSlicesResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesResponse) GetUser() QueryWithSlicesUser { return v.User }
+func (v *QueryWithSlicesResponse) GetUser() (val QueryWithSlicesUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithSlicesUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -58,16 +73,36 @@ type QueryWithSlicesUser struct {
 }
 
 // GetEmails returns QueryWithSlicesUser.Emails, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmails() []string { return v.Emails }
+func (v *QueryWithSlicesUser) GetEmails() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Emails
+}
 
 // GetEmailsOrNull returns QueryWithSlicesUser.EmailsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsOrNull() []string { return v.EmailsOrNull }
+func (v *QueryWithSlicesUser) GetEmailsOrNull() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsOrNull
+}
 
 // GetEmailsWithNulls returns QueryWithSlicesUser.EmailsWithNulls, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNulls() []string { return v.EmailsWithNulls }
+func (v *QueryWithSlicesUser) GetEmailsWithNulls() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsWithNulls
+}
 
 // GetEmailsWithNullsOrNull returns QueryWithSlicesUser.EmailsWithNullsOrNull, and is useful for accessing the field via an interface.
-func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() []string { return v.EmailsWithNullsOrNull }
+func (v *QueryWithSlicesUser) GetEmailsWithNullsOrNull() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.EmailsWithNullsOrNull
+}
 
 // __ListInputQueryInput is used internally by genqlient
 type __ListInputQueryInput struct {
@@ -75,7 +110,12 @@ type __ListInputQueryInput struct {
 }
 
 // GetNames returns __ListInputQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *__ListInputQueryInput) GetNames() []string { return v.Names }
+func (v *__ListInputQueryInput) GetNames() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // The query executed by ListInputQuery.
 const ListInputQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageBindings-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageBindings-testdata-queries-generated.go
@@ -19,7 +19,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -33,7 +38,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() testutil.ID { return v.Id }
+func (v *SimpleQueryUser) GetId() (val testutil.ID) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-PackageName-testdata-queries-myfile.go
@@ -18,7 +18,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-StructReferences-testdata-queries-generated.go
@@ -22,7 +22,12 @@ type InputObjectQueryResponse struct {
 }
 
 // GetUser returns InputObjectQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *InputObjectQueryResponse) GetUser() *InputObjectQueryUser { return v.User }
+func (v *InputObjectQueryResponse) GetUser() (val *InputObjectQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // InputObjectQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -36,7 +41,12 @@ type InputObjectQueryUser struct {
 }
 
 // GetId returns InputObjectQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *InputObjectQueryUser) GetId() string { return v.Id }
+func (v *InputObjectQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 type PokemonInput struct {
 	Species string `json:"species"`
@@ -44,10 +54,20 @@ type PokemonInput struct {
 }
 
 // GetSpecies returns PokemonInput.Species, and is useful for accessing the field via an interface.
-func (v *PokemonInput) GetSpecies() string { return v.Species }
+func (v *PokemonInput) GetSpecies() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Species
+}
 
 // GetLevel returns PokemonInput.Level, and is useful for accessing the field via an interface.
-func (v *PokemonInput) GetLevel() int { return v.Level }
+func (v *PokemonInput) GetLevel() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Level
+}
 
 // QueryWithStructsResponse is returned by QueryWithStructs on success.
 type QueryWithStructsResponse struct {
@@ -59,7 +79,12 @@ type QueryWithStructsResponse struct {
 }
 
 // GetUser returns QueryWithStructsResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsResponse) GetUser() *QueryWithStructsUser { return v.User }
+func (v *QueryWithStructsResponse) GetUser() (val *QueryWithStructsUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithStructsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -70,7 +95,10 @@ type QueryWithStructsUser struct {
 }
 
 // GetAuthMethods returns QueryWithStructsUser.AuthMethods, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUser) GetAuthMethods() []*QueryWithStructsUserAuthMethodsAuthMethod {
+func (v *QueryWithStructsUser) GetAuthMethods() (val []*QueryWithStructsUserAuthMethodsAuthMethod) {
+	if v == nil {
+		return
+	}
 	return v.AuthMethods
 }
 
@@ -81,10 +109,20 @@ type QueryWithStructsUserAuthMethodsAuthMethod struct {
 }
 
 // GetProvider returns QueryWithStructsUserAuthMethodsAuthMethod.Provider, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() string { return v.Provider }
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Provider
+}
 
 // GetEmail returns QueryWithStructsUserAuthMethodsAuthMethod.Email, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() string { return v.Email }
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // Role is a type a user may have.
 type Role string
@@ -122,25 +160,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() string { return v.Name }
+func (v *UserQueryInput) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() string { return v.Id }
+func (v *UserQueryInput) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() *PokemonInput { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val *PokemonInput) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -229,7 +302,12 @@ type __InputObjectQueryInput struct {
 }
 
 // GetQuery returns __InputObjectQueryInput.Query, and is useful for accessing the field via an interface.
-func (v *__InputObjectQueryInput) GetQuery() *UserQueryInput { return v.Query }
+func (v *__InputObjectQueryInput) GetQuery() (val *UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // The query executed by InputObjectQuery.
 const InputObjectQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-StructReferencesAndOptionalPointer-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-StructReferencesAndOptionalPointer-testdata-queries-generated.go
@@ -22,7 +22,12 @@ type InputObjectQueryResponse struct {
 }
 
 // GetUser returns InputObjectQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *InputObjectQueryResponse) GetUser() *InputObjectQueryUser { return v.User }
+func (v *InputObjectQueryResponse) GetUser() (val *InputObjectQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // InputObjectQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -36,7 +41,12 @@ type InputObjectQueryUser struct {
 }
 
 // GetId returns InputObjectQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *InputObjectQueryUser) GetId() string { return v.Id }
+func (v *InputObjectQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 type PokemonInput struct {
 	Species string `json:"species"`
@@ -44,10 +54,20 @@ type PokemonInput struct {
 }
 
 // GetSpecies returns PokemonInput.Species, and is useful for accessing the field via an interface.
-func (v *PokemonInput) GetSpecies() string { return v.Species }
+func (v *PokemonInput) GetSpecies() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Species
+}
 
 // GetLevel returns PokemonInput.Level, and is useful for accessing the field via an interface.
-func (v *PokemonInput) GetLevel() int { return v.Level }
+func (v *PokemonInput) GetLevel() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Level
+}
 
 // QueryWithStructsResponse is returned by QueryWithStructs on success.
 type QueryWithStructsResponse struct {
@@ -59,7 +79,12 @@ type QueryWithStructsResponse struct {
 }
 
 // GetUser returns QueryWithStructsResponse.User, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsResponse) GetUser() *QueryWithStructsUser { return v.User }
+func (v *QueryWithStructsResponse) GetUser() (val *QueryWithStructsUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // QueryWithStructsUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -70,7 +95,10 @@ type QueryWithStructsUser struct {
 }
 
 // GetAuthMethods returns QueryWithStructsUser.AuthMethods, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUser) GetAuthMethods() []*QueryWithStructsUserAuthMethodsAuthMethod {
+func (v *QueryWithStructsUser) GetAuthMethods() (val []*QueryWithStructsUserAuthMethodsAuthMethod) {
+	if v == nil {
+		return
+	}
 	return v.AuthMethods
 }
 
@@ -81,10 +109,20 @@ type QueryWithStructsUserAuthMethodsAuthMethod struct {
 }
 
 // GetProvider returns QueryWithStructsUserAuthMethodsAuthMethod.Provider, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() *string { return v.Provider }
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetProvider() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Provider
+}
 
 // GetEmail returns QueryWithStructsUserAuthMethodsAuthMethod.Email, and is useful for accessing the field via an interface.
-func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() *string { return v.Email }
+func (v *QueryWithStructsUserAuthMethodsAuthMethod) GetEmail() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // Role is a type a user may have.
 type Role string
@@ -122,25 +160,60 @@ type UserQueryInput struct {
 }
 
 // GetEmail returns UserQueryInput.Email, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetEmail() *string { return v.Email }
+func (v *UserQueryInput) GetEmail() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Email
+}
 
 // GetName returns UserQueryInput.Name, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetName() *string { return v.Name }
+func (v *UserQueryInput) GetName() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetId returns UserQueryInput.Id, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetId() *string { return v.Id }
+func (v *UserQueryInput) GetId() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetRole returns UserQueryInput.Role, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetRole() *Role { return v.Role }
+func (v *UserQueryInput) GetRole() (val *Role) {
+	if v == nil {
+		return
+	}
+	return v.Role
+}
 
 // GetNames returns UserQueryInput.Names, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetNames() []*string { return v.Names }
+func (v *UserQueryInput) GetNames() (val []*string) {
+	if v == nil {
+		return
+	}
+	return v.Names
+}
 
 // GetHasPokemon returns UserQueryInput.HasPokemon, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetHasPokemon() *PokemonInput { return v.HasPokemon }
+func (v *UserQueryInput) GetHasPokemon() (val *PokemonInput) {
+	if v == nil {
+		return
+	}
+	return v.HasPokemon
+}
 
 // GetBirthdate returns UserQueryInput.Birthdate, and is useful for accessing the field via an interface.
-func (v *UserQueryInput) GetBirthdate() *time.Time { return v.Birthdate }
+func (v *UserQueryInput) GetBirthdate() (val *time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *UserQueryInput) UnmarshalJSON(b []byte) error {
 
@@ -232,7 +305,12 @@ type __InputObjectQueryInput struct {
 }
 
 // GetQuery returns __InputObjectQueryInput.Query, and is useful for accessing the field via an interface.
-func (v *__InputObjectQueryInput) GetQuery() *UserQueryInput { return v.Query }
+func (v *__InputObjectQueryInput) GetQuery() (val *UserQueryInput) {
+	if v == nil {
+		return
+	}
+	return v.Query
+}
 
 // The query executed by InputObjectQuery.
 const InputObjectQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-Subpackage-testdata-queries-mypkg-myfile.go
@@ -18,7 +18,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-SubpackageConfig-testdata-queries-mypkg-myfile.go
@@ -18,7 +18,12 @@ type SimpleQueryResponse struct {
 }
 
 // GetUser returns SimpleQueryResponse.User, and is useful for accessing the field via an interface.
-func (v *SimpleQueryResponse) GetUser() SimpleQueryUser { return v.User }
+func (v *SimpleQueryResponse) GetUser() (val SimpleQueryUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // SimpleQueryUser includes the requested fields of the GraphQL type User.
 // The GraphQL type's documentation follows.
@@ -32,7 +37,12 @@ type SimpleQueryUser struct {
 }
 
 // GetId returns SimpleQueryUser.Id, and is useful for accessing the field via an interface.
-func (v *SimpleQueryUser) GetId() string { return v.Id }
+func (v *SimpleQueryUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // The query executed by SimpleQuery.
 const SimpleQuery_Operation = `

--- a/generate/testdata/snapshots/TestGenerateWithConfig-UseStructReference-testdata-queries-generated.go
+++ b/generate/testdata/snapshots/TestGenerateWithConfig-UseStructReference-testdata-queries-generated.go
@@ -13,7 +13,12 @@ type StructInput struct {
 }
 
 // GetField returns StructInput.Field, and is useful for accessing the field via an interface.
-func (v *StructInput) GetField() string { return v.Field }
+func (v *StructInput) GetField() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Field
+}
 
 // UseStructReferenceResponse is returned by UseStructReference on success.
 type UseStructReferenceResponse struct {
@@ -21,7 +26,10 @@ type UseStructReferenceResponse struct {
 }
 
 // GetUseStructReferencesInput returns UseStructReferenceResponse.UseStructReferencesInput, and is useful for accessing the field via an interface.
-func (v *UseStructReferenceResponse) GetUseStructReferencesInput() bool {
+func (v *UseStructReferenceResponse) GetUseStructReferencesInput() (val bool) {
+	if v == nil {
+		return
+	}
 	return v.UseStructReferencesInput
 }
 
@@ -34,19 +42,44 @@ type UseStructReferencesInput struct {
 }
 
 // GetStruct returns UseStructReferencesInput.Struct, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetStruct() *StructInput { return v.Struct }
+func (v *UseStructReferencesInput) GetStruct() (val *StructInput) {
+	if v == nil {
+		return
+	}
+	return v.Struct
+}
 
 // GetNullableStruct returns UseStructReferencesInput.NullableStruct, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetNullableStruct() *StructInput { return v.NullableStruct }
+func (v *UseStructReferencesInput) GetNullableStruct() (val *StructInput) {
+	if v == nil {
+		return
+	}
+	return v.NullableStruct
+}
 
 // GetList returns UseStructReferencesInput.List, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetList() []*StructInput { return v.List }
+func (v *UseStructReferencesInput) GetList() (val []*StructInput) {
+	if v == nil {
+		return
+	}
+	return v.List
+}
 
 // GetListOfNullable returns UseStructReferencesInput.ListOfNullable, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetListOfNullable() []*StructInput { return v.ListOfNullable }
+func (v *UseStructReferencesInput) GetListOfNullable() (val []*StructInput) {
+	if v == nil {
+		return
+	}
+	return v.ListOfNullable
+}
 
 // GetNullableList returns UseStructReferencesInput.NullableList, and is useful for accessing the field via an interface.
-func (v *UseStructReferencesInput) GetNullableList() []*StructInput { return v.NullableList }
+func (v *UseStructReferencesInput) GetNullableList() (val []*StructInput) {
+	if v == nil {
+		return
+	}
+	return v.NullableList
+}
 
 // __UseStructReferenceInput is used internally by genqlient
 type __UseStructReferenceInput struct {
@@ -54,7 +87,12 @@ type __UseStructReferenceInput struct {
 }
 
 // GetInput returns __UseStructReferenceInput.Input, and is useful for accessing the field via an interface.
-func (v *__UseStructReferenceInput) GetInput() *UseStructReferencesInput { return v.Input }
+func (v *__UseStructReferenceInput) GetInput() (val *UseStructReferencesInput) {
+	if v == nil {
+		return
+	}
+	return v.Input
+}
 
 // The query executed by UseStructReference.
 const UseStructReference_Operation = `

--- a/generate/types.go
+++ b/generate/types.go
@@ -425,7 +425,7 @@ func (typ *goStructType) WriteDefinition(w io.Writer, g *generator) error {
 			"Get%s returns %s.%s, and is useful for accessing the field via an interface.",
 			field.GoName, typ.GoName, field.GoName)
 		writeDescription(w, description)
-		fmt.Fprintf(w, "func (v *%s) Get%s() %s { return v.%s }\n",
+		fmt.Fprintf(w, "func (v *%s) Get%s() (val %s) { if v == nil { return }; return v.%s }\n",
 			typ.GoName, field.GoName, field.GoType.Reference(), field.Selector)
 	}
 

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -21,13 +21,28 @@ type AnimalFields struct {
 }
 
 // GetId returns AnimalFields.Id, and is useful for accessing the field via an interface.
-func (v *AnimalFields) GetId() string { return v.Id }
+func (v *AnimalFields) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetHair returns AnimalFields.Hair, and is useful for accessing the field via an interface.
-func (v *AnimalFields) GetHair() AnimalFieldsHairBeingsHair { return v.Hair }
+func (v *AnimalFields) GetHair() (val AnimalFieldsHairBeingsHair) {
+	if v == nil {
+		return
+	}
+	return v.Hair
+}
 
 // GetOwner returns AnimalFields.Owner, and is useful for accessing the field via an interface.
-func (v *AnimalFields) GetOwner() AnimalFieldsOwnerBeing { return v.Owner }
+func (v *AnimalFields) GetOwner() (val AnimalFieldsOwnerBeing) {
+	if v == nil {
+		return
+	}
+	return v.Owner
+}
 
 func (v *AnimalFields) UnmarshalJSON(b []byte) error {
 
@@ -104,7 +119,12 @@ type AnimalFieldsHairBeingsHair struct {
 }
 
 // GetHasHair returns AnimalFieldsHairBeingsHair.HasHair, and is useful for accessing the field via an interface.
-func (v *AnimalFieldsHairBeingsHair) GetHasHair() bool { return v.HasHair }
+func (v *AnimalFieldsHairBeingsHair) GetHasHair() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.HasHair
+}
 
 // AnimalFieldsOwnerAnimal includes the requested fields of the GraphQL type Animal.
 type AnimalFieldsOwnerAnimal struct {
@@ -113,10 +133,20 @@ type AnimalFieldsOwnerAnimal struct {
 }
 
 // GetTypename returns AnimalFieldsOwnerAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *AnimalFieldsOwnerAnimal) GetTypename() string { return v.Typename }
+func (v *AnimalFieldsOwnerAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns AnimalFieldsOwnerAnimal.Id, and is useful for accessing the field via an interface.
-func (v *AnimalFieldsOwnerAnimal) GetId() string { return v.Id }
+func (v *AnimalFieldsOwnerAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // AnimalFieldsOwnerBeing includes the requested fields of the GraphQL interface Being.
 //
@@ -204,16 +234,36 @@ type AnimalFieldsOwnerUser struct {
 }
 
 // GetTypename returns AnimalFieldsOwnerUser.Typename, and is useful for accessing the field via an interface.
-func (v *AnimalFieldsOwnerUser) GetTypename() string { return v.Typename }
+func (v *AnimalFieldsOwnerUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns AnimalFieldsOwnerUser.Id, and is useful for accessing the field via an interface.
-func (v *AnimalFieldsOwnerUser) GetId() string { return v.Id }
+func (v *AnimalFieldsOwnerUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetLuckyNumber returns AnimalFieldsOwnerUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *AnimalFieldsOwnerUser) GetLuckyNumber() int { return v.LuckyFieldsUser.LuckyNumber }
+func (v *AnimalFieldsOwnerUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyFieldsUser.LuckyNumber
+}
 
 // GetHair returns AnimalFieldsOwnerUser.Hair, and is useful for accessing the field via an interface.
-func (v *AnimalFieldsOwnerUser) GetHair() MoreUserFieldsHair { return v.UserFields.MoreUserFields.Hair }
+func (v *AnimalFieldsOwnerUser) GetHair() (val MoreUserFieldsHair) {
+	if v == nil {
+		return
+	}
+	return v.UserFields.MoreUserFields.Hair
+}
 
 func (v *AnimalFieldsOwnerUser) UnmarshalJSON(b []byte) error {
 
@@ -280,10 +330,20 @@ type FriendsFields struct {
 }
 
 // GetId returns FriendsFields.Id, and is useful for accessing the field via an interface.
-func (v *FriendsFields) GetId() string { return v.Id }
+func (v *FriendsFields) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns FriendsFields.Name, and is useful for accessing the field via an interface.
-func (v *FriendsFields) GetName() string { return v.Name }
+func (v *FriendsFields) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InnerBeingFields includes the GraphQL fields of Being requested by the fragment InnerBeingFields.
 //
@@ -365,10 +425,20 @@ type InnerBeingFieldsAnimal struct {
 }
 
 // GetId returns InnerBeingFieldsAnimal.Id, and is useful for accessing the field via an interface.
-func (v *InnerBeingFieldsAnimal) GetId() string { return v.Id }
+func (v *InnerBeingFieldsAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InnerBeingFieldsAnimal.Name, and is useful for accessing the field via an interface.
-func (v *InnerBeingFieldsAnimal) GetName() string { return v.Name }
+func (v *InnerBeingFieldsAnimal) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // InnerBeingFields includes the GraphQL fields of User requested by the fragment InnerBeingFields.
 type InnerBeingFieldsUser struct {
@@ -378,13 +448,28 @@ type InnerBeingFieldsUser struct {
 }
 
 // GetId returns InnerBeingFieldsUser.Id, and is useful for accessing the field via an interface.
-func (v *InnerBeingFieldsUser) GetId() string { return v.Id }
+func (v *InnerBeingFieldsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns InnerBeingFieldsUser.Name, and is useful for accessing the field via an interface.
-func (v *InnerBeingFieldsUser) GetName() string { return v.Name }
+func (v *InnerBeingFieldsUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetFriends returns InnerBeingFieldsUser.Friends, and is useful for accessing the field via an interface.
-func (v *InnerBeingFieldsUser) GetFriends() []FriendsFields { return v.Friends }
+func (v *InnerBeingFieldsUser) GetFriends() (val []FriendsFields) {
+	if v == nil {
+		return
+	}
+	return v.Friends
+}
 
 // InnerLuckyFields includes the GraphQL fields of Lucky requested by the fragment InnerLuckyFields.
 //
@@ -450,7 +535,12 @@ type InnerLuckyFieldsUser struct {
 }
 
 // GetLuckyNumber returns InnerLuckyFieldsUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *InnerLuckyFieldsUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *InnerLuckyFieldsUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // LuckyFields includes the GraphQL fields of Lucky requested by the fragment LuckyFields.
 //
@@ -521,13 +611,28 @@ type LuckyFieldsUser struct {
 }
 
 // GetLuckyNumber returns LuckyFieldsUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *LuckyFieldsUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *LuckyFieldsUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // GetId returns LuckyFieldsUser.Id, and is useful for accessing the field via an interface.
-func (v *LuckyFieldsUser) GetId() string { return v.MoreUserFields.Id }
+func (v *LuckyFieldsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.MoreUserFields.Id
+}
 
 // GetHair returns LuckyFieldsUser.Hair, and is useful for accessing the field via an interface.
-func (v *LuckyFieldsUser) GetHair() MoreUserFieldsHair { return v.MoreUserFields.Hair }
+func (v *LuckyFieldsUser) GetHair() (val MoreUserFieldsHair) {
+	if v == nil {
+		return
+	}
+	return v.MoreUserFields.Hair
+}
 
 func (v *LuckyFieldsUser) UnmarshalJSON(b []byte) error {
 
@@ -586,10 +691,20 @@ type MoreUserFields struct {
 }
 
 // GetId returns MoreUserFields.Id, and is useful for accessing the field via an interface.
-func (v *MoreUserFields) GetId() string { return v.Id }
+func (v *MoreUserFields) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetHair returns MoreUserFields.Hair, and is useful for accessing the field via an interface.
-func (v *MoreUserFields) GetHair() MoreUserFieldsHair { return v.Hair }
+func (v *MoreUserFields) GetHair() (val MoreUserFieldsHair) {
+	if v == nil {
+		return
+	}
+	return v.Hair
+}
 
 // MoreUserFieldsHair includes the requested fields of the GraphQL type Hair.
 type MoreUserFieldsHair struct {
@@ -597,14 +712,24 @@ type MoreUserFieldsHair struct {
 }
 
 // GetColor returns MoreUserFieldsHair.Color, and is useful for accessing the field via an interface.
-func (v *MoreUserFieldsHair) GetColor() string { return v.Color }
+func (v *MoreUserFieldsHair) GetColor() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Color
+}
 
 type NewUser struct {
 	Name string `json:"name"`
 }
 
 // GetName returns NewUser.Name, and is useful for accessing the field via an interface.
-func (v *NewUser) GetName() string { return v.Name }
+func (v *NewUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // QueryFragment includes the GraphQL fields of Query requested by the fragment QueryFragment.
 type QueryFragment struct {
@@ -612,7 +737,12 @@ type QueryFragment struct {
 }
 
 // GetBeings returns QueryFragment.Beings, and is useful for accessing the field via an interface.
-func (v *QueryFragment) GetBeings() []QueryFragmentBeingsBeing { return v.Beings }
+func (v *QueryFragment) GetBeings() (val []QueryFragmentBeingsBeing) {
+	if v == nil {
+		return
+	}
+	return v.Beings
+}
 
 func (v *QueryFragment) UnmarshalJSON(b []byte) error {
 
@@ -697,13 +827,28 @@ type QueryFragmentBeingsAnimal struct {
 }
 
 // GetTypename returns QueryFragmentBeingsAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *QueryFragmentBeingsAnimal) GetTypename() string { return v.Typename }
+func (v *QueryFragmentBeingsAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns QueryFragmentBeingsAnimal.Id, and is useful for accessing the field via an interface.
-func (v *QueryFragmentBeingsAnimal) GetId() string { return v.Id }
+func (v *QueryFragmentBeingsAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetOwner returns QueryFragmentBeingsAnimal.Owner, and is useful for accessing the field via an interface.
-func (v *QueryFragmentBeingsAnimal) GetOwner() InnerBeingFields { return v.Owner }
+func (v *QueryFragmentBeingsAnimal) GetOwner() (val InnerBeingFields) {
+	if v == nil {
+		return
+	}
+	return v.Owner
+}
 
 func (v *QueryFragmentBeingsAnimal) UnmarshalJSON(b []byte) error {
 
@@ -863,13 +1008,28 @@ type QueryFragmentBeingsUser struct {
 }
 
 // GetTypename returns QueryFragmentBeingsUser.Typename, and is useful for accessing the field via an interface.
-func (v *QueryFragmentBeingsUser) GetTypename() string { return v.Typename }
+func (v *QueryFragmentBeingsUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns QueryFragmentBeingsUser.Id, and is useful for accessing the field via an interface.
-func (v *QueryFragmentBeingsUser) GetId() string { return v.Id }
+func (v *QueryFragmentBeingsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetLuckyNumber returns QueryFragmentBeingsUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *QueryFragmentBeingsUser) GetLuckyNumber() int { return v.InnerLuckyFieldsUser.LuckyNumber }
+func (v *QueryFragmentBeingsUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.InnerLuckyFieldsUser.LuckyNumber
+}
 
 func (v *QueryFragmentBeingsUser) UnmarshalJSON(b []byte) error {
 
@@ -941,13 +1101,28 @@ type UserFields struct {
 }
 
 // GetId returns UserFields.Id, and is useful for accessing the field via an interface.
-func (v *UserFields) GetId() string { return v.Id }
+func (v *UserFields) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetLuckyNumber returns UserFields.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *UserFields) GetLuckyNumber() int { return v.LuckyFieldsUser.LuckyNumber }
+func (v *UserFields) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyFieldsUser.LuckyNumber
+}
 
 // GetHair returns UserFields.Hair, and is useful for accessing the field via an interface.
-func (v *UserFields) GetHair() MoreUserFieldsHair { return v.MoreUserFields.Hair }
+func (v *UserFields) GetHair() (val MoreUserFieldsHair) {
+	if v == nil {
+		return
+	}
+	return v.MoreUserFields.Hair
+}
 
 func (v *UserFields) UnmarshalJSON(b []byte) error {
 
@@ -1010,7 +1185,12 @@ type __createUserInput struct {
 }
 
 // GetUser returns __createUserInput.User, and is useful for accessing the field via an interface.
-func (v *__createUserInput) GetUser() NewUser { return v.User }
+func (v *__createUserInput) GetUser() (val NewUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // __queryWithCustomMarshalInput is used internally by genqlient
 type __queryWithCustomMarshalInput struct {
@@ -1018,7 +1198,12 @@ type __queryWithCustomMarshalInput struct {
 }
 
 // GetDate returns __queryWithCustomMarshalInput.Date, and is useful for accessing the field via an interface.
-func (v *__queryWithCustomMarshalInput) GetDate() time.Time { return v.Date }
+func (v *__queryWithCustomMarshalInput) GetDate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Date
+}
 
 func (v *__queryWithCustomMarshalInput) UnmarshalJSON(b []byte) error {
 
@@ -1090,10 +1275,20 @@ type __queryWithCustomMarshalOptionalInput struct {
 }
 
 // GetDate returns __queryWithCustomMarshalOptionalInput.Date, and is useful for accessing the field via an interface.
-func (v *__queryWithCustomMarshalOptionalInput) GetDate() *time.Time { return v.Date }
+func (v *__queryWithCustomMarshalOptionalInput) GetDate() (val *time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Date
+}
 
 // GetId returns __queryWithCustomMarshalOptionalInput.Id, and is useful for accessing the field via an interface.
-func (v *__queryWithCustomMarshalOptionalInput) GetId() *string { return v.Id }
+func (v *__queryWithCustomMarshalOptionalInput) GetId() (val *string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 func (v *__queryWithCustomMarshalOptionalInput) UnmarshalJSON(b []byte) error {
 
@@ -1170,7 +1365,12 @@ type __queryWithCustomMarshalSliceInput struct {
 }
 
 // GetDates returns __queryWithCustomMarshalSliceInput.Dates, and is useful for accessing the field via an interface.
-func (v *__queryWithCustomMarshalSliceInput) GetDates() []time.Time { return v.Dates }
+func (v *__queryWithCustomMarshalSliceInput) GetDates() (val []time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Dates
+}
 
 func (v *__queryWithCustomMarshalSliceInput) UnmarshalJSON(b []byte) error {
 
@@ -1253,7 +1453,12 @@ type __queryWithFlattenInput struct {
 }
 
 // GetIds returns __queryWithFlattenInput.Ids, and is useful for accessing the field via an interface.
-func (v *__queryWithFlattenInput) GetIds() []string { return v.Ids }
+func (v *__queryWithFlattenInput) GetIds() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Ids
+}
 
 // __queryWithFragmentsInput is used internally by genqlient
 type __queryWithFragmentsInput struct {
@@ -1261,7 +1466,12 @@ type __queryWithFragmentsInput struct {
 }
 
 // GetIds returns __queryWithFragmentsInput.Ids, and is useful for accessing the field via an interface.
-func (v *__queryWithFragmentsInput) GetIds() []string { return v.Ids }
+func (v *__queryWithFragmentsInput) GetIds() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Ids
+}
 
 // __queryWithInterfaceListFieldInput is used internally by genqlient
 type __queryWithInterfaceListFieldInput struct {
@@ -1269,7 +1479,12 @@ type __queryWithInterfaceListFieldInput struct {
 }
 
 // GetIds returns __queryWithInterfaceListFieldInput.Ids, and is useful for accessing the field via an interface.
-func (v *__queryWithInterfaceListFieldInput) GetIds() []string { return v.Ids }
+func (v *__queryWithInterfaceListFieldInput) GetIds() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Ids
+}
 
 // __queryWithInterfaceListPointerFieldInput is used internally by genqlient
 type __queryWithInterfaceListPointerFieldInput struct {
@@ -1277,7 +1492,12 @@ type __queryWithInterfaceListPointerFieldInput struct {
 }
 
 // GetIds returns __queryWithInterfaceListPointerFieldInput.Ids, and is useful for accessing the field via an interface.
-func (v *__queryWithInterfaceListPointerFieldInput) GetIds() []string { return v.Ids }
+func (v *__queryWithInterfaceListPointerFieldInput) GetIds() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Ids
+}
 
 // __queryWithInterfaceNoFragmentsInput is used internally by genqlient
 type __queryWithInterfaceNoFragmentsInput struct {
@@ -1285,7 +1505,12 @@ type __queryWithInterfaceNoFragmentsInput struct {
 }
 
 // GetId returns __queryWithInterfaceNoFragmentsInput.Id, and is useful for accessing the field via an interface.
-func (v *__queryWithInterfaceNoFragmentsInput) GetId() string { return v.Id }
+func (v *__queryWithInterfaceNoFragmentsInput) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // __queryWithNamedFragmentsInput is used internally by genqlient
 type __queryWithNamedFragmentsInput struct {
@@ -1293,7 +1518,12 @@ type __queryWithNamedFragmentsInput struct {
 }
 
 // GetIds returns __queryWithNamedFragmentsInput.Ids, and is useful for accessing the field via an interface.
-func (v *__queryWithNamedFragmentsInput) GetIds() []string { return v.Ids }
+func (v *__queryWithNamedFragmentsInput) GetIds() (val []string) {
+	if v == nil {
+		return
+	}
+	return v.Ids
+}
 
 // __queryWithOmitemptyInput is used internally by genqlient
 type __queryWithOmitemptyInput struct {
@@ -1301,7 +1531,12 @@ type __queryWithOmitemptyInput struct {
 }
 
 // GetId returns __queryWithOmitemptyInput.Id, and is useful for accessing the field via an interface.
-func (v *__queryWithOmitemptyInput) GetId() string { return v.Id }
+func (v *__queryWithOmitemptyInput) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // __queryWithVariablesInput is used internally by genqlient
 type __queryWithVariablesInput struct {
@@ -1309,7 +1544,12 @@ type __queryWithVariablesInput struct {
 }
 
 // GetId returns __queryWithVariablesInput.Id, and is useful for accessing the field via an interface.
-func (v *__queryWithVariablesInput) GetId() string { return v.Id }
+func (v *__queryWithVariablesInput) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // countResponse is returned by count on success.
 type countResponse struct {
@@ -1317,7 +1557,12 @@ type countResponse struct {
 }
 
 // GetCount returns countResponse.Count, and is useful for accessing the field via an interface.
-func (v *countResponse) GetCount() int { return v.Count }
+func (v *countResponse) GetCount() (val int) {
+	if v == nil {
+		return
+	}
+	return v.Count
+}
 
 // createUserCreateUser includes the requested fields of the GraphQL type User.
 type createUserCreateUser struct {
@@ -1326,10 +1571,20 @@ type createUserCreateUser struct {
 }
 
 // GetId returns createUserCreateUser.Id, and is useful for accessing the field via an interface.
-func (v *createUserCreateUser) GetId() string { return v.Id }
+func (v *createUserCreateUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns createUserCreateUser.Name, and is useful for accessing the field via an interface.
-func (v *createUserCreateUser) GetName() string { return v.Name }
+func (v *createUserCreateUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // createUserResponse is returned by createUser on success.
 type createUserResponse struct {
@@ -1337,7 +1592,12 @@ type createUserResponse struct {
 }
 
 // GetCreateUser returns createUserResponse.CreateUser, and is useful for accessing the field via an interface.
-func (v *createUserResponse) GetCreateUser() createUserCreateUser { return v.CreateUser }
+func (v *createUserResponse) GetCreateUser() (val createUserCreateUser) {
+	if v == nil {
+		return
+	}
+	return v.CreateUser
+}
 
 // failingQueryMeUser includes the requested fields of the GraphQL type User.
 type failingQueryMeUser struct {
@@ -1345,7 +1605,12 @@ type failingQueryMeUser struct {
 }
 
 // GetId returns failingQueryMeUser.Id, and is useful for accessing the field via an interface.
-func (v *failingQueryMeUser) GetId() string { return v.Id }
+func (v *failingQueryMeUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // failingQueryResponse is returned by failingQuery on success.
 type failingQueryResponse struct {
@@ -1354,10 +1619,20 @@ type failingQueryResponse struct {
 }
 
 // GetFail returns failingQueryResponse.Fail, and is useful for accessing the field via an interface.
-func (v *failingQueryResponse) GetFail() bool { return v.Fail }
+func (v *failingQueryResponse) GetFail() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.Fail
+}
 
 // GetMe returns failingQueryResponse.Me, and is useful for accessing the field via an interface.
-func (v *failingQueryResponse) GetMe() failingQueryMeUser { return v.Me }
+func (v *failingQueryResponse) GetMe() (val failingQueryMeUser) {
+	if v == nil {
+		return
+	}
+	return v.Me
+}
 
 // queryWithCustomMarshalOptionalResponse is returned by queryWithCustomMarshalOptional on success.
 type queryWithCustomMarshalOptionalResponse struct {
@@ -1365,7 +1640,10 @@ type queryWithCustomMarshalOptionalResponse struct {
 }
 
 // GetUserSearch returns queryWithCustomMarshalOptionalResponse.UserSearch, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalOptionalResponse) GetUserSearch() []queryWithCustomMarshalOptionalUserSearchUser {
+func (v *queryWithCustomMarshalOptionalResponse) GetUserSearch() (val []queryWithCustomMarshalOptionalUserSearchUser) {
+	if v == nil {
+		return
+	}
 	return v.UserSearch
 }
 
@@ -1377,13 +1655,28 @@ type queryWithCustomMarshalOptionalUserSearchUser struct {
 }
 
 // GetId returns queryWithCustomMarshalOptionalUserSearchUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalOptionalUserSearchUser) GetId() string { return v.Id }
+func (v *queryWithCustomMarshalOptionalUserSearchUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithCustomMarshalOptionalUserSearchUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalOptionalUserSearchUser) GetName() string { return v.Name }
+func (v *queryWithCustomMarshalOptionalUserSearchUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetBirthdate returns queryWithCustomMarshalOptionalUserSearchUser.Birthdate, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalOptionalUserSearchUser) GetBirthdate() time.Time { return v.Birthdate }
+func (v *queryWithCustomMarshalOptionalUserSearchUser) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *queryWithCustomMarshalOptionalUserSearchUser) UnmarshalJSON(b []byte) error {
 
@@ -1460,7 +1753,10 @@ type queryWithCustomMarshalResponse struct {
 }
 
 // GetUsersBornOn returns queryWithCustomMarshalResponse.UsersBornOn, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalResponse) GetUsersBornOn() []queryWithCustomMarshalUsersBornOnUser {
+func (v *queryWithCustomMarshalResponse) GetUsersBornOn() (val []queryWithCustomMarshalUsersBornOnUser) {
+	if v == nil {
+		return
+	}
 	return v.UsersBornOn
 }
 
@@ -1470,7 +1766,10 @@ type queryWithCustomMarshalSliceResponse struct {
 }
 
 // GetUsersBornOnDates returns queryWithCustomMarshalSliceResponse.UsersBornOnDates, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalSliceResponse) GetUsersBornOnDates() []queryWithCustomMarshalSliceUsersBornOnDatesUser {
+func (v *queryWithCustomMarshalSliceResponse) GetUsersBornOnDates() (val []queryWithCustomMarshalSliceUsersBornOnDatesUser) {
+	if v == nil {
+		return
+	}
 	return v.UsersBornOnDates
 }
 
@@ -1482,13 +1781,26 @@ type queryWithCustomMarshalSliceUsersBornOnDatesUser struct {
 }
 
 // GetId returns queryWithCustomMarshalSliceUsersBornOnDatesUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetId() string { return v.Id }
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithCustomMarshalSliceUsersBornOnDatesUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetName() string { return v.Name }
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetBirthdate returns queryWithCustomMarshalSliceUsersBornOnDatesUser.Birthdate, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetBirthdate() time.Time {
+func (v *queryWithCustomMarshalSliceUsersBornOnDatesUser) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
 	return v.Birthdate
 }
 
@@ -1569,13 +1881,28 @@ type queryWithCustomMarshalUsersBornOnUser struct {
 }
 
 // GetId returns queryWithCustomMarshalUsersBornOnUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalUsersBornOnUser) GetId() string { return v.Id }
+func (v *queryWithCustomMarshalUsersBornOnUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithCustomMarshalUsersBornOnUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalUsersBornOnUser) GetName() string { return v.Name }
+func (v *queryWithCustomMarshalUsersBornOnUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetBirthdate returns queryWithCustomMarshalUsersBornOnUser.Birthdate, and is useful for accessing the field via an interface.
-func (v *queryWithCustomMarshalUsersBornOnUser) GetBirthdate() time.Time { return v.Birthdate }
+func (v *queryWithCustomMarshalUsersBornOnUser) GetBirthdate() (val time.Time) {
+	if v == nil {
+		return
+	}
+	return v.Birthdate
+}
 
 func (v *queryWithCustomMarshalUsersBornOnUser) UnmarshalJSON(b []byte) error {
 
@@ -1657,24 +1984,50 @@ type queryWithFragmentsBeingsAnimal struct {
 }
 
 // GetTypename returns queryWithFragmentsBeingsAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimal) GetTypename() string { return v.Typename }
+func (v *queryWithFragmentsBeingsAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithFragmentsBeingsAnimal.Id, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimal) GetId() string { return v.Id }
+func (v *queryWithFragmentsBeingsAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithFragmentsBeingsAnimal.Name, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimal) GetName() string { return v.Name }
+func (v *queryWithFragmentsBeingsAnimal) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetHair returns queryWithFragmentsBeingsAnimal.Hair, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimal) GetHair() queryWithFragmentsBeingsAnimalHairBeingsHair {
+func (v *queryWithFragmentsBeingsAnimal) GetHair() (val queryWithFragmentsBeingsAnimalHairBeingsHair) {
+	if v == nil {
+		return
+	}
 	return v.Hair
 }
 
 // GetSpecies returns queryWithFragmentsBeingsAnimal.Species, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimal) GetSpecies() Species { return v.Species }
+func (v *queryWithFragmentsBeingsAnimal) GetSpecies() (val Species) {
+	if v == nil {
+		return
+	}
+	return v.Species
+}
 
 // GetOwner returns queryWithFragmentsBeingsAnimal.Owner, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimal) GetOwner() queryWithFragmentsBeingsAnimalOwnerBeing {
+func (v *queryWithFragmentsBeingsAnimal) GetOwner() (val queryWithFragmentsBeingsAnimalOwnerBeing) {
+	if v == nil {
+		return
+	}
 	return v.Owner
 }
 
@@ -1762,7 +2115,12 @@ type queryWithFragmentsBeingsAnimalHairBeingsHair struct {
 }
 
 // GetHasHair returns queryWithFragmentsBeingsAnimalHairBeingsHair.HasHair, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalHairBeingsHair) GetHasHair() bool { return v.HasHair }
+func (v *queryWithFragmentsBeingsAnimalHairBeingsHair) GetHasHair() (val bool) {
+	if v == nil {
+		return
+	}
+	return v.HasHair
+}
 
 // queryWithFragmentsBeingsAnimalOwnerAnimal includes the requested fields of the GraphQL type Animal.
 type queryWithFragmentsBeingsAnimalOwnerAnimal struct {
@@ -1772,13 +2130,28 @@ type queryWithFragmentsBeingsAnimalOwnerAnimal struct {
 }
 
 // GetTypename returns queryWithFragmentsBeingsAnimalOwnerAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetTypename() string { return v.Typename }
+func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithFragmentsBeingsAnimalOwnerAnimal.Id, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetId() string { return v.Id }
+func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithFragmentsBeingsAnimalOwnerAnimal.Name, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetName() string { return v.Name }
+func (v *queryWithFragmentsBeingsAnimalOwnerAnimal) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithFragmentsBeingsAnimalOwnerBeing includes the requested fields of the GraphQL interface Being.
 //
@@ -1866,16 +2239,36 @@ type queryWithFragmentsBeingsAnimalOwnerUser struct {
 }
 
 // GetTypename returns queryWithFragmentsBeingsAnimalOwnerUser.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetTypename() string { return v.Typename }
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithFragmentsBeingsAnimalOwnerUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetId() string { return v.Id }
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithFragmentsBeingsAnimalOwnerUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetName() string { return v.Name }
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetLuckyNumber returns queryWithFragmentsBeingsAnimalOwnerUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *queryWithFragmentsBeingsAnimalOwnerUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // queryWithFragmentsBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
@@ -1966,19 +2359,44 @@ type queryWithFragmentsBeingsUser struct {
 }
 
 // GetTypename returns queryWithFragmentsBeingsUser.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsUser) GetTypename() string { return v.Typename }
+func (v *queryWithFragmentsBeingsUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithFragmentsBeingsUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsUser) GetId() string { return v.Id }
+func (v *queryWithFragmentsBeingsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithFragmentsBeingsUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsUser) GetName() string { return v.Name }
+func (v *queryWithFragmentsBeingsUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetLuckyNumber returns queryWithFragmentsBeingsUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *queryWithFragmentsBeingsUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // GetHair returns queryWithFragmentsBeingsUser.Hair, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsUser) GetHair() queryWithFragmentsBeingsUserHair { return v.Hair }
+func (v *queryWithFragmentsBeingsUser) GetHair() (val queryWithFragmentsBeingsUserHair) {
+	if v == nil {
+		return
+	}
+	return v.Hair
+}
 
 // queryWithFragmentsBeingsUserHair includes the requested fields of the GraphQL type Hair.
 type queryWithFragmentsBeingsUserHair struct {
@@ -1986,7 +2404,12 @@ type queryWithFragmentsBeingsUserHair struct {
 }
 
 // GetColor returns queryWithFragmentsBeingsUserHair.Color, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsBeingsUserHair) GetColor() string { return v.Color }
+func (v *queryWithFragmentsBeingsUserHair) GetColor() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Color
+}
 
 // queryWithFragmentsResponse is returned by queryWithFragments on success.
 type queryWithFragmentsResponse struct {
@@ -1994,7 +2417,12 @@ type queryWithFragmentsResponse struct {
 }
 
 // GetBeings returns queryWithFragmentsResponse.Beings, and is useful for accessing the field via an interface.
-func (v *queryWithFragmentsResponse) GetBeings() []queryWithFragmentsBeingsBeing { return v.Beings }
+func (v *queryWithFragmentsResponse) GetBeings() (val []queryWithFragmentsBeingsBeing) {
+	if v == nil {
+		return
+	}
+	return v.Beings
+}
 
 func (v *queryWithFragmentsResponse) UnmarshalJSON(b []byte) error {
 
@@ -2079,13 +2507,28 @@ type queryWithInterfaceListFieldBeingsAnimal struct {
 }
 
 // GetTypename returns queryWithInterfaceListFieldBeingsAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListFieldBeingsAnimal) GetTypename() string { return v.Typename }
+func (v *queryWithInterfaceListFieldBeingsAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithInterfaceListFieldBeingsAnimal.Id, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListFieldBeingsAnimal) GetId() string { return v.Id }
+func (v *queryWithInterfaceListFieldBeingsAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithInterfaceListFieldBeingsAnimal.Name, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListFieldBeingsAnimal) GetName() string { return v.Name }
+func (v *queryWithInterfaceListFieldBeingsAnimal) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithInterfaceListFieldBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
@@ -2172,13 +2615,28 @@ type queryWithInterfaceListFieldBeingsUser struct {
 }
 
 // GetTypename returns queryWithInterfaceListFieldBeingsUser.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListFieldBeingsUser) GetTypename() string { return v.Typename }
+func (v *queryWithInterfaceListFieldBeingsUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithInterfaceListFieldBeingsUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListFieldBeingsUser) GetId() string { return v.Id }
+func (v *queryWithInterfaceListFieldBeingsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithInterfaceListFieldBeingsUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListFieldBeingsUser) GetName() string { return v.Name }
+func (v *queryWithInterfaceListFieldBeingsUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithInterfaceListFieldResponse is returned by queryWithInterfaceListField on success.
 type queryWithInterfaceListFieldResponse struct {
@@ -2186,7 +2644,10 @@ type queryWithInterfaceListFieldResponse struct {
 }
 
 // GetBeings returns queryWithInterfaceListFieldResponse.Beings, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListFieldResponse) GetBeings() []queryWithInterfaceListFieldBeingsBeing {
+func (v *queryWithInterfaceListFieldResponse) GetBeings() (val []queryWithInterfaceListFieldBeingsBeing) {
+	if v == nil {
+		return
+	}
 	return v.Beings
 }
 
@@ -2273,13 +2734,28 @@ type queryWithInterfaceListPointerFieldBeingsAnimal struct {
 }
 
 // GetTypename returns queryWithInterfaceListPointerFieldBeingsAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetTypename() string { return v.Typename }
+func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithInterfaceListPointerFieldBeingsAnimal.Id, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetId() string { return v.Id }
+func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithInterfaceListPointerFieldBeingsAnimal.Name, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetName() string { return v.Name }
+func (v *queryWithInterfaceListPointerFieldBeingsAnimal) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithInterfaceListPointerFieldBeingsBeing includes the requested fields of the GraphQL interface Being.
 //
@@ -2366,13 +2842,28 @@ type queryWithInterfaceListPointerFieldBeingsUser struct {
 }
 
 // GetTypename returns queryWithInterfaceListPointerFieldBeingsUser.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListPointerFieldBeingsUser) GetTypename() string { return v.Typename }
+func (v *queryWithInterfaceListPointerFieldBeingsUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithInterfaceListPointerFieldBeingsUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListPointerFieldBeingsUser) GetId() string { return v.Id }
+func (v *queryWithInterfaceListPointerFieldBeingsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithInterfaceListPointerFieldBeingsUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListPointerFieldBeingsUser) GetName() string { return v.Name }
+func (v *queryWithInterfaceListPointerFieldBeingsUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithInterfaceListPointerFieldResponse is returned by queryWithInterfaceListPointerField on success.
 type queryWithInterfaceListPointerFieldResponse struct {
@@ -2380,7 +2871,10 @@ type queryWithInterfaceListPointerFieldResponse struct {
 }
 
 // GetBeings returns queryWithInterfaceListPointerFieldResponse.Beings, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceListPointerFieldResponse) GetBeings() []*queryWithInterfaceListPointerFieldBeingsBeing {
+func (v *queryWithInterfaceListPointerFieldResponse) GetBeings() (val []*queryWithInterfaceListPointerFieldBeingsBeing) {
+	if v == nil {
+		return
+	}
 	return v.Beings
 }
 
@@ -2547,13 +3041,28 @@ type queryWithInterfaceNoFragmentsBeingAnimal struct {
 }
 
 // GetTypename returns queryWithInterfaceNoFragmentsBeingAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetTypename() string { return v.Typename }
+func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithInterfaceNoFragmentsBeingAnimal.Id, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetId() string { return v.Id }
+func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithInterfaceNoFragmentsBeingAnimal.Name, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetName() string { return v.Name }
+func (v *queryWithInterfaceNoFragmentsBeingAnimal) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithInterfaceNoFragmentsBeingUser includes the requested fields of the GraphQL type User.
 type queryWithInterfaceNoFragmentsBeingUser struct {
@@ -2563,13 +3072,28 @@ type queryWithInterfaceNoFragmentsBeingUser struct {
 }
 
 // GetTypename returns queryWithInterfaceNoFragmentsBeingUser.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsBeingUser) GetTypename() string { return v.Typename }
+func (v *queryWithInterfaceNoFragmentsBeingUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithInterfaceNoFragmentsBeingUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsBeingUser) GetId() string { return v.Id }
+func (v *queryWithInterfaceNoFragmentsBeingUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithInterfaceNoFragmentsBeingUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsBeingUser) GetName() string { return v.Name }
+func (v *queryWithInterfaceNoFragmentsBeingUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithInterfaceNoFragmentsMeUser includes the requested fields of the GraphQL type User.
 type queryWithInterfaceNoFragmentsMeUser struct {
@@ -2578,10 +3102,20 @@ type queryWithInterfaceNoFragmentsMeUser struct {
 }
 
 // GetId returns queryWithInterfaceNoFragmentsMeUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsMeUser) GetId() string { return v.Id }
+func (v *queryWithInterfaceNoFragmentsMeUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithInterfaceNoFragmentsMeUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsMeUser) GetName() string { return v.Name }
+func (v *queryWithInterfaceNoFragmentsMeUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // queryWithInterfaceNoFragmentsResponse is returned by queryWithInterfaceNoFragments on success.
 type queryWithInterfaceNoFragmentsResponse struct {
@@ -2590,12 +3124,18 @@ type queryWithInterfaceNoFragmentsResponse struct {
 }
 
 // GetBeing returns queryWithInterfaceNoFragmentsResponse.Being, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsResponse) GetBeing() queryWithInterfaceNoFragmentsBeing {
+func (v *queryWithInterfaceNoFragmentsResponse) GetBeing() (val queryWithInterfaceNoFragmentsBeing) {
+	if v == nil {
+		return
+	}
 	return v.Being
 }
 
 // GetMe returns queryWithInterfaceNoFragmentsResponse.Me, and is useful for accessing the field via an interface.
-func (v *queryWithInterfaceNoFragmentsResponse) GetMe() queryWithInterfaceNoFragmentsMeUser {
+func (v *queryWithInterfaceNoFragmentsResponse) GetMe() (val queryWithInterfaceNoFragmentsMeUser) {
+	if v == nil {
+		return
+	}
 	return v.Me
 }
 
@@ -2673,18 +3213,34 @@ type queryWithNamedFragmentsBeingsAnimal struct {
 }
 
 // GetTypename returns queryWithNamedFragmentsBeingsAnimal.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsAnimal) GetTypename() string { return v.Typename }
+func (v *queryWithNamedFragmentsBeingsAnimal) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithNamedFragmentsBeingsAnimal.Id, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsAnimal) GetId() string { return v.Id }
+func (v *queryWithNamedFragmentsBeingsAnimal) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetHair returns queryWithNamedFragmentsBeingsAnimal.Hair, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsAnimal) GetHair() AnimalFieldsHairBeingsHair {
+func (v *queryWithNamedFragmentsBeingsAnimal) GetHair() (val AnimalFieldsHairBeingsHair) {
+	if v == nil {
+		return
+	}
 	return v.AnimalFields.Hair
 }
 
 // GetOwner returns queryWithNamedFragmentsBeingsAnimal.Owner, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsAnimal) GetOwner() AnimalFieldsOwnerBeing {
+func (v *queryWithNamedFragmentsBeingsAnimal) GetOwner() (val AnimalFieldsOwnerBeing) {
+	if v == nil {
+		return
+	}
 	return v.AnimalFields.Owner
 }
 
@@ -2843,18 +3399,34 @@ type queryWithNamedFragmentsBeingsUser struct {
 }
 
 // GetTypename returns queryWithNamedFragmentsBeingsUser.Typename, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsUser) GetTypename() string { return v.Typename }
+func (v *queryWithNamedFragmentsBeingsUser) GetTypename() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Typename
+}
 
 // GetId returns queryWithNamedFragmentsBeingsUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsUser) GetId() string { return v.Id }
+func (v *queryWithNamedFragmentsBeingsUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetLuckyNumber returns queryWithNamedFragmentsBeingsUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsUser) GetLuckyNumber() int {
+func (v *queryWithNamedFragmentsBeingsUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
 	return v.UserFields.LuckyFieldsUser.LuckyNumber
 }
 
 // GetHair returns queryWithNamedFragmentsBeingsUser.Hair, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsBeingsUser) GetHair() MoreUserFieldsHair {
+func (v *queryWithNamedFragmentsBeingsUser) GetHair() (val MoreUserFieldsHair) {
+	if v == nil {
+		return
+	}
 	return v.UserFields.MoreUserFields.Hair
 }
 
@@ -2917,7 +3489,10 @@ type queryWithNamedFragmentsResponse struct {
 }
 
 // GetBeings returns queryWithNamedFragmentsResponse.Beings, and is useful for accessing the field via an interface.
-func (v *queryWithNamedFragmentsResponse) GetBeings() []queryWithNamedFragmentsBeingsBeing {
+func (v *queryWithNamedFragmentsResponse) GetBeings() (val []queryWithNamedFragmentsBeingsBeing) {
+	if v == nil {
+		return
+	}
 	return v.Beings
 }
 
@@ -3002,7 +3577,12 @@ type queryWithOmitemptyResponse struct {
 }
 
 // GetUser returns queryWithOmitemptyResponse.User, and is useful for accessing the field via an interface.
-func (v *queryWithOmitemptyResponse) GetUser() queryWithOmitemptyUser { return v.User }
+func (v *queryWithOmitemptyResponse) GetUser() (val queryWithOmitemptyUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // queryWithOmitemptyUser includes the requested fields of the GraphQL type User.
 type queryWithOmitemptyUser struct {
@@ -3012,13 +3592,28 @@ type queryWithOmitemptyUser struct {
 }
 
 // GetId returns queryWithOmitemptyUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithOmitemptyUser) GetId() string { return v.Id }
+func (v *queryWithOmitemptyUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithOmitemptyUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithOmitemptyUser) GetName() string { return v.Name }
+func (v *queryWithOmitemptyUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetLuckyNumber returns queryWithOmitemptyUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *queryWithOmitemptyUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *queryWithOmitemptyUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // queryWithVariablesResponse is returned by queryWithVariables on success.
 type queryWithVariablesResponse struct {
@@ -3026,7 +3621,12 @@ type queryWithVariablesResponse struct {
 }
 
 // GetUser returns queryWithVariablesResponse.User, and is useful for accessing the field via an interface.
-func (v *queryWithVariablesResponse) GetUser() queryWithVariablesUser { return v.User }
+func (v *queryWithVariablesResponse) GetUser() (val queryWithVariablesUser) {
+	if v == nil {
+		return
+	}
+	return v.User
+}
 
 // queryWithVariablesUser includes the requested fields of the GraphQL type User.
 type queryWithVariablesUser struct {
@@ -3036,13 +3636,28 @@ type queryWithVariablesUser struct {
 }
 
 // GetId returns queryWithVariablesUser.Id, and is useful for accessing the field via an interface.
-func (v *queryWithVariablesUser) GetId() string { return v.Id }
+func (v *queryWithVariablesUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns queryWithVariablesUser.Name, and is useful for accessing the field via an interface.
-func (v *queryWithVariablesUser) GetName() string { return v.Name }
+func (v *queryWithVariablesUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetLuckyNumber returns queryWithVariablesUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *queryWithVariablesUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *queryWithVariablesUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // simpleQueryExtMeUser includes the requested fields of the GraphQL type User.
 type simpleQueryExtMeUser struct {
@@ -3052,13 +3667,28 @@ type simpleQueryExtMeUser struct {
 }
 
 // GetId returns simpleQueryExtMeUser.Id, and is useful for accessing the field via an interface.
-func (v *simpleQueryExtMeUser) GetId() string { return v.Id }
+func (v *simpleQueryExtMeUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns simpleQueryExtMeUser.Name, and is useful for accessing the field via an interface.
-func (v *simpleQueryExtMeUser) GetName() string { return v.Name }
+func (v *simpleQueryExtMeUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetLuckyNumber returns simpleQueryExtMeUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *simpleQueryExtMeUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *simpleQueryExtMeUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // simpleQueryExtResponse is returned by simpleQueryExt on success.
 type simpleQueryExtResponse struct {
@@ -3066,7 +3696,12 @@ type simpleQueryExtResponse struct {
 }
 
 // GetMe returns simpleQueryExtResponse.Me, and is useful for accessing the field via an interface.
-func (v *simpleQueryExtResponse) GetMe() simpleQueryExtMeUser { return v.Me }
+func (v *simpleQueryExtResponse) GetMe() (val simpleQueryExtMeUser) {
+	if v == nil {
+		return
+	}
+	return v.Me
+}
 
 // simpleQueryMeUser includes the requested fields of the GraphQL type User.
 type simpleQueryMeUser struct {
@@ -3077,16 +3712,36 @@ type simpleQueryMeUser struct {
 }
 
 // GetId returns simpleQueryMeUser.Id, and is useful for accessing the field via an interface.
-func (v *simpleQueryMeUser) GetId() string { return v.Id }
+func (v *simpleQueryMeUser) GetId() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Id
+}
 
 // GetName returns simpleQueryMeUser.Name, and is useful for accessing the field via an interface.
-func (v *simpleQueryMeUser) GetName() string { return v.Name }
+func (v *simpleQueryMeUser) GetName() (val string) {
+	if v == nil {
+		return
+	}
+	return v.Name
+}
 
 // GetLuckyNumber returns simpleQueryMeUser.LuckyNumber, and is useful for accessing the field via an interface.
-func (v *simpleQueryMeUser) GetLuckyNumber() int { return v.LuckyNumber }
+func (v *simpleQueryMeUser) GetLuckyNumber() (val int) {
+	if v == nil {
+		return
+	}
+	return v.LuckyNumber
+}
 
 // GetGreatScalar returns simpleQueryMeUser.GreatScalar, and is useful for accessing the field via an interface.
-func (v *simpleQueryMeUser) GetGreatScalar() MyGreatScalar { return v.GreatScalar }
+func (v *simpleQueryMeUser) GetGreatScalar() (val MyGreatScalar) {
+	if v == nil {
+		return
+	}
+	return v.GreatScalar
+}
 
 // simpleQueryResponse is returned by simpleQuery on success.
 type simpleQueryResponse struct {
@@ -3094,7 +3749,12 @@ type simpleQueryResponse struct {
 }
 
 // GetMe returns simpleQueryResponse.Me, and is useful for accessing the field via an interface.
-func (v *simpleQueryResponse) GetMe() simpleQueryMeUser { return v.Me }
+func (v *simpleQueryResponse) GetMe() (val simpleQueryMeUser) {
+	if v == nil {
+		return
+	}
+	return v.Me
+}
 
 // The subscription executed by count.
 const count_Operation = `


### PR DESCRIPTION
Add nil check in go structs' getter methods, making chained function call like `a.GetB().GetC().GetD()` won't panic.

<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->



I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
