### PR TITLE
Subscription connection parameters support

### DIFF
--- a/graphql/client.go
+++ b/graphql/client.go
@@ -132,6 +132,16 @@ func NewClientUsingGet(endpoint string, httpClient Doer) Client {
 // The client does not support queries nor mutations, and will return an error
 // if passed a request that attempts one.
 func NewClientUsingWebSocket(endpoint string, wsDialer Dialer, headers http.Header) WebSocketClient {
+	return NewClientUsingWebSocketWithConnectionParams(endpoint, wsDialer, headers, nil)
+}
+
+// NewClientUsingWebSocketWithConnectionParams returns a [WebSocketClient] which makes subscription requests
+// to the given endpoint using webSocket. It allows to pass additional connection parameters
+// to the server during the initial connection handshake.
+//
+// connectionParams is a map of connection parameters to be sent to the server
+// during the initial connection handshake.
+func NewClientUsingWebSocketWithConnectionParams(endpoint string, wsDialer Dialer, headers http.Header, connParams map[string]interface{}) WebSocketClient {
 	if headers == nil {
 		headers = http.Header{}
 	}
@@ -141,6 +151,7 @@ func NewClientUsingWebSocket(endpoint string, wsDialer Dialer, headers http.Head
 	return &webSocketClient{
 		Dialer:        wsDialer,
 		Header:        headers,
+		connParams:    connParams,
 		errChan:       make(chan error),
 		endpoint:      endpoint,
 		subscriptions: subscriptionMap{map_: make(map[string]subscription)},

--- a/graphql/client.go
+++ b/graphql/client.go
@@ -126,35 +126,40 @@ func NewClientUsingGet(endpoint string, httpClient Doer) Client {
 	return newClient(endpoint, httpClient, http.MethodGet)
 }
 
+type WebSocketOption func(*webSocketClient)
+
 // NewClientUsingWebSocket returns a [WebSocketClient] which makes subscription requests
 // to the given endpoint using webSocket.
 //
 // The client does not support queries nor mutations, and will return an error
 // if passed a request that attempts one.
-func NewClientUsingWebSocket(endpoint string, wsDialer Dialer, headers http.Header) WebSocketClient {
-	return NewClientUsingWebSocketWithConnectionParams(endpoint, wsDialer, headers, nil)
-}
-
-// NewClientUsingWebSocketWithConnectionParams returns a [WebSocketClient] which makes subscription requests
-// to the given endpoint using webSocket. It allows to pass additional connection parameters
-// to the server during the initial connection handshake.
-//
-// connectionParams is a map of connection parameters to be sent to the server
-// during the initial connection handshake.
-func NewClientUsingWebSocketWithConnectionParams(endpoint string, wsDialer Dialer, headers http.Header, connParams map[string]interface{}) WebSocketClient {
+func NewClientUsingWebSocket(endpoint string, wsDialer Dialer, headers http.Header, opts ...WebSocketOption) WebSocketClient {
 	if headers == nil {
 		headers = http.Header{}
 	}
 	if headers.Get("Sec-WebSocket-Protocol") == "" {
 		headers.Add("Sec-WebSocket-Protocol", "graphql-transport-ws")
 	}
-	return &webSocketClient{
+	client := &webSocketClient{
 		Dialer:        wsDialer,
 		Header:        headers,
-		connParams:    connParams,
 		errChan:       make(chan error),
 		endpoint:      endpoint,
 		subscriptions: subscriptionMap{map_: make(map[string]subscription)},
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
+}
+
+// WithConnectionParams sets up connection params to be sent to the server
+// during the initial connection handshake.
+func WithConnectionParams(connParams map[string]interface{}) WebSocketOption {
+	return func(ws *webSocketClient) {
+		ws.connParams = connParams
 	}
 }
 

--- a/graphql/websocket.go
+++ b/graphql/websocket.go
@@ -48,10 +48,16 @@ type webSocketClient struct {
 	Header        http.Header
 	endpoint      string
 	conn          WSConn
+	connParams    map[string]interface{}
 	errChan       chan error
 	subscriptions subscriptionMap
 	isClosing     bool
 	sync.Mutex
+}
+
+type webSocketInitMessage struct {
+	Payload map[string]interface{} `json:"payload"`
+	Type    string                 `json:"type"`
 }
 
 type webSocketSendMessage struct {
@@ -67,8 +73,9 @@ type webSocketReceiveMessage struct {
 }
 
 func (w *webSocketClient) sendInit() error {
-	connInitMsg := webSocketSendMessage{
-		Type: webSocketTypeConnInit,
+	connInitMsg := webSocketInitMessage{
+		Type:    webSocketTypeConnInit,
+		Payload: w.connParams,
 	}
 	return w.sendStructAsJSON(connInitMsg)
 }

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -1311,6 +1311,14 @@ type __queryWithVariablesInput struct {
 // GetId returns __queryWithVariablesInput.Id, and is useful for accessing the field via an interface.
 func (v *__queryWithVariablesInput) GetId() string { return v.Id }
 
+// countAuthorizedResponse is returned by countAuthorized on success.
+type countAuthorizedResponse struct {
+	CountAuthorized int `json:"countAuthorized"`
+}
+
+// GetCountAuthorized returns countAuthorizedResponse.CountAuthorized, and is useful for accessing the field via an interface.
+func (v *countAuthorizedResponse) GetCountAuthorized() int { return v.CountAuthorized }
+
 // countResponse is returned by count on success.
 type countResponse struct {
 	Count int `json:"count"`
@@ -3143,6 +3151,58 @@ func countForwardData(interfaceChan interface{}, jsonRawMsg json.RawMessage) err
 	dataChan_, ok := interfaceChan.(chan countWsResponse)
 	if !ok {
 		return errors.New("failed to cast interface into 'chan countWsResponse'")
+	}
+	dataChan_ <- wsResp
+	return nil
+}
+
+// The subscription executed by countAuthorized.
+const countAuthorized_Operation = `
+subscription countAuthorized {
+	countAuthorized
+}
+`
+
+// To unsubscribe, use [graphql.WebSocketClient.Unsubscribe]
+func countAuthorized(
+	ctx_ context.Context,
+	client_ graphql.WebSocketClient,
+) (dataChan_ chan countAuthorizedWsResponse, subscriptionID_ string, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "countAuthorized",
+		Query:  countAuthorized_Operation,
+	}
+
+	dataChan_ = make(chan countAuthorizedWsResponse)
+	subscriptionID_, err_ = client_.Subscribe(req_, dataChan_, countAuthorizedForwardData)
+
+	return dataChan_, subscriptionID_, err_
+}
+
+type countAuthorizedWsResponse struct {
+	Data       *countAuthorizedResponse `json:"data"`
+	Extensions map[string]interface{}   `json:"extensions,omitempty"`
+	Errors     error                    `json:"errors"`
+}
+
+func countAuthorizedForwardData(interfaceChan interface{}, jsonRawMsg json.RawMessage) error {
+	var gqlResp graphql.Response
+	var wsResp countAuthorizedWsResponse
+	err := json.Unmarshal(jsonRawMsg, &gqlResp)
+	if err != nil {
+		return err
+	}
+	if len(gqlResp.Errors) == 0 {
+		err = json.Unmarshal(jsonRawMsg, &wsResp)
+		if err != nil {
+			return err
+		}
+	} else {
+		wsResp.Errors = gqlResp.Errors
+	}
+	dataChan_, ok := interfaceChan.(chan countAuthorizedWsResponse)
+	if !ok {
+		return errors.New("failed to cast interface into 'chan countAuthorizedWsResponse'")
 	}
 	dataChan_ <- wsResp
 	return nil

--- a/internal/integration/generated.go
+++ b/internal/integration/generated.go
@@ -3175,11 +3175,7 @@ func countAuthorized(
 	return dataChan_, subscriptionID_, err_
 }
 
-type countAuthorizedWsResponse struct {
-	Data       *countAuthorizedResponse `json:"data"`
-	Extensions map[string]interface{}   `json:"extensions,omitempty"`
-	Errors     error                    `json:"errors"`
-}
+type countAuthorizedWsResponse graphql.BaseResponse[*countAuthorizedResponse]
 
 func countAuthorizedForwardData(interfaceChan interface{}, jsonRawMsg json.RawMessage) error {
 	var gqlResp graphql.Response

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -95,7 +95,7 @@ func TestSubscription(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			wsClient := newRoundtripWebSocketClient(t, server.URL, nil)
+			wsClient := newRoundtripWebSocketClient(t, server.URL)
 
 			errChan, err := wsClient.Start(ctx)
 			require.NoError(t, err)
@@ -159,11 +159,14 @@ func TestSubscriptionConnectionParams(t *testing.T) {
 		connParams    map[string]interface{}
 		name          string
 		expectedError string
+		opts          []graphql.WebSocketOption
 	}{
 		{
 			name: "authorized_user_gets_counter",
-			connParams: map[string]interface{}{
-				authKey: "authorized-user-token",
+			opts: []graphql.WebSocketOption{
+				graphql.WithConnectionParams(map[string]interface{}{
+					authKey: "authorized-user-token",
+				}),
 			},
 		},
 		{
@@ -174,7 +177,11 @@ func TestSubscriptionConnectionParams(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			wsClient := newRoundtripWebSocketClient(t, server.URL, tc.connParams)
+			wsClient := newRoundtripWebSocketClient(
+				t,
+				server.URL,
+				tc.opts...,
+			)
 
 			errChan, err := wsClient.Start(ctx)
 			require.NoError(t, err)

--- a/internal/integration/roundtrip.go
+++ b/internal/integration/roundtrip.go
@@ -156,14 +156,19 @@ func (md *MyDialer) DialContext(ctx context.Context, urlStr string, requestHeade
 	return graphql.WSConn(conn), err
 }
 
-func newRoundtripWebSocketClient(t *testing.T, endpoint string) graphql.WebSocketClient {
+func newRoundtripWebSocketClient(t *testing.T, endpoint string, connectionParams map[string]interface{}) graphql.WebSocketClient {
 	dialer := websocket.DefaultDialer
 	if !strings.HasPrefix(endpoint, "ws") {
 		_, address, _ := strings.Cut(endpoint, "://")
 		endpoint = "ws://" + address
 	}
 	return &roundtripClient{
-		wsWrapped: graphql.NewClientUsingWebSocket(endpoint, &MyDialer{Dialer: dialer}, nil),
-		t:         t,
+		wsWrapped: graphql.NewClientUsingWebSocketWithConnectionParams(
+			endpoint,
+			&MyDialer{Dialer: dialer},
+			nil,
+			connectionParams,
+		),
+		t: t,
 	}
 }

--- a/internal/integration/roundtrip.go
+++ b/internal/integration/roundtrip.go
@@ -156,18 +156,19 @@ func (md *MyDialer) DialContext(ctx context.Context, urlStr string, requestHeade
 	return graphql.WSConn(conn), err
 }
 
-func newRoundtripWebSocketClient(t *testing.T, endpoint string, connectionParams map[string]interface{}) graphql.WebSocketClient {
+func newRoundtripWebSocketClient(t *testing.T, endpoint string, opts ...graphql.WebSocketOption) graphql.WebSocketClient {
 	dialer := websocket.DefaultDialer
 	if !strings.HasPrefix(endpoint, "ws") {
 		_, address, _ := strings.Cut(endpoint, "://")
 		endpoint = "ws://" + address
 	}
+
 	return &roundtripClient{
-		wsWrapped: graphql.NewClientUsingWebSocketWithConnectionParams(
+		wsWrapped: graphql.NewClientUsingWebSocket(
 			endpoint,
 			&MyDialer{Dialer: dialer},
 			nil,
-			connectionParams,
+			opts...,
 		),
 		t: t,
 	}

--- a/internal/integration/schema.graphql
+++ b/internal/integration/schema.graphql
@@ -19,6 +19,7 @@ type Mutation {
 
 type Subscription {
   count: Int!
+  countAuthorized: Int!
 }
 
 type User implements Being & Lucky {

--- a/internal/integration/server/gqlgen_exec.go
+++ b/internal/integration/server/gqlgen_exec.go
@@ -297,6 +297,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		if e.complexity.Subscription.CountAuthorized == nil {
 			break
 		}
+
 		return e.complexity.Subscription.CountAuthorized(childComplexity), true
 
 	case "User.birthdate":


### PR DESCRIPTION
Adds support for subscription (websocket) connection parameters support.

We are having an issue with authorization when using subscriptions in genqlient. Our mobile app team is using Apollo for GraphQL requests, and Apollo seems to sends its auth in a way that is different from how genqlient does it:

https://www.apollographql.com/docs/react/data/subscriptions#5-authenticate-over-websocket-optional

This is causing a problems, because we use genqlient for testing the backend. It seems that the way Apollo is implemented, authentication (and other headers) are not actually sent as HTTP headers, but as connection parameters instead.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog