### PR TITLE
HTTPError wraps full Response for typed output

### DIFF
--- a/graphql/client.go
+++ b/graphql/client.go
@@ -265,9 +265,20 @@ func (c *client) MakeRequest(ctx context.Context, req *Request, resp *Response) 
 		if err != nil {
 			respBody = []byte(fmt.Sprintf("<unreadable: %v>", err))
 		}
+
+		var gqlResp Response
+		if err = json.Unmarshal(respBody, &gqlResp); err != nil {
+			return &HTTPError{
+				Response: Response{
+					Errors: gqlerror.List{&gqlerror.Error{Message: string(respBody)}},
+				},
+				StatusCode: httpResp.StatusCode,
+			}
+		}
+
 		return &HTTPError{
+			Response:   gqlResp,
 			StatusCode: httpResp.StatusCode,
-			Body:       string(respBody),
 		}
 	}
 

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -1,14 +1,22 @@
 package graphql
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
-// HTTPError represents an HTTP error with status code and response body.
+// HTTPError represents an HTTP error with status coqgqde and response body.
 type HTTPError struct {
-	Body       string
+	Response   Response
 	StatusCode int
 }
 
 // Error implements the error interface for HTTPError.
 func (e *HTTPError) Error() string {
-	return fmt.Sprintf("returned error %v: '%s'", e.StatusCode, e.Body)
+	jsonBody, err := json.Marshal(e.Response)
+	if err != nil {
+		return fmt.Sprintf("returned error %v: '%s'", e.StatusCode, e.Response)
+	}
+
+	return fmt.Sprintf("returned error %v: %s", e.StatusCode, jsonBody)
 }


### PR DESCRIPTION
Follow-up to https://github.com/Khan/genqlient/pull/363. Go one step further lets HTTPError wrap Response to get fully typed error data.



I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
