### PR TITLE
Fix link in introduction.md

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ When releasing a new version:
 
 ### Bug fixes:
 
-- `documentation` link in `introduction.md` now links absolutely to ensure no 404 page
+- fixed documentation link in `introduction.md`
 
 ## v0.8.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,8 @@ When releasing a new version:
 
 ### Bug fixes:
 
+- `documentation` link in `introduction.md` now links absolutely to ensure no 404 page
+
 ## v0.8.0
 
 This release adds support for genqlient subscriptions; see the [documentation](subscriptions.md) for more, and thanks to @matthieu4294967296moineau for the original implementation and @HaraldNordgren for additional testing and improvements.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,6 @@
 # Getting started with genqlient
 
-This document describes how to set up genqlient and use it for simple queries.  See also the full worked [example](../example), the [FAQ](faq.md), and the rest of the [documentation](docs).
+This document describes how to set up genqlient and use it for simple queries.  See also the full worked [example](../example), the [FAQ](faq.md), and the rest of the [documentation](https://github.com/Khan/genqlient/blob/main/docs/).
 
 ## Step 1: Download your schema
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,6 @@
 # Getting started with genqlient
 
-This document describes how to set up genqlient and use it for simple queries.  See also the full worked [example](../example), the [FAQ](faq.md), and the rest of the [documentation](https://github.com/Khan/genqlient/blob/main/docs/).
+This document describes how to set up genqlient and use it for simple queries.  See also the full worked [example](../example), the [FAQ](faq.md), and the rest of the [documentation](./).
 
 ## Step 1: Download your schema
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Check out the
[contributing docs](https://github.com/Khan/genqlient/blob/main/docs/CONTRIBUTING.md)
for more on contributing to genqlient.
-->

## Issue

Currently, the link to `docs` in the `introduction.md` is broken; it hits a 404 page because it uses a relative link, pointing to the `docs` directory within the `docs` directory.

## Changes

We've changed to use an absolute link instead.

I have:
- [x] Written a clear PR title and description (above)
- [x] Signed the [Khan Academy CLA](https://www.khanacademy.org/r/cla)
- [x] Added tests covering my changes, if applicable
- [x] Included a link to the issue fixed, if applicable
- [x] Included documentation, for new features
- [x] Added an entry to the changelog
