### PR TITLE
Matching in genqlient by Normalizing Paths

### DIFF
--- a/generate/parse.go
+++ b/generate/parse.go
@@ -91,6 +91,8 @@ func expandFilenames(globs []string) ([]string, error) {
 	for _, glob := range globs {
 		// SplitPattern in case the path is absolute or something; a valid path
 		// isn't necessarily a valid glob-pattern.
+		glob = filepath.Clean(glob)
+		glob = filepath.ToSlash(glob)
 		base, pattern := doublestar.SplitPattern(glob)
 		matches, err := doublestar.Glob(os.DirFS(base), pattern, doublestar.WithFilesOnly())
 		if err != nil {


### PR DESCRIPTION
This pull request addresses an issue with the `genqlient` library, which uses the `doublestar` package for path matching. The current implementation does not correctly match paths on Windows systems due to differences in path separators. I've implemented a simple fix by converting Windows-style backslashes (`\`) to forward slashes (`/`) before performing the match, allowing the path matching to work correctly across all platforms.

#371
bmatcuk/doublestar#61
